### PR TITLE
Add safe fallback and logging for unrecognized strategist actions

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ load_dotenv()
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+RULEBOOK_FALLBACK_ENABLED = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
 
 # Ensure the fallback is visible to later getenv calls
 os.environ.setdefault("OPENAI_BASE_URL", OPENAI_BASE_URL)
@@ -19,6 +20,7 @@ if not _logger.handlers:
 _logger.setLevel(logging.INFO)
 _logger.info("OPENAI_BASE_URL=%s", OPENAI_BASE_URL)
 _logger.info("OPENAI_API_KEY present=%s", bool(OPENAI_API_KEY))
+_logger.info("RULEBOOK_FALLBACK_ENABLED=%s", RULEBOOK_FALLBACK_ENABLED)
 
 if not OPENAI_API_KEY:
     raise EnvironmentError("OPENAI_API_KEY is not set")

--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
                                 print(
                                     f"[⚠️] Unrecognised strategist action '{raw_action}' for {src.get('name')}"
                                 )
+                                acc["fallback_unrecognized_action"] = True
                             if tag:
                                 acc["action_tag"] = tag
                                 acc["recommended_action"] = action

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import json
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.letter_generator import (
+    generate_all_dispute_letters_with_ai,
+    DEFAULT_DISPUTE_REASON,
+)
+
+class Dummy:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
+    # Patch external dependencies
+    monkeypatch.setattr(
+        'logic.letter_generator.generate_strategy',
+        lambda session_id, bureau_data: {"dispute_items": {}}
+    )
+
+    def fake_call_gpt(*args, **kwargs):
+        return {
+            "opening_paragraph": "Opening",
+            "accounts": [
+                {
+                    "name": "Bank A",
+                    "account_number": "1",
+                    "status": "open",
+                    "paragraph": "client raw note ABCXYZ",
+                    "requested_action": "Delete",
+                }
+            ],
+            "inquiries": [],
+            "closing_paragraph": "Closing",
+        }
+
+    monkeypatch.setattr('logic.letter_generator.call_gpt_dispute_letter', fake_call_gpt)
+    monkeypatch.setattr('logic.letter_generator.render_html_to_pdf', lambda html, path: None)
+    monkeypatch.setattr('logic.letter_generator.fix_draft_with_guardrails', lambda *a, **k: None)
+    import pdfkit
+    monkeypatch.setattr(pdfkit, 'configuration', lambda *a, **k: None)
+
+    client_info = {
+        "name": "Test Client",
+        "session_id": "sess1",
+        "custom_dispute_notes": {"Bank A": "raw note ABCXYZ"},
+    }
+
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {
+                    "name": "Bank A",
+                    "account_number": "1",
+                    "action_tag": "dispute",
+                    "fallback_unrecognized_action": True,
+                }
+            ],
+            "inquiries": [],
+        }
+    }
+
+    generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+
+    data = json.load(open(tmp_path / "Experian_gpt_response.json"))
+    assert data["accounts"][0]["paragraph"] == DEFAULT_DISPUTE_REASON
+    assert "ABCXYZ" not in data["accounts"][0]["paragraph"]
+
+    out, _ = capsys.readouterr()
+    assert "fallback_used=True" in out
+    assert "raw_client_text_present=False" in out


### PR DESCRIPTION
## Summary
- track unrecognized strategist actions and guard letter generation
- add configurable Rulebook fallback to avoid inserting client text
- log per-letter summary and test the fallback behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893a25cabe0832e800189da7ba1cb49