### PR TITLE
Add trace export for strategist diagnostics

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 RULEBOOK_FALLBACK_ENABLED = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
+EXPORT_TRACE_FILE = os.getenv("EXPORT_TRACE_FILE", "1") != "0"
 
 # Ensure the fallback is visible to later getenv calls
 os.environ.setdefault("OPENAI_BASE_URL", OPENAI_BASE_URL)
@@ -21,6 +22,7 @@ _logger.setLevel(logging.INFO)
 _logger.info("OPENAI_BASE_URL=%s", OPENAI_BASE_URL)
 _logger.info("OPENAI_API_KEY present=%s", bool(OPENAI_API_KEY))
 _logger.info("RULEBOOK_FALLBACK_ENABLED=%s", RULEBOOK_FALLBACK_ENABLED)
+_logger.info("EXPORT_TRACE_FILE=%s", EXPORT_TRACE_FILE)
 
 if not OPENAI_API_KEY:
     raise EnvironmentError("OPENAI_API_KEY is not set")

--- a/main.py
+++ b/main.py
@@ -210,6 +210,8 @@ def merge_strategy_data(strategy_obj: dict, bureau_data_obj: dict, classificatio
                         {
                             "stage": "strategy_decision",
                             "action": acc.get("action_tag") or None,
+                            "recommended_action": acc.get("recommended_action"),
+                            "flags": acc.get("flags"),
                             "reason": acc.get("advisor_comment")
                             or acc.get("analysis")
                             or raw_action,
@@ -224,6 +226,7 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
     today_folder = None
     pdf_path = None
     audit = start_audit()
+    session_id = client_info.get("session_id", "session")
 
     try:
         print("\n✅ Starting Credit Repair Process (B2C Mode)...")
@@ -236,7 +239,6 @@ def run_credit_repair_process(client_info, proofs_files, is_identity_theft):
         if "email" not in client_info or not client_info["email"]:
             raise ValueError("Client email is missing.")
 
-        session_id = client_info.get("session_id", "session")
         audit.log_step("session_initialized", {"session_id": session_id})
 
         # Record raw and structured client explanations for traceability
@@ -530,6 +532,9 @@ Best regards,
         save_log_file(client_info, is_identity_theft, today_folder, log_messages)
         if today_folder:
             audit.save(today_folder)
+            if config.EXPORT_TRACE_FILE:
+                from trace_exporter import export_trace_file
+                export_trace_file(audit, session_id)
         clear_audit()
         if pdf_path and os.path.exists(pdf_path):
             try:

--- a/trace_exporter.py
+++ b/trace_exporter.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def export_trace_file(audit: Any, session_id: str) -> Path:
+    """Export strategist and fallback diagnostics to trace.json.
+
+    Parameters
+    ----------
+    audit: AuditLogger or dict
+        The audit object or its underlying data structure.
+    session_id: str
+        Current client session identifier.
+    """
+    data: Dict[str, Any] = audit.data if hasattr(audit, "data") else audit
+
+    steps = data.get("steps", [])
+    accounts = data.get("accounts", {})
+
+    strategist_raw_output = ""
+    for step in steps:
+        if step.get("stage") == "strategist_raw_output":
+            strategist_raw_output = step.get("details", {}).get("content", "")
+            break
+
+    strategist_failure_reasons = [
+        step.get("details", {}).get("failure_reason")
+        for step in steps
+        if step.get("stage") == "strategist_failure"
+    ]
+
+    strategy_decision_log = []
+    fallback_actions = []
+    per_account_failures = []
+    recommendation_summary = []
+
+    for acc_id, entries in accounts.items():
+        for entry in entries:
+            stage = entry.get("stage")
+            if stage == "strategy_decision":
+                decision = {"account_id": acc_id}
+                for key in [
+                    "action",
+                    "recommended_action",
+                    "flags",
+                    "reason",
+                    "classification",
+                ]:
+                    if entry.get(key) is not None:
+                        decision[key] = entry.get(key)
+                strategy_decision_log.append(decision)
+                recommendation_summary.append(
+                    {
+                        "account_id": acc_id,
+                        "action": entry.get("action"),
+                        "recommended_action": entry.get("recommended_action"),
+                    }
+                )
+            elif stage == "strategy_fallback":
+                fb = {"account_id": acc_id}
+                for key in [
+                    "fallback_reason",
+                    "strategist_action",
+                    "overrode_strategist",
+                    "failure_reason",
+                    "raw_action",
+                ]:
+                    if entry.get(key) is not None:
+                        fb[key] = entry.get(key)
+                fallback_actions.append(fb)
+                fail_info = {
+                    k: entry.get(k)
+                    for k in ("failure_reason", "fallback_reason")
+                    if entry.get(k) is not None
+                }
+                if fail_info:
+                    per_account_failures.append({"account_id": acc_id, **fail_info})
+
+    trace: Dict[str, Any] = {
+        "strategist_raw_output": strategist_raw_output,
+        "strategist_failure_reasons": strategist_failure_reasons,
+        "strategy_decision_log": strategy_decision_log,
+        "fallback_actions": fallback_actions,
+        "per_account_failures": per_account_failures,
+        "recommendation_summary": recommendation_summary,
+    }
+
+    trace_folder = Path("client_output") / session_id / "trace"
+    trace_folder.mkdir(parents=True, exist_ok=True)
+    trace_path = trace_folder / "trace.json"
+    with trace_path.open("w", encoding="utf-8") as f:
+        json.dump(trace, f, indent=2)
+    return trace_path
+
+__all__ = ["export_trace_file"]


### PR DESCRIPTION
## Summary
- add `EXPORT_TRACE_FILE` config flag to control trace export
- log action recommendations and flags for each account
- export strategist and fallback diagnostics to `client_output/<session_id>/trace/trace.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895015ac290832e92957ff3ea8897e0