### PR TITLE
Add comprehensive audit logging for client sessions

### DIFF
--- a/logic/generate_custom_letters.py
+++ b/logic/generate_custom_letters.py
@@ -79,6 +79,13 @@ Please draft a compliant letter body that blends the neutral legal phrase with t
                 "prompt": prompt,
             },
         )
+        audit.log_step(
+            "custom_letter_response",
+            {
+                "account_id": structured_summary.get("account_id"),
+                "response": body,
+            },
+        )
     return body
 
 
@@ -137,6 +144,17 @@ def generate_custom_letter(account: dict, client_info: dict, output_path: Path, 
     response_path = output_path / f"{safe_recipient}_custom_gpt_response.txt"
     with open(response_path, "w", encoding="utf-8") as f:
         f.write(body_paragraph)
+
+    audit = get_audit()
+    if audit:
+        audit.log_step(
+            "custom_letter_generated",
+            {
+                "account_id": account.get("account_id"),
+                "output_pdf": str(full_path),
+                "response": body_paragraph,
+            },
+        )
 
 
 def generate_custom_letters(

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -303,7 +303,13 @@ Return strictly valid JSON: all property names and strings in double quotes, no 
     print(content)
     print("----- END RESPONSE -----\n")
 
-    return parse_json(content)
+    result = parse_json(content)
+    if audit:
+        audit.log_step(
+            "goodwill_letter_response",
+            {"creditor": creditor, "response": result},
+        )
+    return result
 
 def load_creditor_address_map():
     try:
@@ -390,6 +396,13 @@ def generate_goodwill_letter_with_ai(creditor, accounts, client_info, output_pat
 
     with open(output_path / f"{safe_name}_gpt_response.json", 'w') as f:
         json.dump(gpt_data, f, indent=2)
+
+    audit = get_audit()
+    if audit:
+        audit.log_step(
+            "goodwill_letter_generated",
+            {"creditor": creditor, "output_pdf": str(full_path), "response": gpt_data},
+        )
 
 def generate_goodwill_letters(client_info, bureau_data, output_path: Path, run_date: str = None):
     seen_creditors = set()


### PR DESCRIPTION
## Summary
- log raw and structured client explanations at session start
- record strategy decisions and per-letter prompts, responses, and fallbacks

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f977c38c832ea708a2d217094757