### PR TITLE
Add audit logging levels to control verbosity

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1,15 +1,33 @@
 from __future__ import annotations
 import json
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 _current_audit: Optional["AuditLogger"] = None
+
+
+class AuditLevel(Enum):
+    ESSENTIAL = 1
+    VERBOSE = 2
 
 class AuditLogger:
     """Collects structured audit information for a credit repair run."""
 
-    def __init__(self) -> None:
+    ESSENTIAL_STEPS = {
+        "strategist_invocation",
+        "strategist_raw_output",
+        "strategist_failure",
+        "strategy_generated",
+        "strategy_merged",
+        "strategy_decision",
+        "pre_strategy_fallback",
+        "strategy_fallback",
+    }
+
+    def __init__(self, level: AuditLevel = AuditLevel.ESSENTIAL) -> None:
+        self.level = level
         self.data: Dict[str, Any] = {
             "start_time": datetime.utcnow().isoformat(),
             "steps": [],
@@ -18,6 +36,8 @@ class AuditLogger:
         }
 
     def log_step(self, stage: str, details: Optional[Dict[str, Any]] = None) -> None:
+        if self.level == AuditLevel.ESSENTIAL and stage not in self.ESSENTIAL_STEPS:
+            return
         self.data["steps"].append(
             {
                 "stage": stage,
@@ -27,6 +47,8 @@ class AuditLogger:
         )
 
     def log_account(self, account_id: Any, info: Dict[str, Any]) -> None:
+        if self.level == AuditLevel.ESSENTIAL and info.get("stage") not in self.ESSENTIAL_STEPS:
+            return
         acc = self.data["accounts"].setdefault(str(account_id), [])
         entry = {"timestamp": datetime.utcnow().isoformat()}
         entry.update(info)
@@ -45,9 +67,9 @@ class AuditLogger:
         return path
 
 
-def start_audit() -> AuditLogger:
+def start_audit(level: AuditLevel = AuditLevel.ESSENTIAL) -> AuditLogger:
     global _current_audit
-    _current_audit = AuditLogger()
+    _current_audit = AuditLogger(level=level)
     return _current_audit
 
 


### PR DESCRIPTION
## Summary
- Introduce `AuditLevel` enum with `ESSENTIAL` and `VERBOSE`
- Add `ESSENTIAL_STEPS` filtering to `AuditLogger` and allow specifying log level
- Update `start_audit` to instantiate `AuditLogger` with a configurable level (default `ESSENTIAL`)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894dcb26910832e8a587255149acc30