### PR TITLE
feat: add strategist failure reason enum

### DIFF
--- a/logic/constants.py
+++ b/logic/constants.py
@@ -51,6 +51,16 @@ class FallbackReason(str, Enum):
     NO_RECOMMENDATION = "no_recommendation"
 
 
+class StrategistFailureReason(str, Enum):
+    """Reasons why a strategist run failed."""
+
+    MISSING_INPUT = "missing_input"
+    SCHEMA_ERROR = "schema_error"
+    EMPTY_OUTPUT = "empty_output"
+    UNRECOGNIZED_FORMAT = "unrecognized_format"
+    PROMPT_MISMATCH = "prompt_mismatch"
+
+
 def normalize_action_tag(raw: str | None) -> tuple[str, str]:
     """Return (action_tag, recommended_action) for a strategist value.
 
@@ -65,3 +75,11 @@ def normalize_action_tag(raw: str | None) -> tuple[str, str]:
     if not tag:
         return "", str(raw).strip()
     return tag, _DISPLAY_NAME.get(tag, tag.title())
+
+
+__all__ = [
+    "VALID_ACTION_TAGS",
+    "FallbackReason",
+    "StrategistFailureReason",
+    "normalize_action_tag",
+]


### PR DESCRIPTION
## Summary
- add `StrategistFailureReason` enum for strategist failure cases
- export enum from constants module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ccbc4374832ebb84a1f58f084fd0