### PR TITLE
feat: add dispute strategy engine

### DIFF
--- a/logic/strategy_engine.py
+++ b/logic/strategy_engine.py
@@ -1,24 +1,86 @@
 from __future__ import annotations
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from session_manager import get_session, update_session
 from .rules_loader import load_rules
 from .outcomes_store import get_outcomes
 
 
-def generate_strategy(session_id: str, bureau_data: Dict[str, Any]) -> Dict[str, Any]:
-    """Build a strategy document for a given session.
+# Simple mapping of dispute types to relevant statutes and tone guidance.
+# In a production system these would likely come from a dedicated rules
+# service or configuration file.  For the purposes of unit testing we keep a
+# lightweight, documented mapping here.
+LEGAL_BASIS = {
+    "late": "FCRA 611(a)",
+    "identity_theft": "FCRA 605B",
+    "collections": "FCRA 623(a)(3)",
+    "inaccurate_reporting": "FCRA 611(a)",
+}
 
-    The strategy combines the sanitized explanations (stored as
-    ``structured_summaries``), the current rulebook, a snapshot of the
-    provided credit report data and recent outcome telemetry. The raw client
-    explanations are intentionally excluded to prevent accidental leakage
-    into any generated letters.
+TONE_MAP = {
+    "identity_theft": "urgent and firm",
+    "collections": "assertive",
+    "late": "professional",
+    "inaccurate_reporting": "professional",
+}
+
+
+def _lookup_account(account_id: str, bureau_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return account details and originating bureau for ``account_id``."""
+
+    for bureau, payload in bureau_data.items():
+        for section in payload.values():
+            if isinstance(section, list):
+                for entry in section:
+                    if str(entry.get("account_id")) == str(account_id):
+                        result = dict(entry)
+                        result["bureau"] = bureau
+                        return result
+    return {"bureau": None}
+
+
+def _build_dispute_items(structured: Dict[str, Any], bureau_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Construct per-account dispute strategies."""
+
+    items: List[Dict[str, Any]] = []
+    for item_id, summary in structured.items():
+        account_id = summary.get("account_id", item_id)
+        account_info = _lookup_account(account_id, bureau_data)
+        dispute_type = summary.get("dispute_type", "inaccurate_reporting")
+        legal_basis = LEGAL_BASIS.get(dispute_type, "FCRA 611")
+        tone = TONE_MAP.get(dispute_type, "professional")
+
+        item = {
+            "account_id": account_id,
+            "bureau": account_info.get("bureau"),
+            "account_name": account_info.get("name"),
+            "dispute_type": dispute_type,
+            "rationale": summary.get("facts_summary"),
+            "legal_basis": legal_basis,
+            "tone": tone,
+            "next_steps": [
+                "Send dispute letter to bureau",
+                "Monitor response and follow up",
+            ],
+        }
+        items.append(item)
+    return items
+
+
+def generate_strategy(session_id: str, bureau_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a comprehensive strategy document for a given session.
+
+    The strategy combines sanitized client summaries (``structured_summaries``),
+    the current rulebook, a snapshot of the provided credit report data and
+    recent outcome telemetry. Raw client explanations are intentionally
+    excluded to prevent accidental leakage into any generated letters.
     """
 
     session = get_session(session_id) or {}
     structured = session.get("structured_summaries", {})
+
+    items = _build_dispute_items(structured, bureau_data)
 
     strategy: Dict[str, Any] = {
         "generated_at": datetime.utcnow().isoformat(),
@@ -26,6 +88,11 @@ def generate_strategy(session_id: str, bureau_data: Dict[str, Any]) -> Dict[str,
         "dispute_items": structured,
         "bureau_data": bureau_data,
         "historical_outcomes": get_outcomes(),
+        "items": items,
+        "tone_guidelines": "Maintain a firm but respectful tone and avoid admissions of liability.",
+        "follow_up": [
+            "Review bureau responses and escalate unresolved items",
+        ],
     }
 
     update_session(session_id, strategy=strategy)

--- a/tests/test_strategy_engine.py
+++ b/tests/test_strategy_engine.py
@@ -25,7 +25,44 @@ def test_strategy_engine_uses_structured_summaries():
     update_intake(session_id, raw_explanations=[{"account_id": "1", "text": "raw"}])
     strategy = generate_strategy(session_id, {"Experian": {"disputes": []}})
     assert strategy["dispute_items"] == structured
+    # ensure per-account strategy items were produced
+    assert any(item["account_id"] == "1" for item in strategy.get("items", []))
     session = get_session(session_id)
     assert "strategy" in session
     assert "raw_explanations" not in session
     assert "raw" not in json.dumps(strategy)
+
+
+def test_strategy_engine_assigns_legal_basis_and_tone():
+    session_id = "sess-legal"
+    structured = {
+        "1": {
+            "account_id": "1",
+            "dispute_type": "late",
+            "facts_summary": "I was never late",
+        },
+        "2": {
+            "account_id": "2",
+            "dispute_type": "identity_theft",
+            "facts_summary": "Not my account",
+        },
+    }
+    update_session(session_id, structured_summaries=structured)
+
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {"account_id": "1", "name": "ACME", "status": "Late"},
+                {"account_id": "2", "name": "Fraud Co", "status": "Collections"},
+            ]
+        }
+    }
+
+    strategy = generate_strategy(session_id, bureau_data)
+    assert len(strategy.get("items", [])) == 2
+    item1 = next(i for i in strategy["items"] if i["account_id"] == "1")
+    item2 = next(i for i in strategy["items"] if i["account_id"] == "2")
+    assert item1["legal_basis"] == "FCRA 611(a)"
+    assert item2["legal_basis"] == "FCRA 605B"
+    assert item1["tone"] != item2["tone"]
+    assert strategy["follow_up"]


### PR DESCRIPTION
## Summary
- build central strategy engine that maps dispute types to legal bases and tone
- generate per-account strategy items with next steps and guidelines
- add unit tests for strategy personalization and legal basis mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b0d0c8ec832e993cb16251a03360