### PR TITLE
Track strategist failure reasons in analytics

### DIFF
--- a/analytics/strategist_failures.py
+++ b/analytics/strategist_failures.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, Iterable
+
+
+def tally_failure_reasons(audit: Any) -> Dict[str, int]:
+    """Return counts of strategist failure reasons from an audit object.
+
+    The ``audit`` argument may be an :class:`AuditLogger` instance or a raw
+    ``dict`` representing the audit data. Only entries that contain a
+    ``failure_reason`` key are tallied.
+    """
+    if audit is None:
+        return {}
+
+    data = getattr(audit, "data", audit) or {}
+    accounts: Dict[str, Iterable[Dict[str, Any]]] = data.get("accounts", {})
+
+    counter: Counter[str] = Counter()
+    seen: set[tuple[str, str]] = set()
+    for account_id, entries in accounts.items():
+        for entry in entries:
+            reason = entry.get("failure_reason")
+            if reason and (account_id, reason) not in seen:
+                counter[reason] += 1
+                seen.add((account_id, reason))
+
+    return dict(counter)

--- a/analytics_tracker.py
+++ b/analytics_tracker.py
@@ -4,9 +4,17 @@ import logging
 import config
 from pathlib import Path
 from datetime import datetime
+from typing import Dict, Optional
 
-def save_analytics_snapshot(client_info: dict, report_summary: dict):
-    logging.getLogger(__name__).info("Analytics tracker using OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
+
+def save_analytics_snapshot(
+    client_info: dict,
+    report_summary: dict,
+    strategist_failures: Optional[Dict[str, int]] = None,
+) -> None:
+    logging.getLogger(__name__).info(
+        "Analytics tracker using OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL
+    )
     analytics_dir = Path("analytics_data")
     analytics_dir.mkdir(exist_ok=True)
 
@@ -29,10 +37,15 @@ def save_analytics_snapshot(client_info: dict, report_summary: dict):
             "total_inquiries": report_summary.get("total_inquiries", 0),
             "num_negative_accounts": report_summary.get("num_negative_accounts", 0),
             "num_accounts_over_90_util": report_summary.get("num_accounts_over_90_util", 0),
-            "account_types_in_problem": report_summary.get("account_types_in_problem", [])
+            "account_types_in_problem": report_summary.get("account_types_in_problem", []),
         },
-        "strategic_recommendations": report_summary.get("strategic_recommendations", [])
+        "strategic_recommendations": report_summary.get(
+            "strategic_recommendations", []
+        ),
     }
+
+    if strategist_failures:
+        snapshot["strategist_failures"] = strategist_failures
 
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(snapshot, f, indent=2)

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from logic.summary_classifier import classify_client_summary
 from logic.constants import StrategistFailureReason
 from email_sender import send_email_with_attachment
 from analytics_tracker import save_analytics_snapshot
+from analytics.strategist_failures import tally_failure_reasons
 from audit import start_audit, get_audit, clear_audit
 
 logger = logging.getLogger(__name__)
@@ -459,9 +460,14 @@ Best regards,
         audit.log_step("email_sent", {"files": output_files})
 
         from logic.utils import extract_summary_from_sections
-        save_analytics_snapshot(client_info, extract_summary_from_sections(sections))
+        failure_counts = tally_failure_reasons(audit)
+        save_analytics_snapshot(
+            client_info,
+            extract_summary_from_sections(sections),
+            strategist_failures=failure_counts,
+        )
         log_messages.append("📊 Analytics snapshot saved.")
-        audit.log_step("analytics_saved")
+        audit.log_step("analytics_saved", {"strategist_failures": failure_counts})
 
         print(f"\n🎯 Credit Repair Process completed successfully!")
         print(f"📂 All output saved to: {today_folder}")

--- a/tests/test_strategist_failure_tally.py
+++ b/tests/test_strategist_failure_tally.py
@@ -1,0 +1,44 @@
+import sys
+import types
+
+sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
+
+import main
+from audit import start_audit, clear_audit
+from analytics.strategist_failures import tally_failure_reasons
+from logic.constants import StrategistFailureReason
+
+
+def test_tally_failure_reasons():
+    audit = start_audit()
+
+    strategy = {
+        "accounts": [
+            {"name": "Bad Corp", "account_number": "1111", "recommended_action": "foobar"},
+            {"name": "Empty Action", "account_number": "3333"},
+        ]
+    }
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {"name": "Bad Corp", "account_number": "1111", "status": "collection"},
+                {"name": "No Strat", "account_number": "2222", "status": "chargeoff"},
+                {"name": "Empty Action", "account_number": "3333", "status": "repossession"},
+            ],
+            "goodwill": [],
+            "high_utilization": [],
+        }
+    }
+
+    main.merge_strategy_data(strategy, bureau_data, {}, audit, [])
+
+    counts = tally_failure_reasons(audit)
+
+    expected = {
+        StrategistFailureReason.UNRECOGNIZED_FORMAT.value: 1,
+        StrategistFailureReason.MISSING_INPUT.value: 1,
+        StrategistFailureReason.EMPTY_OUTPUT.value: 1,
+    }
+
+    assert counts == expected
+    clear_audit()


### PR DESCRIPTION
## Summary
- tally strategist failure reasons from audit logs
- include failure counts in analytics snapshot and process analytics
- test failure tally helper

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6894d77edc38832e8ee0657920422ebc