### PR TITLE
Add YAML-based rules and loader

### DIFF
--- a/logic/rules_loader.py
+++ b/logic/rules_loader.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import yaml
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+
+
+def _load_yaml(filename: str):
+    path = RULES_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(f"Missing required rules file: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"Invalid YAML in {path}: {exc}") from exc
+
+
+def load_rules() -> list:
+    """Load and return dispute rules from ``dispute_rules.yaml``.
+
+    Returns a list of rule dictionaries.
+    """
+    data = _load_yaml("dispute_rules.yaml")
+    if not isinstance(data, list):
+        raise ValueError("dispute_rules.yaml must define a list of rules")
+    return data
+
+
+def load_neutral_phrases() -> dict:
+    """Load and return neutral phrases mapping from ``neutral_phrases.yaml``."""
+    data = _load_yaml("neutral_phrases.yaml")
+    if not isinstance(data, dict):
+        raise ValueError("neutral_phrases.yaml must define a mapping")
+    return data
+
+
+def load_state_rules() -> dict:
+    """Load and return state compliance rules from ``state_rules.yaml``."""
+    data = _load_yaml("state_rules.yaml")
+    if not isinstance(data, dict):
+        raise ValueError("state_rules.yaml must define a mapping")
+    return data

--- a/rules/dispute_rules.yaml
+++ b/rules/dispute_rules.yaml
@@ -1,0 +1,18 @@
+- id: RULE_NO_ADMISSION
+  severity: critical
+  description: Never admit fault or debt ownership
+  block_patterns:
+    - "\\bI admit\\b"
+    - "\\bmy fault\\b"
+    - "\\bI promise to pay\\b"
+    - "\\bI forgot\\b"
+    - "\\bI was late\\b"
+    - "\\bit was my account\\b"
+  fix_template: "I dispute the accuracy of this information and request validation."
+
+- id: RULE_PII_LIMIT
+  severity: critical
+  description: Mask PII; allow only name, address, DOB, last 4 SSN
+  block_patterns:
+    - "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+    - "\\b\\d{9}\\b"

--- a/rules/neutral_phrases.yaml
+++ b/rules/neutral_phrases.yaml
@@ -1,0 +1,8 @@
+not_mine:
+  - "I do not recognize this account and request full validation."
+inaccurate_reporting:
+  - "The reported details appear to be inaccurate; please validate and correct as necessary."
+identity_theft:
+  - "This account appears to result from identity theft; please block it under FCRA §605B."
+inconsistency_across_bureaus:
+  - "I have noted discrepancies across credit bureaus and request correction."

--- a/rules/state_rules.yaml
+++ b/rules/state_rules.yaml
@@ -1,0 +1,13 @@
+CA:
+  requires:
+    - "license_number"
+  disclosures:
+    - "California Credit Services Act disclosure..."
+  prohibit:
+    - "prepaid_fees"
+
+NY:
+  medical_debt_clause: "Pursuant to New York rules limiting medical debt reporting, please confirm whether this qualifies for removal."
+
+GA:
+  prohibit_service: true

--- a/tests/test_rules_loader.py
+++ b/tests/test_rules_loader.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic import rules_loader
+
+
+def test_load_rules():
+    rules = rules_loader.load_rules()
+    assert isinstance(rules, list)
+    assert rules[0]["id"] == "RULE_NO_ADMISSION"
+
+
+def test_load_neutral_phrases():
+    phrases = rules_loader.load_neutral_phrases()
+    assert "not_mine" in phrases
+    assert phrases["not_mine"][0].startswith("I do not recognize")
+
+
+def test_load_state_rules():
+    state_rules = rules_loader.load_state_rules()
+    assert state_rules["CA"]["requires"][0] == "license_number"
+    assert state_rules["GA"]["prohibit_service"] is True
+
+
+def test_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(rules_loader, "RULES_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError):
+        rules_loader.load_rules()
+
+
+def test_invalid_yaml(tmp_path, monkeypatch):
+    (tmp_path / "dispute_rules.yaml").write_text(": bad\n", encoding="utf-8")
+    monkeypatch.setattr(rules_loader, "RULES_DIR", tmp_path)
+    with pytest.raises(RuntimeError):
+        rules_loader.load_rules()


### PR DESCRIPTION
## Summary
- add YAML files for dispute rules, neutral phrases, and state compliance
- provide `rules_loader` for centralized YAML access with validation
- test loading behavior and error handling

## Testing
- `OPENAI_API_KEY=dummy pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68936f4bd49c832eafdd9f65f8a0574b