### PR TITLE
Add outcomes storage and export

### DIFF
--- a/logic/outcomes_store.py
+++ b/logic/outcomes_store.py
@@ -1,0 +1,64 @@
+import json
+import os
+import threading
+from datetime import datetime
+from typing import Dict, List, Optional
+
+OUTCOMES_FILE = os.path.join("data", "outcomes.json")
+_lock = threading.Lock()
+
+
+def _load_outcomes() -> List[Dict]:
+    if not os.path.exists(OUTCOMES_FILE):
+        return []
+    try:
+        with open(OUTCOMES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, list):
+                return data
+    except Exception:
+        pass
+    return []
+
+
+def _write_outcomes(outcomes: List[Dict]) -> None:
+    os.makedirs(os.path.dirname(OUTCOMES_FILE), exist_ok=True)
+    tmp_path = OUTCOMES_FILE + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(outcomes, f)
+    os.replace(tmp_path, OUTCOMES_FILE)
+
+
+def record_outcome(
+    session_id: str,
+    account_id: str,
+    bureau: str,
+    letter_version: int,
+    result: str,
+    days_to_response: Optional[int] | None = None,
+    reason: Optional[str] | None = None,
+) -> None:
+    """Append an outcome record with timestamp to persistent storage."""
+    record = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "session_id": session_id,
+        "account_id": account_id,
+        "bureau": bureau,
+        "letter_version": letter_version,
+        "result": result,
+        "days_to_response": days_to_response,
+        "reason": reason,
+    }
+    with _lock:
+        outcomes = _load_outcomes()
+        outcomes.append(record)
+        _write_outcomes(outcomes)
+
+
+def get_outcomes(filter_by: Optional[Dict] | None = None) -> List[Dict]:
+    """Return stored outcomes optionally filtered by keys (e.g., bureau, result)."""
+    with _lock:
+        outcomes = list(_load_outcomes())
+    if not filter_by:
+        return outcomes
+    return [o for o in outcomes if all(o.get(k) == v for k, v in filter_by.items())]

--- a/scripts/export_outcomes.py
+++ b/scripts/export_outcomes.py
@@ -1,0 +1,55 @@
+import csv
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+# Allow importing the project modules when this script is run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.outcomes_store import get_outcomes
+
+EXPORT_DIR = Path("exports")
+
+
+def export_outcomes() -> None:
+    """Export outcomes from the last 7 days to JSON and CSV files."""
+    now = datetime.utcnow()
+    start = now - timedelta(days=7)
+    all_outcomes = get_outcomes()
+    recent = []
+    for o in all_outcomes:
+        ts = o.get("timestamp")
+        try:
+            dt = datetime.fromisoformat(ts)
+        except Exception:
+            continue
+        if start <= dt <= now:
+            recent.append(o)
+
+    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+    date_str = now.strftime("%Y-%m-%d")
+    json_path = EXPORT_DIR / f"outcomes_{date_str}.json"
+    csv_path = EXPORT_DIR / f"outcomes_{date_str}.csv"
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(recent, f, ensure_ascii=False, indent=2)
+
+    fieldnames = [
+        "timestamp",
+        "session_id",
+        "account_id",
+        "bureau",
+        "letter_version",
+        "result",
+        "days_to_response",
+        "reason",
+    ]
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(recent)
+
+
+if __name__ == "__main__":
+    export_outcomes()

--- a/tests/test_outcomes_store.py
+++ b/tests/test_outcomes_store.py
@@ -1,0 +1,57 @@
+import csv
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic import outcomes_store
+from scripts import export_outcomes
+
+
+def test_record_and_filter(tmp_path, monkeypatch):
+    file_path = tmp_path / "outcomes.json"
+    monkeypatch.setattr(outcomes_store, "OUTCOMES_FILE", str(file_path))
+
+    outcomes_store.record_outcome("sess1", "acc1", "Equifax", 1, "deleted", 3, "error")
+    outcomes_store.record_outcome("sess2", "acc2", "Experian", 1, "verified")
+
+    assert file_path.exists()
+    data = json.loads(file_path.read_text())
+    assert len(data) == 2
+
+    subset = outcomes_store.get_outcomes({"result": "deleted"})
+    assert len(subset) == 1
+    assert subset[0]["account_id"] == "acc1"
+
+
+def test_export_last_week(tmp_path, monkeypatch):
+    file_path = tmp_path / "outcomes.json"
+    monkeypatch.setattr(outcomes_store, "OUTCOMES_FILE", str(file_path))
+
+    outcomes_store.record_outcome("sess1", "acc1", "Equifax", 1, "deleted")
+    outcomes_store.record_outcome("sess2", "acc2", "Experian", 1, "verified")
+
+    data = outcomes_store.get_outcomes()
+    data[0]["timestamp"] = (datetime.utcnow() - timedelta(days=8)).isoformat()
+    file_path.write_text(json.dumps(data))
+
+    export_dir = tmp_path / "exports"
+    monkeypatch.setattr(export_outcomes, "EXPORT_DIR", export_dir)
+    export_outcomes.export_outcomes()
+
+    date_str = datetime.utcnow().strftime("%Y-%m-%d")
+    json_path = export_dir / f"outcomes_{date_str}.json"
+    csv_path = export_dir / f"outcomes_{date_str}.csv"
+    assert json_path.exists()
+    assert csv_path.exists()
+
+    exported = json.loads(json_path.read_text())
+    assert len(exported) == 1
+    assert exported[0]["account_id"] == "acc2"
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert rows[0]["account_id"] == "acc2"


### PR DESCRIPTION
## Summary
- Implement outcomes store with atomic JSON persistence and filtering API
- Add export script to generate weekly CSV/JSON reports for recent outcomes
- Test recording, filtering, and export functionality

## Testing
- `pytest tests/test_outcomes_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68937ed6b25c832e8dd0de7fe60a5a41