### PR TITLE
Improve strategist vs fallback audit logging

### DIFF
--- a/tests/test_strategy_decision_logging.py
+++ b/tests/test_strategy_decision_logging.py
@@ -1,0 +1,54 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from audit import start_audit, clear_audit
+
+
+def test_strategy_decision_logged_for_all_accounts(tmp_path):
+    import types
+    sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
+    import main
+
+    audit = start_audit()
+    strategy = {
+        "accounts": [
+            {"name": "Bad Corp", "account_number": "1111", "recommended_action": "foobar"},
+            {"name": "Good Tag", "account_number": "3333", "recommended_action": "dispute"},
+        ]
+    }
+    bureau_data = {
+        "Experian": {
+            "disputes": [
+                {"name": "Bad Corp", "account_number": "1111", "status": "collection"},
+                {"name": "No Strat", "account_number": "2222", "status": "chargeoff"},
+                {"name": "Good Tag", "account_number": "3333", "status": "open"},
+                {"name": "No Action", "account_number": "4444", "status": "open"},
+            ],
+            "goodwill": [],
+            "high_utilization": [],
+        }
+    }
+    classification_map = {}
+    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
+    audit_file = audit.save(tmp_path)
+    data = json.loads(audit_file.read_text())
+
+    def find_stage(name, stage):
+        return next(e for e in data["accounts"][name] if e.get("stage") == stage)
+
+    assert find_stage("Good Tag", "strategy_decision").get("action") == "dispute"
+    assert find_stage("Bad Corp", "strategy_decision").get("action") == "dispute"
+    assert find_stage("No Strat", "strategy_decision").get("action") == "dispute"
+    assert find_stage("No Action", "strategy_decision").get("action") is None
+
+    bad_fallback = find_stage("Bad Corp", "strategy_fallback")
+    assert bad_fallback.get("strategist_action") == "foobar"
+    assert bad_fallback.get("overrode_strategist") is True
+
+    no_action_fallback = find_stage("No Action", "strategy_fallback")
+    assert no_action_fallback.get("strategist_action") is None
+    assert no_action_fallback.get("overrode_strategist") is False
+    clear_audit()

--- a/tests/test_strategy_fallback_logging.py
+++ b/tests/test_strategy_fallback_logging.py
@@ -39,6 +39,8 @@ def test_strategy_fallback_logs_include_reason_and_override(tmp_path):
 
     assert bad_entry.get("fallback_reason") == FallbackReason.UNRECOGNIZED_TAG.value
     assert bad_entry.get("overrode_strategist") is True
+    assert bad_entry.get("strategist_action") == "foobar"
     assert no_entry.get("fallback_reason") == FallbackReason.NO_RECOMMENDATION.value
     assert no_entry.get("overrode_strategist") is False
+    assert "strategist_action" in no_entry and no_entry.get("strategist_action") is None
     clear_audit()

--- a/tests/test_strategy_generator_audit.py
+++ b/tests/test_strategy_generator_audit.py
@@ -6,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from audit import start_audit, clear_audit
 from logic.generate_strategy_report import StrategyGenerator
+from logic.constants import StrategistFailureReason
 
 
 def test_malformed_json_triggers_audit(monkeypatch, tmp_path):
@@ -33,5 +34,6 @@ def test_malformed_json_triggers_audit(monkeypatch, tmp_path):
     data = json.loads(audit_file.read_text())
     stages = [s["stage"] for s in data["steps"]]
     assert "strategist_raw_output" in stages
-    assert "strategist_failure" in stages
+    fail_entry = next(s for s in data["steps"] if s["stage"] == "strategist_failure")
+    assert fail_entry["details"].get("failure_reason") == StrategistFailureReason.UNRECOGNIZED_FORMAT.value
     clear_audit()


### PR DESCRIPTION
## Summary
- Record raw LLM strategist output before parsing and log explicit failure reasons for empty, malformed, or schema-invalid responses
- Expand audit logs and tests to capture strategist action overrides and per-account strategy decisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f62a0340832e8bb82837a4fbbfdc