### PR TITLE
feat: add review step before letter generation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import UploadPage from './pages/UploadPage';
 import StatusPage from './pages/StatusPage';
+import ReviewPage from './pages/ReviewPage';
 import './App.css';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/upload" element={<UploadPage />} />
         <Route path="/status" element={<StatusPage />} />
+        <Route path="/review" element={<ReviewPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -17,10 +17,14 @@ export async function startProcess(email, file) {
   return response.json();
 }
 
-export async function checkStatus(taskId) {
-  const response = await fetch(`${API_BASE_URL}/api/status/${taskId}`);
+export async function submitExplanations(payload) {
+  const response = await fetch(`${API_BASE_URL}/api/submit-explanations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
   if (!response.ok) {
-    throw new Error('Failed to fetch status');
+    throw new Error('Failed to submit explanations');
   }
   return response.json();
 }

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -1,0 +1,56 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { submitExplanations } from '../api';
+
+export default function ReviewPage() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const uploadData = state?.uploadData;
+  const [explanations, setExplanations] = useState({});
+
+  if (!uploadData) {
+    return <p>No upload data available.</p>;
+  }
+
+  const accounts = [
+    ...(uploadData.accounts?.negative_accounts || []),
+    ...(uploadData.accounts?.open_accounts_with_issues || []),
+  ];
+
+  const handleChange = (key, value) => {
+    setExplanations((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await submitExplanations({
+        session_id: uploadData.session_id,
+        filename: uploadData.filename,
+        email: uploadData.email,
+        explanations,
+      });
+      navigate('/status');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="container">
+      <h2>Explain Your Situation</h2>
+      {accounts.map((acc, idx) => (
+        <div key={idx} className="account-block">
+          <p>
+            <strong>{acc.name}</strong> ({acc.account_number})
+          </p>
+          <textarea
+            value={explanations[acc.name] || ''}
+            onChange={(e) => handleChange(acc.name, e.target.value)}
+            placeholder="Your explanation"
+          />
+        </div>
+      ))}
+      <button onClick={handleSubmit}>Generate Letters</button>
+    </div>
+  );
+}

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -1,34 +1,8 @@
-import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import { checkStatus } from '../api';
-
 export default function StatusPage() {
-  const location = useLocation();
-  const initialStatus = location.state?.initialStatus;
-  const [status, setStatus] = useState(initialStatus?.status || 'processing');
-
-  useEffect(() => {
-    let interval;
-    if (initialStatus?.task_id) {
-      interval = setInterval(async () => {
-        try {
-          const data = await checkStatus(initialStatus.task_id);
-          setStatus(data.status);
-          if (data.status === 'done') {
-            clearInterval(interval);
-          }
-        } catch (err) {
-          console.error(err);
-        }
-      }, 3000);
-    }
-    return () => clearInterval(interval);
-  }, [initialStatus]);
-
   return (
     <div className="container">
-      <h2>Processing Status</h2>
-      <p>Status: {status}</p>
+      <h2>Processing</h2>
+      <p>Your letters are being generated and will be emailed to you shortly.</p>
     </div>
   );
 }

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -19,7 +19,7 @@ export default function UploadPage() {
     setError('');
     try {
       const data = await startProcess(email, file);
-      navigate('/status', { state: { initialStatus: data } });
+      navigate('/review', { state: { uploadData: { ...data, email } } });
     } catch (err) {
       console.error(err);
       setError('Upload failed. Please try again.');


### PR DESCRIPTION
## Summary
- split Celery processing into extraction and generation steps
- expose `/api/submit-explanations` to accept user-provided dispute reasons
- add React review page to collect explanations for each account

## Testing
- `pytest` *(fails: FileNotFoundError: ❌ Missing SmartCredit report at: uploads/smartcredit_report.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_68929a972fd8832ead3d88f77940976e