### PR TITLE
Consolidate strategist audit logging

### DIFF
--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -40,16 +40,6 @@ class StrategyGenerator:
             else ""
         )
 
-        if audit:
-            audit.log_step(
-                "strategist_input",
-                {
-                    "bureau_data": bureau_data,
-                    "classification_map": classification_map or {},
-                    "supporting_docs_text": supporting_docs_text,
-                },
-            )
-
         prompt = f"""
 You are a credit repair strategist. Analyze the client's credit report data and propose a concise plan of action.
 Client name: {client_name}

--- a/main.py
+++ b/main.py
@@ -312,8 +312,8 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
             {
                 "client_info": client_info,
                 "bureau_data": bureau_data,
+                "classification_map": classification_map or {},
                 "supporting_docs_text": docs_text,
-                "classification_map": classification_map,
             },
         )
         strategy = strat_gen.generate(


### PR DESCRIPTION
## Summary
- Remove now redundant `strategist_input` audit step from strategy generation
- Log strategist invocation details (client info, bureau data, classification map, supporting docs) in one place

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894de0d95fc832e9048c72d335d1f28