### PR TITLE
refactor: centralize pdf rendering

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 RULEBOOK_FALLBACK_ENABLED = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
 EXPORT_TRACE_FILE = os.getenv("EXPORT_TRACE_FILE", "1") != "0"
+WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
 
 # Ensure the fallback is visible to later getenv calls
 os.environ.setdefault("OPENAI_BASE_URL", OPENAI_BASE_URL)

--- a/logic/instruction_renderer.py
+++ b/logic/instruction_renderer.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 
 import html as html_utils
 import random
-from jinja2 import Environment, FileSystemLoader
-
-env = Environment(loader=FileSystemLoader("templates"))
+from logic import pdf_renderer
 
 
 def render_instruction_html(context: dict) -> str:
     """Render the Jinja2 template with the provided context."""
+    env = pdf_renderer.ensure_template_env("templates")
     template = env.get_template("instruction_template.html")
     return template.render(**context)
 

--- a/logic/instructions_generator.py
+++ b/logic/instructions_generator.py
@@ -9,17 +9,15 @@ from __future__ import annotations
 
 import base64
 import json
-import os
 from datetime import datetime
 from pathlib import Path
-
-import pdfkit
 
 from logic.instruction_data_preparation import (
     prepare_instruction_data,
     generate_account_action,  # re-exported for backward compatibility
 )
 from logic.instruction_renderer import build_instruction_html
+from logic import pdf_renderer
 
 
 def get_logo_base64() -> str:
@@ -30,19 +28,6 @@ def get_logo_base64() -> str:
             encoded = base64.b64encode(f.read()).decode("ascii")
         return f"data:image/png;base64,{encoded}"
     return ""
-
-
-def render_html_to_pdf(html_string: str, output_path: Path):
-    """Render the provided HTML string to a PDF file."""
-    config = pdfkit.configuration(
-        wkhtmltopdf=os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
-    )
-    options = {"quiet": ""}
-    try:
-        pdfkit.from_string(html_string, str(output_path), configuration=config, options=options)
-        print(f"[📄] PDF rendered: {output_path}")
-    except Exception as e:
-        print(f"[❌] Failed to render PDF: {e}")
 
 
 def generate_html(
@@ -103,7 +88,7 @@ def render_pdf_from_html(html: str, output_path: Path) -> Path:
     """Persist the rendered PDF to disk."""
     output_path.mkdir(parents=True, exist_ok=True)
     filepath = output_path / "Start_Here - Instructions.pdf"
-    render_html_to_pdf(html, filepath)
+    pdf_renderer.render_html_to_pdf(html, str(filepath))
     return filepath
 
 

--- a/logic/letter_rendering.py
+++ b/logic/letter_rendering.py
@@ -2,36 +2,24 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
-import pdfkit
-from dotenv import load_dotenv
-from jinja2 import Environment, FileSystemLoader
-
-
-load_dotenv()
-WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
+from config import WKHTMLTOPDF_PATH
+from logic import pdf_renderer
 
 
 def render_dispute_letter_html(context: dict) -> str:
     """Render the dispute letter HTML using the Jinja template."""
 
-    env = Environment(loader=FileSystemLoader("templates"))
+    env = pdf_renderer.ensure_template_env("templates")
     template = env.get_template("dispute_letter_template.html")
     return template.render(**context)
 
 
 def render_html_to_pdf(html_string: str, output_path: Path) -> None:
-    """Convert an HTML string to a PDF file at the given path."""
+    """Thin wrapper around :func:`logic.pdf_renderer.render_html_to_pdf`."""
 
-    try:
-        config = pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_PATH)
-        options = {"quiet": ""}
-        pdfkit.from_string(html_string, str(output_path), configuration=config, options=options)
-        print(f"[📄] PDF rendered: {output_path}")
-    except Exception as e:  # pragma: no cover - rendering failures are logged
-        print(f"[❌] Failed to render PDF: {e}")
+    pdf_renderer.render_html_to_pdf(html_string, str(output_path))
 
 
 __all__ = ["render_dispute_letter_html", "render_html_to_pdf", "WKHTMLTOPDF_PATH"]

