### PR TITLE
Integrate guardrails across letter generators

### DIFF
--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from openai import OpenAI
 from dotenv import load_dotenv
 from .json_utils import parse_json
+from logic.guardrails import fix_draft_with_guardrails
 
 load_dotenv()
 client = OpenAI(
@@ -67,7 +68,15 @@ Ensure the response is strictly valid JSON: all property names and strings in do
             content = (
                 content.replace("```json", "").replace("```", "").strip()
             )
-        return parse_json(content)
+        report = parse_json(content)
+        fix_draft_with_guardrails(
+            json.dumps(report, indent=2),
+            client_info.get("state"),
+            {},
+            client_info.get("session_id", ""),
+            "strategy",
+        )
+        return report
 
     def save_report(
         self,

--- a/logic/guardrails.py
+++ b/logic/guardrails.py
@@ -1,0 +1,129 @@
+import os
+from typing import Tuple, List
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from logic.rule_checker import check_letter, RuleViolation
+from logic.rules_loader import load_rules
+from session_manager import get_session, update_session
+
+load_dotenv()
+client = OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+)
+
+
+def _build_system_prompt() -> str:
+    rules = load_rules()
+    lines = [
+        "You are a credit dispute letter generator. Follow the systemic rules provided:",
+    ]
+    for rule in rules:
+        desc = rule.get("description")
+        if desc:
+            lines.append(f"- {desc}")
+    lines.append("Use only neutral, factual language.")
+    return "\n".join(lines)
+
+
+SYSTEM_PROMPT = _build_system_prompt()
+
+
+def _record_letter(session_id: str, letter_type: str, text: str, violations: List[RuleViolation], iterations: int) -> None:
+    session = get_session(session_id) or {}
+    letters = session.get("letters_generated", [])
+    letters.append(
+        {
+            "type": letter_type,
+            "text": text,
+            "violations": violations,
+            "iterations": iterations,
+        }
+    )
+    update_session(session_id, letters_generated=letters)
+
+
+def generate_letter_with_guardrails(
+    user_prompt: str,
+    state: str | None,
+    context: dict,
+    session_id: str,
+    letter_type: str,
+) -> Tuple[str, List[RuleViolation], int]:
+    """Generate a letter via LLM and ensure compliance with rule checker."""
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_prompt},
+    ]
+    iterations = 0
+    text = ""
+    violations: List[RuleViolation] = []
+    while iterations < 2:
+        iterations += 1
+        response = client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4"),
+            messages=messages,
+            temperature=0.3,
+        )
+        text = response.choices[0].message.content.strip()
+        if text.startswith("```"):
+            text = text.replace("```", "").strip()
+        text, violations = check_letter(text, state, context)
+        critical = [v for v in violations if v["severity"] == "critical"]
+        if not critical or iterations >= 2:
+            break
+        rule_list = ", ".join(v["rule_id"] for v in critical)
+        messages.append({"role": "assistant", "content": text})
+        messages.append(
+            {
+                "role": "user",
+                "content": f"The draft contains violations of {rule_list}. Please fix them and return a compliant version.",
+            }
+        )
+    _record_letter(session_id, letter_type, text, violations, iterations)
+    return text, violations, iterations
+
+
+def fix_draft_with_guardrails(
+    draft_text: str,
+    state: str | None,
+    context: dict,
+    session_id: str,
+    letter_type: str,
+) -> Tuple[str, List[RuleViolation], int]:
+    """Check and optionally repair an existing draft letter."""
+
+    text, violations = check_letter(draft_text, state, context)
+    iterations = 1
+    critical = [v for v in violations if v["severity"] == "critical"]
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "assistant", "content": text},
+    ]
+    while critical and iterations < 2:
+        rule_list = ", ".join(v["rule_id"] for v in critical)
+        messages.append(
+            {
+                "role": "user",
+                "content": f"The draft contains violations of {rule_list}. Please fix them and return a compliant version.",
+            }
+        )
+        response = client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4"),
+            messages=messages,
+            temperature=0,
+        )
+        text = response.choices[0].message.content.strip()
+        if text.startswith("```"):
+            text = text.replace("```", "").strip()
+        text, violations = check_letter(text, state, context)
+        iterations += 1
+        critical = [v for v in violations if v["severity"] == "critical"]
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "assistant", "content": text},
+        ]
+    _record_letter(session_id, letter_type, text, violations, iterations)
+    return text, violations, iterations

--- a/tests/test_letter_generator_guardrails.py
+++ b/tests/test_letter_generator_guardrails.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.guardrails import generate_letter_with_guardrails, fix_draft_with_guardrails, client
+from session_manager import update_session, get_session
+
+
+class DummyResponse:
+    def __init__(self, text):
+        self.choices = [type("o", (), {"message": type("m", (), {"content": text})})]
+
+
+def test_autofix_and_no_raw_explanation(monkeypatch, tmp_path):
+    session_id = "sess-test"
+    structured = {"account_id": "1", "dispute_type": "not_mine", "facts_summary": "billing issue"}
+    update_session(session_id, structured_summaries={"1": structured})
+
+    outputs = [
+        DummyResponse("I admit fault. SSN 123-45-6789."),
+        DummyResponse("This is a clean letter."),
+    ]
+
+    def fake_create(*args, **kwargs):
+        return outputs.pop(0)
+
+    monkeypatch.setattr(client.chat.completions, "create", fake_create)
+
+    prompt = (
+        "Here is the structured summary for the account:\n" + json.dumps(structured)
+    )
+
+    text, violations, iters = generate_letter_with_guardrails(
+        prompt, "CA", {"debt_type": "medical"}, session_id, "dispute"
+    )
+
+    assert iters == 2
+    assert all(v["severity"] != "critical" for v in violations)
+    session = get_session(session_id)
+    stored = session["letters_generated"][0]["text"]
+    assert "I admit" not in stored
+    assert "123-45-6789" not in stored
+
+
+def test_state_clause_added(monkeypatch):
+    session_id = "sess-ny"
+    update_session(session_id, structured_summaries={})
+
+    def fake_create(*args, **kwargs):
+        return DummyResponse("Irrelevant")
+
+    monkeypatch.setattr(client.chat.completions, "create", fake_create)
+
+    text, violations, _ = fix_draft_with_guardrails(
+        "Please investigate.", "NY", {"debt_type": "medical"}, session_id, "dispute"
+    )
+    assert "Pursuant to New York rules" in text


### PR DESCRIPTION
## Summary
- add guardrails module to build rulebook system prompt and iterate with rule_checker
- use structured summaries and session state in custom, goodwill, dispute, and strategy letters
- log generated letters, violations, and iterations for compliance auditing
- add tests verifying auto-fix, state clause insertion, and absence of raw explanations

## Testing
- `pytest tests/test_letter_generator_guardrails.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893792496b4832e975abf161786c298