### PR TITLE
Ensure audit logging for strategist responses

### DIFF
--- a/dev_scripts/run_strategy_local.py
+++ b/dev_scripts/run_strategy_local.py
@@ -88,7 +88,7 @@ def test_full_letter_workflow():
         from logic.constants import normalize_action_tag
 
         generator = StrategyGenerator()
-        strategy = generator.generate(client_info, bureau_data)
+        strategy = generator.generate(client_info, bureau_data, audit=None)
         index = {(acc["name"].lower(), acc["account_number"]): acc for acc in strategy["accounts"]}
         for payload in bureau_data.values():
             for section, items in payload.items():

--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -77,15 +77,16 @@ Ensure the response is strictly valid JSON: all property names and strings in do
             content = content.replace("```json", "").replace("```", "").strip()
         report, error_reason = parse_json(content)
         expected_keys = {"overview", "accounts", "global_recommendations"}
-        if audit and (
-            error_reason is not None
-            or not isinstance(report, dict)
-            or not expected_keys.issubset(report)
-        ):
-            audit.log_step(
-                "strategist_failure",
-                {"failure_reason": StrategistFailureReason.SCHEMA_ERROR},
-            )
+        if audit:
+            if (
+                error_reason is not None
+                or not isinstance(report, dict)
+                or not expected_keys.issubset(report)
+            ):
+                audit.log_step(
+                    "strategist_failure",
+                    {"failure_reason": StrategistFailureReason.SCHEMA_ERROR},
+                )
         fix_draft_with_guardrails(
             json.dumps(report, indent=2),
             client_info.get("state"),

--- a/tests/test_strategy_generator_audit.py
+++ b/tests/test_strategy_generator_audit.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from audit import start_audit, clear_audit
+from logic.generate_strategy_report import StrategyGenerator
+
+
+def test_malformed_json_triggers_audit(monkeypatch, tmp_path):
+    audit = start_audit()
+    monkeypatch.setattr(
+        "logic.generate_strategy_report.fix_draft_with_guardrails",
+        lambda *a, **k: None,
+    )
+
+    class DummyResponse:
+        class Choice:
+            class Message:
+                content = "{bad json"
+            message = Message()
+        choices = [Choice()]
+
+    monkeypatch.setattr(
+        "logic.generate_strategy_report.client.chat.completions.create",
+        lambda *a, **k: DummyResponse(),
+    )
+
+    gen = StrategyGenerator()
+    gen.generate({}, {}, audit=audit)
+    audit_file = audit.save(tmp_path)
+    data = json.loads(audit_file.read_text())
+    stages = [s["stage"] for s in data["steps"]]
+    assert "strategist_raw_output" in stages
+    assert "strategist_failure" in stages
+    clear_audit()


### PR DESCRIPTION
## Summary
- pass `audit` argument to all `StrategyGenerator.generate` calls
- always log `strategist_raw_output` and `strategist_failure` when an audit is supplied
- test that malformed strategist JSON records both audit steps

## Testing
- `pytest tests/test_strategy_generator_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e8ccc340832eb7a6410e3bb5e691