--- a/logic/pdf_renderer.py
+++ b/logic/pdf_renderer.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pdfkit
+from jinja2 import Environment, FileSystemLoader
+
+from config import WKHTMLTOPDF_PATH
+
+_template_env: Environment | None = None
+
+
+def ensure_template_env(base_template_dir: Optional[str] = None) -> Environment:
+    """Return a Jinja2 environment rooted at ``base_template_dir``.
+
+    The environment is cached so multiple calls reuse the same loader.
+    """
+    global _template_env
+    base_dir = base_template_dir or "templates"
+    if _template_env is None or getattr(_template_env.loader, "searchpath", [None])[0] != base_dir:
+        _template_env = Environment(loader=FileSystemLoader(base_dir))
+    return _template_env
+
+
+def normalize_output_path(path: str) -> str:
+    """Normalize an output path for PDF generation.
+
+    Ensures the path is absolute, ends with ``.pdf`` and that the parent
+    directory exists.
+    """
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    if p.suffix.lower() != ".pdf":
+        p = p.with_suffix(".pdf")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return str(p.resolve())
+
+
+def render_html_to_pdf(
+    html: str,
+    output_path: str,
+    *,
+    wkhtmltopdf_path: Optional[str] = None,
+) -> None:
+    """Render ``html`` to a PDF at ``output_path``.
+
+    Parameters
+    ----------
+    html:
+        The HTML string to convert.
+    output_path:
+        Desired file path for the resulting PDF. The path is normalized using
+        :func:`normalize_output_path`.
+    wkhtmltopdf_path:
+        Optional path to the ``wkhtmltopdf`` executable. Defaults to the
+        repository-wide configuration.
+    """
+    output_path = normalize_output_path(output_path)
+    wkhtmltopdf = wkhtmltopdf_path or WKHTMLTOPDF_PATH
+    try:
+        config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
+        options = {"quiet": ""}
+        pdfkit.from_string(html, output_path, configuration=config, options=options)
+        print(f"[📄] PDF rendered: {output_path}")
+    except Exception as e:  # pragma: no cover - rendering failures are logged
+        print(f"[❌] Failed to render PDF: {e}")

--- a/tests/test_pdf_renderer.py
+++ b/tests/test_pdf_renderer.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import types
+
+import pytest
+
+from logic import pdf_renderer
+
+
+def test_normalize_output_path_creates_dir_and_pdf(tmp_path):
+    raw = tmp_path / "subdir" / "file"
+    normalized = pdf_renderer.normalize_output_path(str(raw))
+    assert normalized.endswith("subdir/file.pdf")
+    assert Path(normalized).is_absolute()
+    assert Path(normalized).parent.exists()
+    assert Path(normalized).suffix == ".pdf"
+
+
+def test_render_html_to_pdf_writes_file(tmp_path, monkeypatch):
+    def fake_config(**kwargs):
+        return types.SimpleNamespace()
+
+    written = {}
+
+    def fake_from_string(html, path, configuration=None, options=None):
+        Path(path).write_bytes(b"PDF")
+        written["path"] = path
+
+    monkeypatch.setattr(pdf_renderer.pdfkit, "configuration", fake_config)
+    monkeypatch.setattr(pdf_renderer.pdfkit, "from_string", fake_from_string)
+
+    output = tmp_path / "out"
+    pdf_renderer.render_html_to_pdf("<p>hi</p>", str(output))
+    assert written["path"].endswith(".pdf")
+    assert (Path(written["path"]).exists())


### PR DESCRIPTION
## Summary
- centralize HTML-to-PDF logic with new `pdf_renderer` utility
- route letter and instruction rendering through shared renderer
- add tests for path normalization and PDF rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952e8f5c3c832eaa95243537f0d4a8