### PR TITLE
Add robust JSON repair utility and enforce strict JSON prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ All backend components read configuration from a `.env` file on startup via
 The Flask server, Celery workers and any CLI scripts load this file
 automatically when they start.
 
+## AI JSON Handling
+
+OpenAI responses are parsed using a repair utility backed by the
+[`dirtyjson`](https://pypi.org/project/dirtyjson/) library. When the model
+returns nearly valid JSON (e.g., with trailing commas or single quotes), the
+utility attempts to clean it so processing can continue without manual
+intervention.
+
 ## Action Tags
 
 Accounts may contain an `action_tag` field used to control which letters are generated. The allowed values are:

--- a/logic/analyze_report.py
+++ b/logic/analyze_report.py
@@ -12,6 +12,7 @@ from logic.utils import (
     extract_inquiries,
 )
 from .utils import normalize_bureau_name, has_late_indicator, enforce_collection_status
+from .json_utils import parse_json
 
 load_dotenv()
 client = OpenAI(
@@ -154,8 +155,10 @@ Return this exact JSON structure:
    - advisor_comment: 1–2 sentence explanation of the account’s effect and what the client should do (dispute, pay down, keep healthy, goodwill, etc.)
 
 ⚠️ Rules:
-- Output valid JSON only
-- No markdown, no explanations, no headers — only pure JSON
+- Return strictly valid JSON
+- All property names and strings must use double quotes
+- No trailing commas, comments, or text outside the JSON
+- No markdown or explanations
 - Use proper casing, punctuation, and clean formatting
 - Never guess — only include facts that are visible
 Use the following late payment data to help you accurately tag late accounts, even if the report formatting is inconsistent:
@@ -190,8 +193,8 @@ Report text:
         f.write(inquiry_summary)
 
     try:
-        return json.loads(content)
-    except json.JSONDecodeError:
+        return parse_json(content)
+    except Exception:
         print("\u26a0\ufe0f The AI returned invalid JSON. Here's the raw response:")
         print(content)
         raise

--- a/logic/extract_info.py
+++ b/logic/extract_info.py
@@ -8,6 +8,7 @@ from .utils import normalize_bureau_name, BUREAUS
 from collections import Counter
 from openai import OpenAI
 from dotenv import load_dotenv
+from .json_utils import parse_json
 
 logging.getLogger("pdfplumber.page").setLevel(logging.ERROR)
 
@@ -163,6 +164,8 @@ Output JSON in this format:
   "current_address": "..."
 }}
 
+Return strictly valid JSON: use double quotes for all property names and strings, avoid trailing commas, and include no text outside the JSON.
+
 Here is the text:
 ===
 {raw_text}
@@ -174,7 +177,7 @@ Here is the text:
                 temperature=0.1
             )
             content = response.choices[0].message.content.strip()
-            ai_data = json.loads(content)
+            ai_data = parse_json(content)
             for b in bureaus:
                 data[b].update(ai_data)
         except Exception as e:

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -15,6 +15,7 @@ from logic.utils import (
     get_client_address_lines,
     analyze_custom_notes,
 )
