### PR TITLE
Improve credit report workflow resilience

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,8 +4,10 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 import os
 import uuid
+from werkzeug.utils import secure_filename
 from tasks import process_report, extract_problematic_accounts
 from admin import admin_bp
+from session_manager import set_session, get_session
 
 logger = logging.getLogger(__name__)
 logger.info("Flask app starting with OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
@@ -45,8 +47,17 @@ def start_process():
         session_id = str(uuid.uuid4())
         upload_folder = os.path.join("uploads", session_id)
         os.makedirs(upload_folder, exist_ok=True)
-        local_filename = os.path.join(upload_folder, uploaded_file.filename)
+
+        original_name = uploaded_file.filename
+        sanitized = secure_filename(original_name) or "report.pdf"
+        ext = os.path.splitext(sanitized)[1]
+        unique_name = f"{uuid.uuid4().hex}{ext}"
+        local_filename = os.path.join(upload_folder, unique_name)
         uploaded_file.save(local_filename)
+
+        if not os.path.exists(local_filename):
+            logger.error("File failed to save at %s", local_filename)
+            return jsonify({"status": "error", "message": "File upload failed"}), 500
 
         size = os.path.getsize(local_filename)
         print(f"💾 File saved to {local_filename} ({size} bytes)")
@@ -57,6 +68,12 @@ def start_process():
             if first_bytes != b"%PDF":
                 print("❌ File is not a valid PDF")
                 return jsonify({"status": "error", "message": "Invalid PDF file"}), 400
+
+        set_session(session_id, {
+            "file_path": local_filename,
+            "original_filename": original_name,
+            "email": data.get("email")
+        })
 
         goal = data.get("goal")
         is_identity_theft = str(data.get("is_identity_theft", "")).lower() in ("1", "true", "yes")
@@ -79,7 +96,8 @@ def start_process():
         return jsonify({
             "status": "ok",
             "session_id": session_id,
-            "filename": uploaded_file.filename,
+            "filename": unique_name,
+            "original_filename": original_name,
             "accounts": accounts,
         })
 
@@ -92,16 +110,25 @@ def start_process():
 def submit_explanations():
     data = request.get_json(force=True)
     session_id = data.get("session_id")
-    filename = data.get("filename")
     email = data.get("email")
     goal = data.get("goal", "Not specified")
     is_identity_theft = data.get("is_identity_theft", False)
     explanations = data.get("explanations", {})
 
-    if not (session_id and filename and email):
+    if not (session_id and email):
         return jsonify({"status": "error", "message": "Missing data"}), 400
 
-    file_path = os.path.join("uploads", session_id, filename)
+    session = get_session(session_id)
+    file_path = session.get("file_path") if session else None
+    if not file_path or not os.path.exists(file_path):
+        dir_listing = []
+        if session:
+            dir_path = os.path.dirname(file_path)
+            if os.path.exists(dir_path):
+                dir_listing = os.listdir(dir_path)
+        logger.error("File for session %s missing at %s. Dir contents: %s", session_id, file_path, dir_listing)
+        return jsonify({"status": "error", "message": "Uploaded report is missing. Please restart the process."}), 404
+
     process_report.delay(file_path, email, goal, is_identity_theft, session_id, explanations)
 
     return jsonify({"status": "processing", "message": "Letters generation started."})

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
         log_messages.append("✅ Process started.")
 
         from logic.upload_validator import is_safe_pdf, move_uploaded_file
+        from session_manager import update_session
 
         if "email" not in client_info or not client_info["email"]:
             raise ValueError("Client email is missing.")
@@ -66,6 +67,7 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
             raise FileNotFoundError("SmartCredit report file not found at path: " + str(uploaded_path))
 
         pdf_path = move_uploaded_file(Path(uploaded_path), session_id)
+        update_session(session_id, file_path=str(pdf_path))
         if not is_safe_pdf(pdf_path):
             raise ValueError("Uploaded file failed PDF safety checks.")
 
@@ -330,9 +332,11 @@ def extract_problematic_accounts_from_report(file_path: str, session_id: str | N
     validate_env_variables()
 
     from logic.upload_validator import is_safe_pdf, move_uploaded_file
+    from session_manager import update_session
 
     session_id = session_id or "session"
     pdf_path = move_uploaded_file(Path(file_path), session_id)
+    update_session(session_id, file_path=str(pdf_path))
     if not is_safe_pdf(pdf_path):
         raise ValueError("Uploaded file failed PDF safety checks.")
 

--- a/session_manager.py
+++ b/session_manager.py
@@ -1,0 +1,46 @@
+import json
+import os
+import threading
+from typing import Any, Dict
+
+SESSION_FILE = os.path.join("data", "sessions.json")
+_lock = threading.Lock()
+
+
+def _load_sessions() -> Dict[str, Dict[str, Any]]:
+    if not os.path.exists(SESSION_FILE):
+        return {}
+    try:
+        with open(SESSION_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_sessions(sessions: Dict[str, Dict[str, Any]]) -> None:
+    os.makedirs(os.path.dirname(SESSION_FILE), exist_ok=True)
+    with open(SESSION_FILE, 'w', encoding='utf-8') as f:
+        json.dump(sessions, f)
+
+
+def set_session(session_id: str, data: Dict[str, Any]) -> None:
+    with _lock:
+        sessions = _load_sessions()
+        sessions[session_id] = data
+        _save_sessions(sessions)
+
+
+def get_session(session_id: str) -> Dict[str, Any] | None:
+    with _lock:
+        sessions = _load_sessions()
+        return sessions.get(session_id)
+
+
+def update_session(session_id: str, **kwargs: Any) -> Dict[str, Any]:
+    with _lock:
+        sessions = _load_sessions()
+        session = sessions.get(session_id, {})
+        session.update(kwargs)
+        sessions[session_id] = session
+        _save_sessions(sessions)
+        return session

--- a/tasks.py
+++ b/tasks.py
@@ -13,11 +13,20 @@ logger = logging.getLogger(__name__)
 logger.info("Celery worker starting with OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
 logger.info("Celery worker OPENAI_API_KEY present=%s", bool(config.OPENAI_API_KEY))
 
+
+def _ensure_file(file_path: str) -> None:
+    if not os.path.exists(file_path):
+        dir_path = os.path.dirname(file_path)
+        listing = os.listdir(dir_path) if os.path.exists(dir_path) else []
+        logger.error("File not found: %s. Dir contents: %s", file_path, listing)
+        raise FileNotFoundError(f"Required file missing: {file_path}")
+
 @app.task(bind=True, name='extract_problematic_accounts')
 def extract_problematic_accounts(self, file_path: str, session_id: str | None = None):
     """Extract problematic accounts from the report."""
     try:
         logger.info("Extracting accounts from %s", file_path)
+        _ensure_file(file_path)
         return extract_problematic_accounts_from_report(file_path, session_id)
     except Exception as exc:
         logger.exception("❌ Error extracting accounts")
@@ -38,6 +47,7 @@ def process_report(self, file_path: str, email: str, goal: str = "Not specified"
         if not session_id:
             session_id = str(uuid.uuid4())
 
+        _ensure_file(file_path)
         logger.info("Starting processing for %s", email)
 
         client_info = {


### PR DESCRIPTION
## Summary
- persist session file paths so tasks and endpoints share state
- sanitize and uniquely name uploaded reports, storing paths in session store
- add file-existence checks and detailed logging in endpoints and Celery tasks

## Testing
- `OPENAI_API_KEY=dummy pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6892aab50f4c832e97916f612d4cd41a