### PR TITLE
Enhance neutral phrase usage for personalized letters

### DIFF
--- a/dev_scripts/test_logic_fixes.py
+++ b/dev_scripts/test_logic_fixes.py
@@ -321,6 +321,7 @@ def test_letter_duplicate_accounts_removed():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter") as mock_d,
         mock.patch("logic.letter_generator.render_html_to_pdf"),
+        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
     ):
         out_dir = Path("output/tmp_dupes")
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -358,6 +359,7 @@ def test_partial_account_number_deduplication():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter") as mock_d,
         mock.patch("logic.letter_generator.render_html_to_pdf"),
+        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
     ):
         out_dir = Path("output/tmp_dupe_nums")
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -402,6 +404,7 @@ def test_merge_custom_note_with_default():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter", return_value=gpt_resp),
         mock.patch("logic.letter_generator.render_html_to_pdf"),
+        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
     ):
         out_dir = Path("output/tmp_merge")
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -449,8 +452,10 @@ def test_general_note_routed_to_goodwill():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter", return_value=gpt_resp),
         mock.patch("logic.letter_generator.render_html_to_pdf"),
+        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
         mock.patch("logic.generate_goodwill_letters.call_gpt_for_goodwill_letter") as mock_gw,
         mock.patch("logic.generate_goodwill_letters.render_html_to_pdf"),
+        mock.patch("logic.generate_goodwill_letters.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
     ):
         out_dir = Path("output/tmp_general")
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_letter_generator_guardrails.py
+++ b/tests/test_letter_generator_guardrails.py
@@ -56,4 +56,4 @@ def test_state_clause_added(monkeypatch):
     text, violations, _ = fix_draft_with_guardrails(
         "Please investigate.", "NY", {"debt_type": "medical"}, session_id, "dispute"
     )
-    assert "pursuant to new york rules" in text.lower()
+    assert "new york financial services law" in text.lower()

--- a/tests/test_neutral_phrase_integration.py
+++ b/tests/test_neutral_phrase_integration.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+import sys
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from logic.letter_generator import call_gpt_dispute_letter
+from logic import rules_loader
+import openai
+
+
+class DummyResp:
+    def __init__(self, content: str):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+
+def test_dispute_prompt_includes_neutral_phrase(monkeypatch):
+    captured = {}
+
+    def fake_create(*args, **kwargs):
+        captured["prompt"] = kwargs["messages"][0]["content"]
+        return DummyResp('{"opening_paragraph": "", "accounts": [], "inquiries": [], "closing_paragraph": ""}')
+
+    dummy_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+    monkeypatch.setattr(openai, "OpenAI", lambda **_: dummy_client)
+    monkeypatch.setattr(
+        "logic.letter_generator.classify_client_summary",
+        lambda struct, state: {"category": "not_mine"},
+    )
+
+    structured = {"explanation": "I never opened this"}
+    call_gpt_dispute_letter(
+        {"legal_name": "Test", "session_id": ""},
+        "Equifax",
+        [{"account_id": "1", "name": "Acc", "account_number": "123", "reported_status": "open"}],
+        [],
+        False,
+        {"1": structured},
+        "",
+    )
+
+    phrases = rules_loader.load_neutral_phrases()["not_mine"]
+    assert any(p in captured["prompt"] for p in phrases)
+    assert '"explanation": "I never opened this"' in captured["prompt"]

--- a/tests/test_rule_checker.py
+++ b/tests/test_rule_checker.py
@@ -12,8 +12,12 @@ def test_admissions_replaced_and_ca_disclosure():
     text = "I admit this is my fault."
     cleaned, violations = check_letter(text, state="CA", context={})
     assert "I admit" not in cleaned
-    assert "I dispute the accuracy of this information and request validation." in cleaned
-    assert "California Credit Services Act disclosure" in cleaned
+    assert (
+        "I dispute the accuracy of this information and request validation under applicable law." in cleaned
+    )
+    assert (
+        "Under the California Credit Services Act, we are required to provide this disclosure." in cleaned
+    )
     assert any(v["rule_id"] == "RULE_NO_ADMISSION" for v in violations)
 
 
@@ -28,7 +32,7 @@ def test_pii_masked_and_violation_recorded():
 def test_state_specific_clause_appended_for_ny_medical():
     text = "This concerns a medical debt."
     cleaned, _ = check_letter(text, state="NY", context={"debt_type": "medical"})
-    assert "pursuant to new york rules limiting medical debt reporting" in cleaned.lower()
+    assert "new york financial services law" in cleaned.lower()
 
 
 def test_ga_service_prohibited():

--- a/tests/test_rules_loader.py
+++ b/tests/test_rules_loader.py
@@ -19,6 +19,13 @@ def test_load_neutral_phrases():
     assert phrases["not_mine"][0].startswith("I do not recognize")
 
 
+def test_get_neutral_phrase_matches_category():
+    phrase = rules_loader.get_neutral_phrase(
+        "not_mine", {"facts_summary": "this account is not mine"}
+    )
+    assert phrase in rules_loader.load_neutral_phrases()["not_mine"]
+
+
 def test_load_state_rules():
     state_rules = rules_loader.load_state_rules()
     assert state_rules["CA"]["requires"][0] == "license_number"

--- a/tests/test_state_compliance_in_text.py
+++ b/tests/test_state_compliance_in_text.py
@@ -17,7 +17,7 @@ def test_ny_medical_clause_injected_and_logged(tmp_path):
         state="NY",
         context={"debt_type": "medical", "session_id": session_id},
     )
-    assert "pursuant to new york rules limiting medical debt reporting" in cleaned.lower()
+    assert "new york financial services law" in cleaned.lower()
     assert cleaned.index("Additionally") < cleaned.index("Sincerely")
     session = get_session(session_id)
     assert session["state_compliance"]["state"] == "NY"


### PR DESCRIPTION
## Summary
- Select neutral legal phrases with a simple heuristic via `get_neutral_phrase`
- Blend neutral phrases with client summaries in dispute, goodwill, and custom letter prompts
- Add tests and adjust existing ones for updated state clause and disclosure wording

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893cf31f31c832e8f5e04f591062c42