### PR TITLE
Implement state compliance clause injection

### DIFF
--- a/logic/rule_checker.py
+++ b/logic/rule_checker.py
@@ -67,19 +67,74 @@ def check_letter(text: str, state: str | None, context: dict) -> tuple[str, list
             if matches and rule.get("fix_template"):
                 modified_text = regex.sub(rule["fix_template"], modified_text)
 
-    # Append state-specific clauses
+    # Append state-specific clauses and handle prohibitions
     if state:
-        state_data = state_rules.get(state.upper())
-        clauses: list[str] = []
-        if state_data:
-            disclosures = state_data.get("disclosures")
-            if disclosures:
-                clauses.extend(disclosures)
-            if "medical_debt_clause" in state_data and context.get("debt_type") == "medical":
-                clauses.append(state_data["medical_debt_clause"])
-        if clauses:
+        state_key = state.upper()
+        state_data = state_rules.get(state_key, {})
+        clauses_added: list[str] = []
+
+        if state_data.get("prohibit_service"):
+            violations.append(
+                {
+                    "rule_id": "STATE_PROHIBITED",
+                    "severity": "critical",
+                    "span": None,
+                    "message": f"Service is not available in {state_key}",
+                }
+            )
+
+        # Insert state-specific clauses before the closing signature
+        debt_type = context.get("debt_type")
+        clause_texts: list[str] = []
+        clauses_config = state_data.get("clauses", {})
+        if debt_type and isinstance(clauses_config, dict):
+            clause_info = clauses_config.get(debt_type)
+            if clause_info:
+                reference = clause_info.get("reference", "")
+                text_clause = clause_info.get("text", "")
+                sentence = f"Additionally, pursuant to {reference}, {text_clause}".rstrip()
+                if not sentence.endswith("."):
+                    sentence += "."
+                clause_texts.append(sentence)
+                clauses_added.append(clause_info.get("label", text_clause))
+
+        if clause_texts:
+            lines = modified_text.splitlines()
+            if len(lines) >= 2:
+                signature_line = lines[-1]
+                closing_line = lines[-2]
+                body = "\n".join(lines[:-2]).rstrip()
+                if body:
+                    body += "\n"
+                body += "\n".join(clause_texts)
+                modified_text = body + "\n" + closing_line + "\n" + signature_line
+            else:
+                if not modified_text.endswith("\n"):
+                    modified_text += "\n"
+                modified_text += "\n".join(clause_texts)
+
+        # Append required disclosures after the signature
+        disclosures = state_data.get("disclosures") or []
+        if disclosures:
             if not modified_text.endswith("\n"):
                 modified_text += "\n"
-            modified_text += "\n" + "\n".join(clauses)
+            modified_text += "\n".join(disclosures)
+            clauses_added.extend(disclosures)
+
+        # Log clause additions to session if session_id provided
+        session_id = context.get("session_id")
+        if session_id and clauses_added:
+            try:
+                from session_manager import update_session
+
+                update_session(
+                    session_id,
+                    state_compliance={
+                        "state": state_key,
+                        "clauses_added": clauses_added,
+                    },
+                )
+            except Exception:
+                pass
 
     return modified_text, violations

--- a/rules/state_rules.yaml
+++ b/rules/state_rules.yaml
@@ -7,7 +7,11 @@ CA:
     - "prepaid_fees"
 
 NY:
-  medical_debt_clause: "Pursuant to New York rules limiting medical debt reporting, please confirm whether this qualifies for removal."
+  clauses:
+    medical:
+      reference: "New York rules limiting medical debt reporting"
+      text: "please confirm whether this qualifies for removal."
+      label: "NY Medical Debt Clause"
 
 GA:
   prohibit_service: true

--- a/tests/test_letter_generator_guardrails.py
+++ b/tests/test_letter_generator_guardrails.py
@@ -56,4 +56,4 @@ def test_state_clause_added(monkeypatch):
     text, violations, _ = fix_draft_with_guardrails(
         "Please investigate.", "NY", {"debt_type": "medical"}, session_id, "dispute"
     )
-    assert "Pursuant to New York rules" in text
+    assert "pursuant to new york rules" in text.lower()

--- a/tests/test_rule_checker.py
+++ b/tests/test_rule_checker.py
@@ -28,4 +28,4 @@ def test_pii_masked_and_violation_recorded():
 def test_state_specific_clause_appended_for_ny_medical():
     text = "This concerns a medical debt."
     cleaned, _ = check_letter(text, state="NY", context={"debt_type": "medical"})
-    assert "Pursuant to New York rules limiting medical debt reporting" in cleaned
+    assert "pursuant to new york rules limiting medical debt reporting" in cleaned.lower()

--- a/tests/test_state_compliance_in_text.py
+++ b/tests/test_state_compliance_in_text.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.rule_checker import check_letter
+from session_manager import get_session, update_session
+
+
+def test_ny_medical_clause_injected_and_logged(tmp_path):
+    session_id = "sess-ny-compliance"
+    text = "Please review this account.\nSincerely,\nJohn Doe"
+    cleaned, violations = check_letter(
+        text,
+        state="NY",
+        context={"debt_type": "medical", "session_id": session_id},
+    )
+    assert "pursuant to new york rules limiting medical debt reporting" in cleaned.lower()
+    assert cleaned.index("Additionally") < cleaned.index("Sincerely")
+    session = get_session(session_id)
+    assert session["state_compliance"]["state"] == "NY"
+    assert "NY Medical Debt Clause" in session["state_compliance"]["clauses_added"]
+
+
+def test_ga_prohibit_service_flags_violation():
+    _, violations = check_letter("Body\nSincerely,\nName", state="GA", context={})
+    assert any(v["rule_id"] == "STATE_PROHIBITED" and v["severity"] == "critical" for v in violations)
+
+
+def test_unrelated_state_no_extra_text():
+    text = "Investigate this account.\nSincerely,\nJane Doe"
+    cleaned, _ = check_letter(text, state="TX", context={})
+    assert "Additionally, pursuant" not in cleaned


### PR DESCRIPTION
## Summary
- enhance rule_checker to insert state-specific clauses before signatures, append disclosures, and log clause usage
- flag prohibited service states like GA with critical violations
- add state compliance tests and update existing tests for case-insensitive checks

## Testing
- `pytest tests/test_state_compliance_in_text.py -q`
- `OPENAI_API_KEY=dummy pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68937c1e64ec832eb88b15d407cbd15d