### PR TITLE
Improve JSON repair and prompt validation

### DIFF
--- a/logic/analyze_report.py
+++ b/logic/analyze_report.py
@@ -67,6 +67,8 @@ Your task: deeply analyze the following SmartCredit report text and extract a st
 Client goal: "{client_goal}"
 Identity theft case: {"Yes" if is_identity_theft else "No"}
 
+Return only valid JSON with all property names in double quotes. No comments or extra text outside the JSON object.
+
 Return this exact JSON structure:
 
 1. personal_info_issues: List of inconsistencies or mismatches in personal info (name, address, DOB) across bureaus.

--- a/logic/json_utils.py
+++ b/logic/json_utils.py
@@ -1,6 +1,12 @@
 import json
 import logging
 import re
+from pathlib import Path
+
+try:
+    from json_repair import repair_json as _jsonrepair
+except Exception:  # pragma: no cover - optional dependency
+    _jsonrepair = None
 
 try:
     import dirtyjson as _dirtyjson
@@ -15,45 +21,66 @@ except Exception:  # pragma: no cover - optional dependency
 _TRAILING_COMMA_RE = re.compile(r',(?=\s*[}\]])')
 _SINGLE_QUOTE_KEY_RE = re.compile(r"'([^']*)'(?=\s*:)" )
 _SINGLE_QUOTE_VALUE_RE = re.compile(r":\s*'([^']*)'" )
+_UNQUOTED_KEY_RE = re.compile(r'(?P<prefix>^|[,{])\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*(?=:)')
+_LOG_PATH = Path("invalid_ai_json.log")
+
+
+def _log_invalid_json(raw: str) -> None:
+    """Persist the raw AI output for debugging."""
+    try:
+        with _LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(raw)
+            f.write("\n---\n")
+    except Exception:  # pragma: no cover - best effort only
+        logging.debug("Unable to log invalid JSON output.")
 
 
 def _basic_clean(content: str) -> str:
-    """Apply simple regex-based fixes for common JSON issues."""
-    cleaned = _TRAILING_COMMA_RE.sub(r"", content)
+    """Apply regex-based fixes for common JSON issues."""
+    cleaned = _TRAILING_COMMA_RE.sub("", content)
     cleaned = _SINGLE_QUOTE_KEY_RE.sub(r'"\1"', cleaned)
     cleaned = _SINGLE_QUOTE_VALUE_RE.sub(r': "\1"', cleaned)
+    cleaned = _UNQUOTED_KEY_RE.sub(lambda m: f'{m.group("prefix")}"{m.group("key")}"', cleaned)
     return cleaned
 
 
-def parse_json(text: str):
-    """Parse ``text`` as JSON, attempting repairs on failure.
+def _repair_json(content: str) -> str:
+    """Attempt to repair malformed JSON using json_repair or basic regex fixes."""
+    if _jsonrepair is not None:
+        try:
+            return _jsonrepair(content)
+        except Exception:  # pragma: no cover - if repair fails, fall back
+            logging.debug("json_repair failed to process input")
+    return _basic_clean(content)
 
-    This first tries :func:`json.loads`. If that fails, it tries ``dirtyjson`` or
-    ``json5`` when available. As a last resort it applies basic regex fixes for
-    trailing commas and single quotes. If parsing still fails, the original
-    ``JSONDecodeError`` is raised.
-    """
+
+def parse_json(text: str):
+    """Parse ``text`` as JSON, attempting repairs on failure."""
+    normalized = _repair_json(text)
     try:
-        return json.loads(text)
+        return json.loads(normalized)
     except json.JSONDecodeError:
+        _log_invalid_json(text)
         logging.warning("⚠️ The AI returned invalid JSON. Attempting to repair.")
-        # Try dirtyjson if available
+        cleaned = _basic_clean(normalized)
+        if cleaned != normalized:
+            logging.debug("Cleaned JSON string: %s", cleaned)
+            try:
+                return json.loads(cleaned)
+            except json.JSONDecodeError:
+                pass
         if _dirtyjson is not None:
             try:
-                repaired = _dirtyjson.loads(text)
+                repaired = _dirtyjson.loads(normalized)
                 logging.debug("Repaired JSON via dirtyjson: %s", repaired)
                 return repaired
             except Exception:  # pragma: no cover - handle silently
                 logging.debug("dirtyjson failed to parse input")
         if _json5 is not None:
             try:
-                repaired = _json5.loads(text)
+                repaired = _json5.loads(normalized)
                 logging.debug("Repaired JSON via json5: %s", repaired)
                 return repaired
             except Exception:  # pragma: no cover - handle silently
                 logging.debug("json5 failed to parse input")
-        cleaned = _basic_clean(text)
-        if cleaned != text:
-            logging.debug("Cleaned JSON string: %s", cleaned)
-            return json.loads(cleaned)
         raise

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -13,3 +13,6 @@ def test_parse_trailing_comma():
 
 def test_parse_single_quotes():
     assert parse_json("{'a': 'b'}") == {"a": "b"}
+
+def test_parse_unquoted_keys():
+    assert parse_json('{advisor_comment: "text here"}') == {"advisor_comment": "text here"}


### PR DESCRIPTION
## Summary
- pre-normalize AI JSON responses and retry parsing with logging
- enforce valid JSON requirement in credit analysis prompt
- test parsing of JSON with unquoted property names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689394fca9b8832e95a9b5a586d92934