### PR TITLE
Log strategy decision for all accounts

### DIFF
--- a/tests/test_strategist_failure_tally.py
+++ b/tests/test_strategist_failure_tally.py
@@ -34,6 +34,10 @@ def test_tally_failure_reasons():
 
     counts = tally_failure_reasons(audit)
 
+    accounts = audit.data["accounts"]
+    assert any(e["stage"] == "strategy_decision" for e in accounts["No Strat"])
+    assert any(e["stage"] == "strategy_decision" for e in accounts["Empty Action"])
+
     expected = {
         StrategistFailureReason.UNRECOGNIZED_FORMAT.value: 1,
         StrategistFailureReason.MISSING_INPUT.value: 1,


### PR DESCRIPTION
## Summary
- Always audit strategy decisions for every account, recording `None` when no action tag exists
- Test tallying ensures accounts without strategist recommendations log a `strategy_decision`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eaa2a07c832e91178bf27c0ec5f6