### PR TITLE
test: enforce warning-free suite

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -29,7 +29,7 @@ class AuditLogger:
     def __init__(self, level: AuditLevel = AuditLevel.ESSENTIAL) -> None:
         self.level = level
         self.data: Dict[str, Any] = {
-            "start_time": datetime.utcnow().isoformat(),
+            "start_time": datetime.now(UTC).isoformat(),
             "steps": [],
             "accounts": {},
             "errors": [],
@@ -41,7 +41,7 @@ class AuditLogger:
         self.data["steps"].append(
             {
                 "stage": stage,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "details": details or {},
             }
         )
@@ -50,13 +50,13 @@ class AuditLogger:
         if self.level == AuditLevel.ESSENTIAL and info.get("stage") not in self.ESSENTIAL_STEPS:
             return
         acc = self.data["accounts"].setdefault(str(account_id), [])
-        entry = {"timestamp": datetime.utcnow().isoformat()}
+        entry = {"timestamp": datetime.now(UTC).isoformat()}
         entry.update(info)
         acc.append(entry)
 
     def log_error(self, message: str) -> None:
         self.data["errors"].append(
-            {"timestamp": datetime.utcnow().isoformat(), "message": message}
+            {"timestamp": datetime.now(UTC).isoformat(), "message": message}
         )
 
     def save(self, folder: Path) -> Path:

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -1,0 +1,5 @@
+## Dev Notes
+
+- Added strict warning policy (`-W error`) to pytest and resolved all existing warnings.
+- Replaced deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(UTC)`.
+- Adjusted tests to avoid or capture sanitization warnings and ensured files are closed.

--- a/logic/outcomes_store.py
+++ b/logic/outcomes_store.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Dict, List, Optional
 
 OUTCOMES_FILE = os.path.join("data", "outcomes.json")
@@ -40,7 +40,7 @@ def record_outcome(
 ) -> None:
     """Append an outcome record with timestamp to persistent storage."""
     record = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "session_id": session_id,
         "account_id": account_id,
         "bureau": bureau,

--- a/logic/strategy_engine.py
+++ b/logic/strategy_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any, Dict, List
 
 from session_manager import get_session, update_session
@@ -83,7 +83,7 @@ def generate_strategy(session_id: str, bureau_data: Dict[str, Any]) -> Dict[str,
     items = _build_dispute_items(structured, bureau_data)
 
     strategy: Dict[str, Any] = {
-        "generated_at": datetime.utcnow().isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
         "rules": load_rules(),
         "dispute_items": structured,
         "bureau_data": bureau_data,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -W error
+

--- a/scripts/export_outcomes.py
+++ b/scripts/export_outcomes.py
@@ -1,6 +1,6 @@
 import csv
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 import sys
 
@@ -14,7 +14,7 @@ EXPORT_DIR = Path("exports")
 
 def export_outcomes() -> None:
     """Export outcomes from the last 7 days to JSON and CSV files."""
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     start = now - timedelta(days=7)
     all_outcomes = get_outcomes()
     recent = []

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -56,12 +56,13 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     bureau_data = {
         "Experian": {
             "disputes": [
-                {"name": "Bank A", "account_number": "1", "action_tag": "dispute"}
+                {"name": "Bank A", "account_number": "1", "account_id": "1", "action_tag": "dispute"}
             ],
             "inquiries": [],
         }
     }
 
     generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
-    data = json.load(open(tmp_path / "Experian_gpt_response.json"))
+    with open(tmp_path / "Experian_gpt_response.json") as f:
+        data = json.load(f)
     assert "SECRET RAW" not in json.dumps(data)

--- a/tests/test_outcomes_store.py
+++ b/tests/test_outcomes_store.py
@@ -1,6 +1,6 @@
 import csv
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 import sys
 
@@ -34,14 +34,14 @@ def test_export_last_week(tmp_path, monkeypatch):
     outcomes_store.record_outcome("sess2", "acc2", "Experian", 1, "verified")
 
     data = outcomes_store.get_outcomes()
-    data[0]["timestamp"] = (datetime.utcnow() - timedelta(days=8)).isoformat()
+    data[0]["timestamp"] = (datetime.now(UTC) - timedelta(days=8)).isoformat()
     file_path.write_text(json.dumps(data))
 
     export_dir = tmp_path / "exports"
     monkeypatch.setattr(export_outcomes, "EXPORT_DIR", export_dir)
     export_outcomes.export_outcomes()
 
-    date_str = datetime.utcnow().strftime("%Y-%m-%d")
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
     json_path = export_dir / f"outcomes_{date_str}.json"
     csv_path = export_dir / f"outcomes_{date_str}.csv"
     assert json_path.exists()

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pdfkit
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -66,14 +67,16 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     bureau_data = {
         "Experian": {
             "disputes": [
-                {"name": "Bank A", "account_number": "1", "action_tag": "dispute"}
+                {"name": "Bank A", "account_number": "1", "account_id": "1", "action_tag": "dispute"}
             ],
             "inquiries": [],
         }
     }
 
-    generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
-    data = json.load(open(tmp_path / "Experian_gpt_response.json"))
+    with pytest.warns(UserWarning):
+        generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+    with open(tmp_path / "Experian_gpt_response.json") as f:
+        data = json.load(f)
     dump = json.dumps(data)
     assert "furious" not in dump
     assert "heartbroken" not in dump
@@ -127,7 +130,8 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
     ]
 
     generate_goodwill_letter_with_ai("Creditor", accounts, client_info, tmp_path)
-    data = json.load(open(tmp_path / "Creditor_gpt_response.json"))
+    with open(tmp_path / "Creditor_gpt_response.json") as f:
+        data = json.load(f)
     dump = json.dumps(data)
     assert "devastated" not in dump
     assert "angry" not in dump


### PR DESCRIPTION
## Summary
- fail tests on warnings via pytest.ini
- replace deprecated datetime.utcnow calls with timezone-aware datetime.now(UTC)
- adjust tests to avoid or capture sanitization warnings and close files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952b5a14e8832e8a82176bf3c6dba4