### PR TITLE
Implement rule checker module and tests

### DIFF
--- a/logic/rule_checker.py
+++ b/logic/rule_checker.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+from typing import TypedDict, Literal
+
+from logic.rules_loader import load_rules, load_state_rules
+
+
+class RuleViolation(TypedDict):
+    rule_id: str
+    severity: Literal["critical", "warning"]
+    span: tuple[int, int] | None
+    message: str
+
+
+def check_letter(text: str, state: str | None, context: dict) -> tuple[str, list[RuleViolation]]:
+    """
+    Returns (possibly_fixed_text, violations)
+    - Load systemic rules
+    - Scan for block_patterns; for each match:
+        * If fix_template exists → replace
+        * Else → record violation
+    - Mask PII according to RULE_PII_LIMIT
+    - Append state-specific clauses if applicable
+    - Return modified text + list of violations
+    """
+    rules = load_rules()
+    state_rules = load_state_rules()
+
+    modified_text = text
+    violations: list[RuleViolation] = []
+
+    # PII masking first
+    for rule in rules:
+        if rule.get("id") != "RULE_PII_LIMIT":
+            continue
+        for pattern in rule.get("block_patterns", []):
+            regex = re.compile(pattern)
+            matches = list(regex.finditer(modified_text))
+            for m in matches:
+                violations.append(
+                    {
+                        "rule_id": rule["id"],
+                        "severity": rule.get("severity", "warning"),
+                        "span": m.span(),
+                        "message": rule.get("description", ""),
+                    }
+                )
+            modified_text = regex.sub("[REDACTED]", modified_text)
+
+    # Apply other systemic rules
+    for rule in rules:
+        if rule.get("id") == "RULE_PII_LIMIT":
+            continue
+        for pattern in rule.get("block_patterns", []):
+            regex = re.compile(pattern, flags=re.IGNORECASE)
+            matches = list(regex.finditer(modified_text))
+            for m in matches:
+                violations.append(
+                    {
+                        "rule_id": rule["id"],
+                        "severity": rule.get("severity", "warning"),
+                        "span": m.span(),
+                        "message": rule.get("description", ""),
+                    }
+                )
+            if matches and rule.get("fix_template"):
+                modified_text = regex.sub(rule["fix_template"], modified_text)
+
+    # Append state-specific clauses
+    if state:
+        state_data = state_rules.get(state.upper())
+        clauses: list[str] = []
+        if state_data:
+            disclosures = state_data.get("disclosures")
+            if disclosures:
+                clauses.extend(disclosures)
+            if "medical_debt_clause" in state_data and context.get("debt_type") == "medical":
+                clauses.append(state_data["medical_debt_clause"])
+        if clauses:
+            if not modified_text.endswith("\n"):
+                modified_text += "\n"
+            modified_text += "\n" + "\n".join(clauses)
+
+    return modified_text, violations

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ PyMuPDF
 celery
 redis
 dirtyjson
+pyyaml
 

--- a/tests/test_rule_checker.py
+++ b/tests/test_rule_checker.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.rule_checker import check_letter
+
+
+def test_admissions_replaced_and_ca_disclosure():
+    text = "I admit this is my fault."
+    cleaned, violations = check_letter(text, state="CA", context={})
+    assert "I admit" not in cleaned
+    assert "I dispute the accuracy of this information and request validation." in cleaned
+    assert "California Credit Services Act disclosure" in cleaned
+    assert any(v["rule_id"] == "RULE_NO_ADMISSION" for v in violations)
+
+
+def test_pii_masked_and_violation_recorded():
+    text = "My SSN is 123-45-6789"
+    cleaned, violations = check_letter(text, state=None, context={})
+    assert "123-45-6789" not in cleaned
+    assert "[REDACTED]" in cleaned
+    assert any(v["rule_id"] == "RULE_PII_LIMIT" and v["severity"] == "critical" for v in violations)
+
+
+def test_state_specific_clause_appended_for_ny_medical():
+    text = "This concerns a medical debt."
+    cleaned, _ = check_letter(text, state="NY", context={"debt_type": "medical"})
+    assert "Pursuant to New York rules limiting medical debt reporting" in cleaned


### PR DESCRIPTION
## Summary
- implement rule_checker.check_letter to mask PII, replace prohibited language, and append state-specific clauses
- add tests verifying rule checker behavior and include PyYAML dependency

## Testing
- `OPENAI_API_KEY="test" pytest tests/test_rule_checker.py tests/test_rules_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_689371d8f0d0832e8ed81ce847d554ad