### PR TITLE
Return error reasons from parse_json

### DIFF
--- a/logic/analyze_report.py
+++ b/logic/analyze_report.py
@@ -195,7 +195,8 @@ Report text:
         f.write(inquiry_summary)
 
     try:
-        return parse_json(content)
+        data, _ = parse_json(content)
+        return data
     except Exception:
         print("\u26a0\ufe0f The AI returned invalid JSON. Here's the raw response:")
         print(content)

--- a/logic/explanations_normalizer.py
+++ b/logic/explanations_normalizer.py
@@ -96,7 +96,7 @@ def extract_structured(safe_text: str, account_ctx: Dict[str, Any]) -> Dict[str,
             },
         )
         content = response.output[0].content[0].text
-        data = parse_json(content)
+        data, _ = parse_json(content)
     except Exception:
         # Fallback to empty structure
         data = {}

--- a/logic/extract_info.py
+++ b/logic/extract_info.py
@@ -177,7 +177,7 @@ Here is the text:
                 temperature=0.1
             )
             content = response.choices[0].message.content.strip()
-            ai_data = parse_json(content)
+            ai_data, _ = parse_json(content)
             for b in bureaus:
                 data[b].update(ai_data)
         except Exception as e:

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -304,7 +304,7 @@ Return strictly valid JSON: all property names and strings in double quotes, no 
     print(content)
     print("----- END RESPONSE -----\n")
 
-    result = parse_json(content)
+    result, _ = parse_json(content)
     if audit:
         audit.log_step(
             "goodwill_letter_response",

--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -68,7 +68,7 @@ Ensure the response is strictly valid JSON: all property names and strings in do
             content = (
                 content.replace("```json", "").replace("```", "").strip()
             )
-        report = parse_json(content)
+        report, _ = parse_json(content)
         fix_draft_with_guardrails(
             json.dumps(report, indent=2),
             client_info.get("state"),

--- a/logic/json_utils.py
+++ b/logic/json_utils.py
@@ -52,17 +52,21 @@ def _repair_json(content: str) -> str:
 
 
 def parse_json(text: str):
-    """Parse ``text`` as JSON, attempting repairs on failure."""
+    """Parse ``text`` as JSON, attempting repairs on failure.
+
+    Returns a tuple of ``(data, error_reason)`` where ``error_reason`` is ``None``
+    on success or ``"invalid_json"`` when parsing fails even after repair.
+    """
     try:
-        return json.loads(text)
+        return json.loads(text), None
     except json.JSONDecodeError as e:
         logging.warning("Initial JSON parse error: %s", e)
         repaired = _repair_json(text)
         logging.debug("Raw JSON before repair: %s", text)
         logging.debug("Repaired JSON string: %s", repaired)
         try:
-            return json.loads(repaired)
+            return json.loads(repaired), None
         except json.JSONDecodeError as e2:
             logging.error("Repaired JSON parse error: %s", e2)
             _log_invalid_json(text, repaired, str(e2))
-            return {}
+            return {}, "invalid_json"

--- a/logic/letter_generator.py
+++ b/logic/letter_generator.py
@@ -241,7 +241,7 @@ Unauthorized Inquiries:
     print(content)
     print("----- END RESPONSE -----\n")
 
-    result = parse_json(content)
+    result, _ = parse_json(content)
     if audit:
         audit.log_step(
             "dispute_response",

--- a/logic/summary_classifier.py
+++ b/logic/summary_classifier.py
@@ -84,7 +84,8 @@ def classify_client_summary(summary: Dict[str, Any], state: str | None = None) -
                 response_format={"type": "json_object"},
             )
             content = resp.output[0].content[0].text
-            data = parse_json(content) or {}
+            data, _ = parse_json(content)
+            data = data or {}
             category = data.get("category")
         except Exception:
             category = None

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -5,20 +5,44 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from logic.json_utils import parse_json
 
+
 def test_parse_valid_json():
-    assert parse_json('{"a": 1}') == {"a": 1}
+    data, err = parse_json('{"a": 1}')
+    assert data == {"a": 1}
+    assert err is None
+
 
 def test_parse_trailing_comma():
-    assert parse_json('{"a": 1,}') == {"a": 1}
+    data, err = parse_json('{"a": 1,}')
+    assert data == {"a": 1}
+    assert err is None
+
 
 def test_parse_missing_comma():
-    assert parse_json('{"a": 1 "b": 2}') == {"a": 1, "b": 2}
+    data, err = parse_json('{"a": 1 "b": 2}')
+    assert data == {"a": 1, "b": 2}
+    assert err is None
+
 
 def test_parse_single_quotes():
-    assert parse_json("{'a': 'b'}") == {"a": "b"}
+    data, err = parse_json("{'a': 'b'}")
+    assert data == {"a": "b"}
+    assert err is None
+
 
 def test_parse_unquoted_keys():
-    assert parse_json('{advisor_comment: "text here"}') == {"advisor_comment": "text here"}
+    data, err = parse_json('{advisor_comment: "text here"}')
+    assert data == {"advisor_comment": "text here"}
+    assert err is None
+
 
 def test_parse_mismatched_braces():
-    assert parse_json('{"a": 1, "b": 2') == {"a": 1, "b": 2}
+    data, err = parse_json('{"a": 1, "b": 2')
+    assert data == {"a": 1, "b": 2}
+    assert err is None
+
+
+def test_parse_invalid_json():
+    data, err = parse_json('not json')
+    assert data == {}
+    assert err == "invalid_json"


### PR DESCRIPTION
## Summary
- Refactor `logic/json_utils.parse_json` to return `(data, error_reason)` instead of only the parsed data
- Update all call sites to unpack the tuple result from `parse_json`
- Extend tests to validate both successful parses and error handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ce647da0832e86c65cc35a7b35b7