### PR TITLE
Isolate raw client explanations from letter generation

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -3,8 +3,16 @@ import os
 import threading
 from typing import Any, Dict
 
+
+# Standard session data that can be safely accessed by most modules.
 SESSION_FILE = os.path.join("data", "sessions.json")
 _lock = threading.Lock()
+
+# Dedicated storage for intake-only information such as the raw client
+# explanations. These values should never be exposed to downstream
+# components like the letter generator.
+INTAKE_FILE = os.path.join("data", "intake_only.json")
+_intake_lock = threading.Lock()
 
 
 def _load_sessions() -> Dict[str, Dict[str, Any]]:
@@ -44,3 +52,47 @@ def update_session(session_id: str, **kwargs: Any) -> Dict[str, Any]:
         sessions[session_id] = session
         _save_sessions(sessions)
         return session
+
+
+# ---------------------------------------------------------------------------
+# Intake-only storage helpers
+# ---------------------------------------------------------------------------
+
+def _load_intake() -> Dict[str, Dict[str, Any]]:
+    if not os.path.exists(INTAKE_FILE):
+        return {}
+    try:
+        with open(INTAKE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_intake(intake: Dict[str, Dict[str, Any]]) -> None:
+    os.makedirs(os.path.dirname(INTAKE_FILE), exist_ok=True)
+    with open(INTAKE_FILE, "w", encoding="utf-8") as f:
+        json.dump(intake, f)
+
+
+def update_intake(session_id: str, **kwargs: Any) -> Dict[str, Any]:
+    """Update or create intake-only data for a session.
+
+    This storage is isolated from the main session data and should only be
+    accessed by trusted intake components (e.g. the explanations endpoint).
+    """
+
+    with _intake_lock:
+        intake = _load_intake()
+        session = intake.get(session_id, {})
+        session.update(kwargs)
+        intake[session_id] = session
+        _save_intake(intake)
+        return session
+
+
+def get_intake(session_id: str) -> Dict[str, Any] | None:
+    """Retrieve intake-only data for a session."""
+
+    with _intake_lock:
+        intake = _load_intake()
+        return intake.get(session_id)

--- a/tests/test_explanations_api.py
+++ b/tests/test_explanations_api.py
@@ -5,7 +5,7 @@ import importlib
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from session_manager import get_session
+from session_manager import get_session, get_intake
 
 
 def test_explanations_endpoint_stores_raw_and_structured(monkeypatch):
@@ -52,7 +52,9 @@ def test_explanations_endpoint_stores_raw_and_structured(monkeypatch):
         summary_data = res.get_json()
 
     session = get_session(session_id)
-    assert session["raw_explanations"][0]["text"] == "I was late"
+    intake = get_intake(session_id)
+    assert intake["raw_explanations"][0]["text"] == "I was late"
+    assert "raw_explanations" not in session
     assert session["structured_summaries"][0]["facts_summary"] == "summary"
     text = json.dumps(summary_data)
     assert "I was late" not in text

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -1,0 +1,67 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from session_manager import update_session, update_intake
+from logic.letter_generator import generate_all_dispute_letters_with_ai
+
+
+def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
+    structured = {
+        "1": {
+            "account_id": "1",
+            "dispute_type": "late",
+            "facts_summary": "summary",
+            "claimed_errors": [],
+            "dates": {},
+            "evidence": [],
+            "risk_flags": {},
+        }
+    }
+    session_id = "sess-intake-guard"
+    update_session(session_id, structured_summaries=structured)
+    update_intake(session_id, raw_explanations=[{"account_id": "1", "text": "SECRET RAW"}])
+
+    def fake_generate_strategy(sess_id, bureau_data):
+        return {"dispute_items": structured}
+
+    def fake_call_gpt(client_info, bureau_name, disputes, inquiries, is_identity_theft, structured_summaries, state):
+        text = json.dumps(structured_summaries)
+        assert "SECRET RAW" not in text
+        return {
+            "opening_paragraph": "Opening",
+            "accounts": [
+                {
+                    "name": "Bank A",
+                    "account_number": "1",
+                    "status": "open",
+                    "paragraph": "placeholder",
+                    "requested_action": "Delete",
+                }
+            ],
+            "inquiries": [],
+            "closing_paragraph": "Closing",
+        }
+
+    monkeypatch.setattr("logic.letter_generator.generate_strategy", fake_generate_strategy)
+    monkeypatch.setattr("logic.letter_generator.call_gpt_dispute_letter", fake_call_gpt)
+    monkeypatch.setattr("logic.letter_generator.render_html_to_pdf", lambda html, path: None)
+    monkeypatch.setattr("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: None)
+    import pdfkit
+    monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
+
+    client_info = {"name": "Test Client", "session_id": session_id}
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {"name": "Bank A", "account_number": "1", "action_tag": "dispute"}
+            ],
+            "inquiries": [],
+        }
+    }
+
+    generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+    data = json.load(open(tmp_path / "Experian_gpt_response.json"))
+    assert "SECRET RAW" not in json.dumps(data)

--- a/tests/test_strategy_engine.py
+++ b/tests/test_strategy_engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from session_manager import update_session, get_session
+from session_manager import update_session, get_session, update_intake
 from logic.strategy_engine import generate_strategy
 
 
@@ -21,9 +21,11 @@ def test_strategy_engine_uses_structured_summaries():
             "risk_flags": {},
         }
     }
-    update_session(session_id, structured_summaries=structured, raw_explanations=[{"account_id": "1", "text": "raw"}])
+    update_session(session_id, structured_summaries=structured)
+    update_intake(session_id, raw_explanations=[{"account_id": "1", "text": "raw"}])
     strategy = generate_strategy(session_id, {"Experian": {"disputes": []}})
     assert strategy["dispute_items"] == structured
     session = get_session(session_id)
     assert "strategy" in session
+    assert "raw_explanations" not in session
     assert "raw" not in json.dumps(strategy)


### PR DESCRIPTION
## Summary
- store client explanations in a dedicated `intake_only` area and add helpers to read/write this data
- keep only structured summaries in sessions and use them when kicking off processing
- adjust Celery task to accept structured summaries and drop raw notes from `client_info`
- add test ensuring dispute letters cannot access intake-only text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a722465c832eb20b35748a065a66