+from .json_utils import parse_json
 
 load_dotenv()
 client = OpenAI(
@@ -251,7 +252,7 @@ Supporting doc names: {', '.join(doc_names) if doc_names else 'None'}
 {docs_section}
 {note_text}
 
-Return valid JSON only. No markdown.
+Return strictly valid JSON: all property names and strings in double quotes, no trailing commas or comments, and no text outside the JSON.
 """
 
     response = client.chat.completions.create(
@@ -268,7 +269,7 @@ Return valid JSON only. No markdown.
     print(content)
     print("----- END RESPONSE -----\n")
 
-    return json.loads(content)
+    return parse_json(content)
 
 def load_creditor_address_map():
     try:

--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from openai import OpenAI
 from dotenv import load_dotenv
+from .json_utils import parse_json
 
 load_dotenv()
 client = OpenAI(
@@ -54,6 +55,7 @@ Return only a JSON object with this structure:
   }}],
   "global_recommendations": []
 }}
+Ensure the response is strictly valid JSON: all property names and strings in double quotes, no trailing commas or comments, and no text outside the JSON.
 """
         response = client.chat.completions.create(
             model="gpt-4",
@@ -65,7 +67,7 @@ Return only a JSON object with this structure:
             content = (
                 content.replace("```json", "").replace("```", "").strip()
             )
-        return json.loads(content)
+        return parse_json(content)
 
     def save_report(
         self,

--- a/logic/json_utils.py
+++ b/logic/json_utils.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import re
+
+try:
+    import dirtyjson as _dirtyjson
+except Exception:  # pragma: no cover - fallback when lib missing
+    _dirtyjson = None
+
+try:
+    import json5 as _json5
+except Exception:  # pragma: no cover - optional dependency
+    _json5 = None
+
+_TRAILING_COMMA_RE = re.compile(r',(?=\s*[}\]])')
+_SINGLE_QUOTE_KEY_RE = re.compile(r"'([^']*)'(?=\s*:)" )
+_SINGLE_QUOTE_VALUE_RE = re.compile(r":\s*'([^']*)'" )
+
+
+def _basic_clean(content: str) -> str:
+    """Apply simple regex-based fixes for common JSON issues."""
+    cleaned = _TRAILING_COMMA_RE.sub(r"", content)
+    cleaned = _SINGLE_QUOTE_KEY_RE.sub(r'"\1"', cleaned)
+    cleaned = _SINGLE_QUOTE_VALUE_RE.sub(r': "\1"', cleaned)
+    return cleaned
+
+
+def parse_json(text: str):
+    """Parse ``text`` as JSON, attempting repairs on failure.
+
+    This first tries :func:`json.loads`. If that fails, it tries ``dirtyjson`` or
+    ``json5`` when available. As a last resort it applies basic regex fixes for
+    trailing commas and single quotes. If parsing still fails, the original
+    ``JSONDecodeError`` is raised.
+    """
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        logging.warning("⚠️ The AI returned invalid JSON. Attempting to repair.")
+        # Try dirtyjson if available
+        if _dirtyjson is not None:
+            try:
+                repaired = _dirtyjson.loads(text)
+                logging.debug("Repaired JSON via dirtyjson: %s", repaired)
+                return repaired
+            except Exception:  # pragma: no cover - handle silently
+                logging.debug("dirtyjson failed to parse input")
+        if _json5 is not None:
+            try:
+                repaired = _json5.loads(text)
+                logging.debug("Repaired JSON via json5: %s", repaired)
+                return repaired
+            except Exception:  # pragma: no cover - handle silently
+                logging.debug("json5 failed to parse input")
+        cleaned = _basic_clean(text)
+        if cleaned != text:
+            logging.debug("Cleaned JSON string: %s", cleaned)
+            return json.loads(cleaned)
+        raise

--- a/logic/letter_generator.py
+++ b/logic/letter_generator.py
@@ -13,6 +13,7 @@ from logic.utils import (
     CHARGEOFF_RE,
     COLLECTION_RE,
 )
+from .json_utils import parse_json
 
 
 def dedupe_disputes(disputes: list[dict], bureau_name: str, log: list[str]) -> list[dict]:
@@ -139,7 +140,7 @@ Return a JSON object with:
 - closing_paragraph
   (should mention the bureau must respond in writing within 30 days under section 611 of the FCRA)
 
-Respond only with JSON.
+Respond only with JSON. The output must be strictly valid JSON: all property names and strings in double quotes, no trailing commas or comments, and no text outside the JSON.
 """
 
     prompt = f'''
@@ -195,7 +196,7 @@ Unauthorized Inquiries:
     print(content)
     print("----- END RESPONSE -----\n")
 
-    result = json.loads(content)
+    result = parse_json(content)
     return result
 
 def generate_all_dispute_letters_with_ai(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ fpdf
 PyMuPDF
 celery
 redis
+dirtyjson
 

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.json_utils import parse_json
+
+def test_parse_valid_json():
+    assert parse_json('{"a": 1}') == {"a": 1}
+
+def test_parse_trailing_comma():
+    assert parse_json('{"a": 1,}') == {"a": 1}
+
+def test_parse_single_quotes():
+    assert parse_json("{'a': 'b'}") == {"a": "b"}


### PR DESCRIPTION
## Summary
- add `parse_json` helper that repairs malformed JSON using `dirtyjson` with regex fallback
- tighten OpenAI prompts and switch JSON parsing to the new helper across analysis and letter generation modules
- document AI JSON handling and add tests for the repair logic

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_json_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6892a5e8f8ec832e9b8046a15e796afc