### PR TITLE
Log raw action for strategy fallbacks and add audit tally helper

### DIFF
--- a/analytics/strategist_failures.py
+++ b/analytics/strategist_failures.py
@@ -27,3 +27,39 @@ def tally_failure_reasons(audit: Any) -> Dict[str, int]:
                 seen.add((account_id, reason))
 
     return dict(counter)
+
+
+def tally_fallback_vs_decision(audit: Any) -> Dict[str, int]:
+    """Count accounts that used strategy fallback versus direct decisions.
+
+    Returns a dictionary with two keys:
+
+    - ``strategy_fallback`` – number of accounts that include a
+      ``strategy_fallback`` entry.
+    - ``strategy_decision_only`` – number of accounts that have a
+      ``strategy_decision`` entry but no ``strategy_fallback`` entry.
+
+    The ``audit`` argument may be an :class:`AuditLogger` instance or a raw
+    ``dict`` representing the audit data.
+    """
+
+    if audit is None:
+        return {}
+
+    data = getattr(audit, "data", audit) or {}
+    accounts: Dict[str, Iterable[Dict[str, Any]]] = data.get("accounts", {})
+
+    counts = {"strategy_fallback": 0, "strategy_decision_only": 0}
+
+    for entries in accounts.values():
+        stages = {e.get("stage") for e in entries}
+        if "strategy_fallback" in stages:
+            counts["strategy_fallback"] += 1
+        elif "strategy_decision" in stages:
+            counts["strategy_decision_only"] += 1
+
+    return counts
+
+
+__all__ = ["tally_failure_reasons", "tally_fallback_vs_decision"]
+

--- a/main.py
+++ b/main.py
@@ -189,6 +189,11 @@ def merge_strategy_data(strategy_obj: dict, bureau_data_obj: dict, classificatio
                                 "stage": "strategy_fallback",
                                 "fallback_reason": fallback_reason.value,
                                 "strategist_action": strategist_action,
+                                **(
+                                    {"raw_action": strategist_action}
+                                    if acc.get("fallback_unrecognized_action") and strategist_action
+                                    else {}
+                                ),
                                 "overrode_strategist": overrode_strategist,
                                 **(
                                     {"failure_reason": failure_reason.value}

--- a/tests/test_audit_fallback_reasons.py
+++ b/tests/test_audit_fallback_reasons.py
@@ -68,6 +68,10 @@ def test_merge_strategy_data_audit_reasons(tmp_path):
         for e in bad_logs
         if e.get("stage") == "strategy_fallback"
     )
+    fail_entry = next(e for e in bad_logs if e.get("stage") == "strategist_failure")
+    fallback_entry = next(e for e in bad_logs if e.get("stage") == "strategy_fallback")
+    assert fail_entry.get("raw_action") == "foobar"
+    assert fallback_entry.get("raw_action") == "foobar"
 
     # No Strat: strategist missing entry
     assert any(e.get("fallback_reason") == FallbackReason.NO_RECOMMENDATION.value for e in no_logs)

--- a/tests/test_audit_fallback_tally.py
+++ b/tests/test_audit_fallback_tally.py
@@ -1,0 +1,40 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from audit import start_audit, clear_audit
+from analytics.strategist_failures import tally_fallback_vs_decision
+
+
+def test_tally_fallback_vs_decision(tmp_path):
+    import types
+    sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
+    import main
+
+    audit = start_audit()
+    strategy = {
+        "accounts": [
+            {"name": "Bad Corp", "account_number": "1111", "recommended_action": "foobar"},
+            {"name": "Good Tag", "account_number": "3333", "recommended_action": "dispute"},
+        ]
+    }
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {"name": "Bad Corp", "account_number": "1111", "status": "collection"},
+                {"name": "No Strat", "account_number": "2222", "status": "chargeoff"},
+                {"name": "Good Tag", "account_number": "3333", "status": "open"},
+            ],
+            "goodwill": [],
+            "high_utilization": [],
+        }
+    }
+    classification_map = {}
+    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
+
+    counts = tally_fallback_vs_decision(audit)
+    assert counts["strategy_fallback"] == 2
+    assert counts["strategy_decision_only"] == 1
+    clear_audit()


### PR DESCRIPTION
## Summary
- Track original strategist action in `strategy_fallback` audit entries and reference it when fallback handles unrecognized formats
- Provide `tally_fallback_vs_decision` helper for analyzing how many accounts needed fallback vs direct decisions
- Extend audit tests for raw action logging and new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eea83040832e96cc00216ac846b7