### PR TITLE
Refactor strategy merging and fallback handling

### DIFF
--- a/logic/strategy_merger.py
+++ b/logic/strategy_merger.py
@@ -1,0 +1,213 @@
+"""Helpers for merging strategist outputs with bureau data."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from logic.constants import (
+    FallbackReason,
+    StrategistFailureReason,
+    normalize_action_tag,
+)
+from logic.fallback_manager import determine_fallback_action
+from logic.utils import normalize_creditor_name
+
+
+def merge_strategy_outputs(strategy_obj: dict, bureau_data_obj: dict) -> None:
+    """Align strategist ``strategy_obj`` with ``bureau_data_obj``.
+
+    Adds strategist recommendations and related metadata onto matching
+    accounts in ``bureau_data_obj``. No logging or fallback handling is
+    performed here.
+    """
+
+    def norm_key(name: str, number: str) -> tuple[str, str]:
+        norm_name = normalize_creditor_name(name)
+        digits = re.sub(r"\D", "", number or "")
+        last4 = digits[-4:] if digits else ""
+        return norm_name, last4
+
+    index = {}
+    for item in strategy_obj.get("accounts", []):
+        key = norm_key(item.get("name", ""), item.get("account_number", ""))
+        index[key] = item
+
+    for payload in bureau_data_obj.values():
+        for items in payload.values():
+            if not isinstance(items, list):
+                continue
+            for acc in items:
+                key = norm_key(acc.get("name", ""), acc.get("account_number", ""))
+                src = index.get(key)
+                raw_action: Optional[str] = None
+                if src is None:
+                    acc["strategist_failure_reason"] = StrategistFailureReason.MISSING_INPUT
+                    continue
+
+                raw_action = src.get("recommended_action") or src.get("recommendation")
+                tag, action = normalize_action_tag(raw_action)
+                if raw_action is None:
+                    acc["strategist_failure_reason"] = StrategistFailureReason.EMPTY_OUTPUT
+                elif raw_action and not tag:
+                    acc["strategist_failure_reason"] = (
+                        StrategistFailureReason.UNRECOGNIZED_FORMAT
+                    )
+                    acc["fallback_unrecognized_action"] = True
+                if tag:
+                    acc["action_tag"] = tag
+                    acc["recommended_action"] = action
+                elif raw_action:
+                    acc["recommended_action"] = raw_action
+
+                acc["strategist_raw_action"] = raw_action
+                if "advisor_comment" in src:
+                    acc["advisor_comment"] = src["advisor_comment"]
+                elif "analysis" in src:
+                    acc["advisor_comment"] = src["analysis"]
+                if src.get("flags"):
+                    acc["flags"] = src["flags"]
+
+
+def handle_strategy_fallbacks(
+    bureau_data_obj: dict,
+    classification_map: dict,
+    audit=None,
+    log_list: list | None = None,
+) -> None:
+    """Apply fallback logic and log strategy decisions."""
+
+    for bureau, payload in bureau_data_obj.items():
+        for section, items in payload.items():
+            if not isinstance(items, list):
+                continue
+            for acc in items:
+                raw_action = acc.get("strategist_raw_action")
+                tag = acc.get("action_tag")
+                failure_reason = acc.get("strategist_failure_reason")
+                acc_id = acc.get("account_id") or acc.get("name")
+
+                if failure_reason and audit:
+                    audit.log_account(
+                        acc_id,
+                        {
+                            "stage": "strategist_failure",
+                            "failure_reason": failure_reason.value,
+                            **(
+                                {"raw_action": raw_action}
+                                if (
+                                    failure_reason
+                                    == StrategistFailureReason.UNRECOGNIZED_FORMAT
+                                    and raw_action
+                                )
+                                else {}
+                            ),
+                        },
+                    )
+                if failure_reason == StrategistFailureReason.MISSING_INPUT and log_list is not None:
+                    log_list.append(
+                        f"[{bureau}] No strategist entry for '{acc.get('name')}' ({acc.get('account_number')})"
+                    )
+                if (
+                    failure_reason == StrategistFailureReason.UNRECOGNIZED_FORMAT
+                    and raw_action
+                ):
+                    print(
+                        f"[⚠️] Unrecognised strategist action '{raw_action}' for {acc.get('name')}"
+                    )
+
+                if not tag:
+                    strategist_action = raw_action if raw_action else None
+                    if raw_action is None:
+                        fallback_reason = FallbackReason.NO_RECOMMENDATION
+                    else:
+                        raw_key = str(raw_action).strip().lower().replace(" ", "_")
+                        fallback_reason = (
+                            FallbackReason.KEYWORD_MATCH
+                            if raw_key == FallbackReason.KEYWORD_MATCH.value
+                            else FallbackReason.UNRECOGNIZED_TAG
+                        )
+
+                    fallback_action = determine_fallback_action(acc)
+                    keywords_trigger = fallback_action == "dispute"
+
+                    if keywords_trigger:
+                        acc["action_tag"] = "dispute"
+                        if raw_action:
+                            acc["recommended_action"] = "Dispute"
+                        else:
+                            acc.setdefault("recommended_action", "Dispute")
+
+                        if log_list is not None and (raw_action is None or not tag):
+                            if raw_action:
+                                log_list.append(
+                                    f"[{bureau}] Fallback dispute overriding '{raw_action}' for '{acc.get('name')}' ({acc.get('account_number')})"
+                                )
+                            else:
+                                log_list.append(
+                                    f"[{bureau}] Fallback dispute (no recommendation) for '{acc.get('name')}' ({acc.get('account_number')})"
+                                )
+                    else:
+                        if log_list is not None and (raw_action is None or not tag):
+                            log_list.append(
+                                f"[{bureau}] Evaluated fallback for '{acc.get('name')}' ({acc.get('account_number')})"
+                            )
+
+                    overrode_strategist = bool(raw_action) and bool(keywords_trigger)
+
+                    if audit:
+                        audit.log_account(
+                            acc_id,
+                            {
+                                "stage": "strategy_fallback",
+                                "fallback_reason": fallback_reason.value,
+                                "strategist_action": strategist_action,
+                                **(
+                                    {"raw_action": strategist_action}
+                                    if acc.get("fallback_unrecognized_action")
+                                    and strategist_action
+                                    else {}
+                                ),
+                                "overrode_strategist": overrode_strategist,
+                                **(
+                                    {"failure_reason": failure_reason.value}
+                                    if failure_reason
+                                    else {}
+                                ),
+                            },
+                        )
+                if audit:
+                    cls = classification_map.get(str(acc.get("account_id")))
+                    audit.log_account(
+                        acc_id,
+                        {
+                            "stage": "strategy_decision",
+                            "action": acc.get("action_tag") or None,
+                            "recommended_action": acc.get("recommended_action"),
+                            "flags": acc.get("flags"),
+                            "reason": acc.get("advisor_comment")
+                            or acc.get("analysis")
+                            or raw_action,
+                            "classification": cls,
+                        },
+                    )
+
+
+def merge_strategy_data(
+    strategy_obj: dict,
+    bureau_data_obj: dict,
+    classification_map: dict,
+    audit=None,
+    log_list: list | None = None,
+) -> None:
+    """Wrapper combining merge and fallback handling."""
+
+    merge_strategy_outputs(strategy_obj, bureau_data_obj)
+    handle_strategy_fallbacks(bureau_data_obj, classification_map, audit, log_list)
+
+
+__all__ = [
+    "merge_strategy_outputs",
+    "handle_strategy_fallbacks",
+    "merge_strategy_data",
+]


### PR DESCRIPTION
## Summary
- Split strategist merge logic into `merge_strategy_outputs` and `handle_strategy_fallbacks`
- Add `logic/strategy_merger` module with helper functions and wrapper
- Simplify `main.py` to use the refactored merger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895203a95a8832e9e7958fdf5253583