### PR TITLE
Add detailed audit trace for client explanations

### DIFF
--- a/logic/generate_custom_letters.py
+++ b/logic/generate_custom_letters.py
@@ -33,7 +33,7 @@ def call_gpt_for_custom_letter(
 ) -> str:
     docs_line = f"Supporting documents summary:\n{docs_text}" if docs_text else ""
     classification = classify_client_summary(structured_summary, state)
-    neutral_phrase = get_neutral_phrase(
+    neutral_phrase, neutral_reason = get_neutral_phrase(
         classification.get("category"), structured_summary
     )
     prompt = f"""
@@ -58,6 +58,7 @@ Please draft a compliant letter body that blends the neutral legal phrase with t
                 "stage": "custom_letter",
                 "classification": classification,
                 "neutral_phrase": neutral_phrase,
+                "neutral_phrase_reason": neutral_reason,
                 "structured_summary": structured_summary,
             },
         )

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -228,7 +228,7 @@ def call_gpt_for_goodwill_letter(
             )
             if cls.get("state_hook"):
                 summary["state_hook"] = cls["state_hook"]
-            neutral = get_neutral_phrase(cls.get("category"), struct)
+            neutral, neutral_reason = get_neutral_phrase(cls.get("category"), struct)
             if neutral:
                 summary["neutral_phrase"] = neutral
             if audit:
@@ -238,6 +238,7 @@ def call_gpt_for_goodwill_letter(
                         "stage": "goodwill_letter",
                         "classification": cls,
                         "neutral_phrase": neutral,
+                        "neutral_phrase_reason": neutral_reason,
                         "structured_summary": struct,
                     },
                 )

--- a/logic/letter_generator.py
+++ b/logic/letter_generator.py
@@ -112,7 +112,7 @@ def call_gpt_dispute_letter(client_info, bureau_name, disputes, inquiries, is_id
     for acc in disputes:
         struct = structured_summaries.get(acc.get("account_id"), {})
         classification = classify_client_summary(struct, state)
-        neutral_phrase = get_neutral_phrase(
+        neutral_phrase, neutral_reason = get_neutral_phrase(
             classification.get("category"), struct
         )
         block = {
@@ -147,6 +147,7 @@ def call_gpt_dispute_letter(client_info, bureau_name, disputes, inquiries, is_id
                     "structured_summary": struct,
                     "classification": classification,
                     "neutral_phrase": neutral_phrase,
+                    "neutral_phrase_reason": neutral_reason,
                     "recommended_action": acc.get("recommended_action"),
                 },
             )

--- a/tests/test_rules_loader.py
+++ b/tests/test_rules_loader.py
@@ -20,10 +20,11 @@ def test_load_neutral_phrases():
 
 
 def test_get_neutral_phrase_matches_category():
-    phrase = rules_loader.get_neutral_phrase(
+    phrase, reason = rules_loader.get_neutral_phrase(
         "not_mine", {"facts_summary": "this account is not mine"}
     )
     assert phrase in rules_loader.load_neutral_phrases()["not_mine"]
+    assert reason["method"] in {"word_overlap", "default"}
 
 
 def test_load_state_rules():


### PR DESCRIPTION
## Summary
- log classification and structured explanations for each account at intake
- capture neutral phrase selections with reasoning across dispute, goodwill, and custom letter generation
- expose classification in strategy decisions and audit traces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894025857d0832eae53e10defb96d98