### PR TITLE
refactor: centralize AI client configuration

### DIFF
--- a/analytics_tracker.py
+++ b/analytics_tracker.py
@@ -13,7 +13,7 @@ def save_analytics_snapshot(
     strategist_failures: Optional[Dict[str, int]] = None,
 ) -> None:
     logging.getLogger(__name__).info(
-        "Analytics tracker using OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL
+        "Analytics tracker using OPENAI_BASE_URL=%s", config.get_ai_config().base_url
     )
     analytics_dir = Path("analytics_data")
     analytics_dir.mkdir(exist_ok=True)

--- a/app.py
+++ b/app.py
@@ -25,8 +25,9 @@ from session_manager import (
 from logic.explanations_normalizer import sanitize, extract_structured
 
 logger = logging.getLogger(__name__)
-logger.info("Flask app starting with OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
-logger.info("Flask app OPENAI_API_KEY present=%s", bool(config.OPENAI_API_KEY))
+_ai_conf = config.get_ai_config()
+logger.info("Flask app starting with OPENAI_BASE_URL=%s", _ai_conf.base_url)
+logger.info("Flask app OPENAI_API_KEY present=%s", bool(_ai_conf.api_key))
 
 app = Flask(__name__)
 CORS(app, resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)

--- a/config.py
+++ b/config.py
@@ -1,31 +1,40 @@
 import os
 import logging
-from dotenv import load_dotenv
 
-load_dotenv()
+from services.ai_client import AIConfig
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 RULEBOOK_FALLBACK_ENABLED = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
 EXPORT_TRACE_FILE = os.getenv("EXPORT_TRACE_FILE", "1") != "0"
 WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
 
-# Ensure the fallback is visible to later getenv calls
-os.environ.setdefault("OPENAI_BASE_URL", OPENAI_BASE_URL)
-
-# Basic logging to confirm configuration
 _logger = logging.getLogger("config")
 if not _logger.handlers:
-    _handler = logging.StreamHandler()
-    _handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
-    _logger.addHandler(_handler)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    _logger.addHandler(handler)
 _logger.setLevel(logging.INFO)
-_logger.info("OPENAI_BASE_URL=%s", OPENAI_BASE_URL)
-_logger.info("OPENAI_API_KEY present=%s", bool(OPENAI_API_KEY))
-_logger.info("RULEBOOK_FALLBACK_ENABLED=%s", RULEBOOK_FALLBACK_ENABLED)
-_logger.info("EXPORT_TRACE_FILE=%s", EXPORT_TRACE_FILE)
 
-if not OPENAI_API_KEY:
-    raise EnvironmentError("OPENAI_API_KEY is not set")
-if "localhost" in OPENAI_BASE_URL:
-    raise EnvironmentError("OPENAI_BASE_URL points to localhost")
+
+def get_ai_config() -> AIConfig:
+    """Return AI configuration loaded from the environment."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+    os.environ.setdefault("OPENAI_BASE_URL", base_url)
+
+    _logger.info("OPENAI_BASE_URL=%s", base_url)
+    _logger.info("OPENAI_API_KEY present=%s", bool(api_key))
+    _logger.info("RULEBOOK_FALLBACK_ENABLED=%s", RULEBOOK_FALLBACK_ENABLED)
+    _logger.info("EXPORT_TRACE_FILE=%s", EXPORT_TRACE_FILE)
+
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY is not set")
+    if "localhost" in base_url:
+        raise EnvironmentError("OPENAI_BASE_URL points to localhost")
+
+    return AIConfig(
+        api_key=api_key,
+        base_url=base_url,
+        chat_model=os.getenv("OPENAI_MODEL", "gpt-4"),
+        response_model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
+    )

--- a/email_sender.py
+++ b/email_sender.py
@@ -14,7 +14,9 @@ def send_email_with_attachment(receiver_email, subject, body, files):
     smtp_port = int(os.getenv("SMTP_PORT", "1025"))
     sender_email = os.getenv("SMTP_USERNAME", "noreply@example.com")
     sender_password = os.getenv("SMTP_PASSWORD", "")  # local dev default
-    logging.getLogger(__name__).info("Email sender using OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
+    logging.getLogger(__name__).info(
+        "Email sender using OPENAI_BASE_URL=%s", config.get_ai_config().base_url
+    )
 
     msg = EmailMessage()
     msg["From"] = sender_email

--- a/logic/explanations_normalizer.py
+++ b/logic/explanations_normalizer.py
@@ -2,16 +2,9 @@ import os
 import re
 from typing import Any, Dict, List
 
-from openai import OpenAI
-from dotenv import load_dotenv
+from services.ai_client import AIClient, get_default_ai_client
 
 from .json_utils import parse_json
-
-load_dotenv()
-client = OpenAI(
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
-)
 
 _PROFANITY = [
     "damn",
@@ -72,7 +65,11 @@ _SCHEMA = {
 }
 
 
-def extract_structured(safe_text: str, account_ctx: Dict[str, Any]) -> Dict[str, Any]:
+def extract_structured(
+    safe_text: str,
+    account_ctx: Dict[str, Any],
+    ai_client: AIClient | None = None,
+) -> Dict[str, Any]:
     """
     Returns structured summary using LLM.
     """
@@ -87,9 +84,9 @@ def extract_structured(safe_text: str, account_ctx: Dict[str, Any]) -> Dict[str,
     )
 
     try:
-        response = client.responses.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
-            input=prompt,
+        client = ai_client or get_default_ai_client()
+        response = client.response_json(
+            prompt=prompt,
             response_format={
                 "type": "json_schema",
                 "json_schema": {"name": "structured_summary", "schema": _SCHEMA},

--- a/logic/generate_strategy_report.py
+++ b/logic/generate_strategy_report.py
@@ -4,22 +4,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-from dotenv import load_dotenv
-from openai import OpenAI
+from services.ai_client import AIClient, get_default_ai_client
 
 from audit import AuditLogger
 from .constants import StrategistFailureReason
 from .json_utils import parse_json
 from logic.guardrails import fix_draft_with_guardrails
 
-load_dotenv()
-client = OpenAI(
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
-)
-
 class StrategyGenerator:
     """Generate an internal strategic analysis using GPT-4."""
+
+    def __init__(self, ai_client: AIClient | None = None):
+        self.ai_client = ai_client or get_default_ai_client()
 
     def generate(
         self,
@@ -65,7 +61,7 @@ Return only a JSON object with this structure:
 }}
 Ensure the response is strictly valid JSON: all property names and strings in double quotes, no trailing commas or comments, and no text outside the JSON.
 """
-        response = client.chat.completions.create(
+        response = self.ai_client.chat_completion(
             model="gpt-4",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.3,

--- a/logic/gpt_prompting.py
+++ b/logic/gpt_prompting.py
@@ -7,8 +7,7 @@ import os
 from datetime import datetime
 from typing import Dict, List
 
-import openai
-from dotenv import load_dotenv
+from services.ai_client import AIClient, get_default_ai_client
 
 from audit import AuditLevel, get_audit
 from .json_utils import parse_json
@@ -26,6 +25,7 @@ def call_gpt_dispute_letter(
     structured_summaries: Dict[str, dict],
     state: str,
     classifier=classify_client_summary,
+    ai_client: AIClient | None = None,
 ) -> dict:
     """Generate GPT-powered dispute letter content."""
 
@@ -141,13 +141,8 @@ Unauthorized Inquiries:
                 "inquiries": inquiry_blocks,
             },
         )
-    load_dotenv()
-    client = openai.OpenAI(
-        api_key=os.getenv("OPENAI_API_KEY"),
-        base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
-    )
-
-    response = client.chat.completions.create(
+    ai_client = ai_client or get_default_ai_client()
+    response = ai_client.chat_completion(
         model="gpt-4",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,

--- a/logic/instructions_generator.py
+++ b/logic/instructions_generator.py
@@ -16,6 +16,7 @@ from logic.instruction_data_preparation import (
     prepare_instruction_data,
     generate_account_action,  # re-exported for backward compatibility
 )
+from services.ai_client import AIClient
 from logic.instruction_renderer import build_instruction_html
 from logic import pdf_renderer
 
@@ -37,6 +38,7 @@ def generate_html(
     run_date: str,
     logo_base64: str,
     strategy: dict | None = None,
+    ai_client: AIClient | None = None,
 ):
     """Return the rendered HTML and merged account list.
 
@@ -50,6 +52,7 @@ def generate_html(
         run_date,
         logo_base64,
         strategy,
+        ai_client=ai_client,
     )
     html = build_instruction_html(context)
     return html, all_accounts
@@ -62,6 +65,7 @@ def generate_instruction_file(
     output_path: Path,
     run_date: str | None = None,
     strategy: dict | None = None,
+    ai_client: AIClient | None = None,
 ):
     """Generate the instruction PDF and JSON context for the client."""
     run_date = run_date or datetime.now().strftime("%B %d, %Y")
@@ -74,6 +78,7 @@ def generate_instruction_file(
         run_date,
         logo_base64,
         strategy,
+        ai_client=ai_client,
     )
 
     html = build_instruction_html(context)

--- a/logic/summary_classifier.py
+++ b/logic/summary_classifier.py
@@ -2,19 +2,11 @@ import os
 import logging
 from typing import Dict, Any
 
-from dotenv import load_dotenv
-from openai import OpenAI
+from services.ai_client import AIClient
 
 from .json_utils import parse_json
 
-load_dotenv()
-
 logger = logging.getLogger(__name__)
-
-client = OpenAI(
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
-)
 
 _RULE_MAP = {
     "identity_theft": {
@@ -60,7 +52,11 @@ def _heuristic_category(summary: Dict[str, Any]) -> str:
     return "inaccurate_reporting"
 
 
-def classify_client_summary(summary: Dict[str, Any], state: str | None = None) -> Dict[str, str]:
+def classify_client_summary(
+    summary: Dict[str, Any],
+    state: str | None = None,
+    ai_client: AIClient | None = None,
+) -> Dict[str, str]:
     """Classify a structured summary into a dispute category and legal strategy.
 
     Attempts to use the OpenAI API when credentials are available; otherwise falls
@@ -70,7 +66,7 @@ def classify_client_summary(summary: Dict[str, Any], state: str | None = None) -
     """
 
     category = None
-    if os.getenv("OPENAI_API_KEY"):
+    if ai_client:
         prompt = (
             "Classify the following structured credit dispute summary into one of "
             "the categories: not_mine, inaccurate_reporting, identity_theft, goodwill. "
@@ -78,9 +74,8 @@ def classify_client_summary(summary: Dict[str, Any], state: str | None = None) -
             f"{summary}"
         )
         try:
-            resp = client.responses.create(
-                model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
-                input=prompt,
+            resp = ai_client.response_json(
+                prompt=prompt,
                 response_format={"type": "json_object"},
             )
             content = resp.output[0].content[0].text

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import warnings
+from typing import Any, List, Dict
+
+from openai import OpenAI
+
+
+@dataclass
+class AIConfig:
+    """Configuration for :class:`AIClient`."""
+
+    api_key: str
+    base_url: str = "https://api.openai.com/v1"
+    chat_model: str = "gpt-4"
+    response_model: str = "gpt-4.1-mini"
+    timeout: float | None = None
+    max_retries: int = 0
+
+
+class AIClient:
+    """Thin wrapper around the OpenAI client used throughout the codebase."""
+
+    def __init__(self, config: AIConfig):
+        self.config = config
+        self._client = OpenAI(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_retries=config.max_retries,
+        )
+
+    # --- OpenAI API helpers -------------------------------------------------
+    def chat_completion(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        model: str | None = None,
+        temperature: float = 0,
+        **kwargs: Any,
+    ):
+        """Proxy to ``chat.completions.create``."""
+
+        model = model or self.config.chat_model
+        return self._client.chat.completions.create(
+            model=model, messages=messages, temperature=temperature, **kwargs
+        )
+
+    def response_json(
+        self,
+        *,
+        prompt: str,
+        model: str | None = None,
+        response_format: Dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        """Proxy to ``responses.create`` for JSON output."""
+
+        model = model or self.config.response_model
+        return self._client.responses.create(
+            model=model,
+            input=prompt,
+            response_format=response_format,
+            **kwargs,
+        )
+
+
+def build_ai_client(config: AIConfig) -> AIClient:
+    """Return an :class:`AIClient` instance from ``config``."""
+
+    return AIClient(config)
+
+
+_default_client: AIClient | None = None
+
+
+def get_default_ai_client() -> AIClient:
+    """Lazily build an :class:`AIClient` using environment configuration."""
+
+    global _default_client
+    if _default_client is None:
+        from config import get_ai_config
+
+        warnings.warn(
+            "Using default AI client built from environment variables; "
+            "please pass an explicit AIClient (deprecated).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _default_client = build_ai_client(get_ai_config())
+    return _default_client

--- a/tasks.py
+++ b/tasks.py
@@ -19,8 +19,9 @@ app = Celery('tasks', broker=BROKER_URL, backend=BROKER_URL)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.info("Celery worker starting with OPENAI_BASE_URL=%s", config.OPENAI_BASE_URL)
-logger.info("Celery worker OPENAI_API_KEY present=%s", bool(config.OPENAI_API_KEY))
+_conf = config.get_ai_config()
+logger.info("Celery worker starting with OPENAI_BASE_URL=%s", _conf.base_url)
+logger.info("Celery worker OPENAI_API_KEY present=%s", bool(_conf.api_key))
 
 # Verify that session_manager is importable at startup. This helps catch
 # cases where the worker is launched from a directory that omits the

--- a/tests/helpers/fake_ai_client.py
+++ b/tests/helpers/fake_ai_client.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+
+class FakeAIClient:
+    """Simple stand-in for :class:`services.ai_client.AIClient` in tests."""
+
+    def __init__(self):
+        self.chat_payloads: List[Dict[str, Any]] = []
+        self.responses: List[str] = []
+        self.chat_responses: List[str] = []
+
+    def add_chat_response(self, content: str) -> None:
+        self.chat_responses.append(content)
+
+    def add_response(self, content: str) -> None:
+        self.responses.append(content)
+
+    def chat_completion(self, *, messages, **kwargs):
+        self.chat_payloads.append({"messages": messages, **kwargs})
+        content = self.chat_responses.pop(0) if self.chat_responses else ""
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
+    def response_json(self, *, prompt, **kwargs):
+        self.chat_payloads.append({"prompt": prompt, **kwargs})
+        content = self.responses.pop(0) if self.responses else ""
+        return SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=content)])]
+        )

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -8,6 +8,7 @@ from logic.letter_generator import (
     generate_all_dispute_letters_with_ai,
     DEFAULT_DISPUTE_REASON,
 )
+from tests.helpers.fake_ai_client import FakeAIClient
 
 class Dummy:
     def __init__(self, data):
@@ -65,7 +66,8 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
     }
 
     with pytest.warns(UserWarning):
-        generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+        fake = FakeAIClient()
+        generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False, ai_client=fake)
 
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)

--- a/tests/test_letter_generator_guardrails.py
+++ b/tests/test_letter_generator_guardrails.py
@@ -4,36 +4,25 @@ from pathlib import Path
 import sys
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from logic.guardrails import generate_letter_with_guardrails, fix_draft_with_guardrails, client
+from logic.guardrails import generate_letter_with_guardrails, fix_draft_with_guardrails
 from session_manager import update_session, get_session
-
-
-class DummyResponse:
-    def __init__(self, text):
-        self.choices = [type("o", (), {"message": type("m", (), {"content": text})})]
+from tests.helpers.fake_ai_client import FakeAIClient
 
 
 def test_autofix_and_no_raw_explanation(monkeypatch, tmp_path):
     session_id = "sess-test"
     structured = {"account_id": "1", "dispute_type": "not_mine", "facts_summary": "billing issue"}
     update_session(session_id, structured_summaries={"1": structured})
-
-    outputs = [
-        DummyResponse("I admit fault. SSN 123-45-6789."),
-        DummyResponse("This is a clean letter."),
-    ]
-
-    def fake_create(*args, **kwargs):
-        return outputs.pop(0)
-
-    monkeypatch.setattr(client.chat.completions, "create", fake_create)
+    fake = FakeAIClient()
+    fake.add_chat_response("I admit fault. SSN 123-45-6789.")
+    fake.add_chat_response("This is a clean letter.")
 
     prompt = (
         "Here is the structured summary for the account:\n" + json.dumps(structured)
     )
 
     text, violations, iters = generate_letter_with_guardrails(
-        prompt, "CA", {"debt_type": "medical"}, session_id, "dispute"
+        prompt, "CA", {"debt_type": "medical"}, session_id, "dispute", ai_client=fake
     )
 
     assert iters == 2
@@ -48,12 +37,10 @@ def test_state_clause_added(monkeypatch):
     session_id = "sess-ny"
     update_session(session_id, structured_summaries={})
 
-    def fake_create(*args, **kwargs):
-        return DummyResponse("Irrelevant")
-
-    monkeypatch.setattr(client.chat.completions, "create", fake_create)
+    fake2 = FakeAIClient()
+    fake2.add_chat_response("Irrelevant")
 
     text, violations, _ = fix_draft_with_guardrails(
-        "Please investigate.", "NY", {"debt_type": "medical"}, session_id, "dispute"
+        "Please investigate.", "NY", {"debt_type": "medical"}, session_id, "dispute", ai_client=fake2
     )
     assert "new york financial services law" in text.lower()

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -6,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from session_manager import update_session, update_intake
 from logic.letter_generator import generate_all_dispute_letters_with_ai
+from tests.helpers.fake_ai_client import FakeAIClient
 
 
 def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
@@ -27,7 +28,7 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     def fake_generate_strategy(sess_id, bureau_data):
         return {"dispute_items": structured}
 
-    def fake_call_gpt(client_info, bureau_name, disputes, inquiries, is_identity_theft, structured_summaries, state):
+    def fake_call_gpt(client_info, bureau_name, disputes, inquiries, is_identity_theft, structured_summaries, state, ai_client=None):
         text = json.dumps(structured_summaries)
         assert "SECRET RAW" not in text
         return {
@@ -62,7 +63,8 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
         }
     }
 
-    generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+    fake = FakeAIClient()
+    generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False, ai_client=fake)
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)
     assert "SECRET RAW" not in json.dumps(data)

--- a/tests/test_neutral_phrase_integration.py
+++ b/tests/test_neutral_phrase_integration.py
@@ -1,31 +1,20 @@
 import json
 from pathlib import Path
 import sys
-import types
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from logic.letter_generator import call_gpt_dispute_letter
 from logic import rules_loader
-import openai
-
-
-class DummyResp:
-    def __init__(self, content: str):
-        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+from tests.helpers.fake_ai_client import FakeAIClient
 
 
 def test_dispute_prompt_includes_neutral_phrase(monkeypatch):
-    captured = {}
-
-    def fake_create(*args, **kwargs):
-        captured["prompt"] = kwargs["messages"][0]["content"]
-        return DummyResp('{"opening_paragraph": "", "accounts": [], "inquiries": [], "closing_paragraph": ""}')
-
-    dummy_client = types.SimpleNamespace(
-        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    fake_client = FakeAIClient()
+    fake_client.add_chat_response(
+        '{"opening_paragraph": "", "accounts": [], "inquiries": [], "closing_paragraph": ""}'
     )
-    monkeypatch.setattr(openai, "OpenAI", lambda **_: dummy_client)
+
     monkeypatch.setattr(
         "logic.letter_generator.classify_client_summary",
         lambda struct, state: {"category": "not_mine"},
@@ -40,8 +29,10 @@ def test_dispute_prompt_includes_neutral_phrase(monkeypatch):
         False,
         {"1": structured},
         "",
+        ai_client=fake_client,
     )
 
+    prompt = fake_client.chat_payloads[0]["messages"][0]["content"]
     phrases = rules_loader.load_neutral_phrases()["not_mine"]
-    assert any(p in captured["prompt"] for p in phrases)
-    assert '"explanation": "I never opened this"' in captured["prompt"]
+    assert any(p in prompt for p in phrases)
+    assert '"explanation": "I never opened this"' in prompt

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -10,6 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from session_manager import update_session, update_intake
 from logic.letter_generator import generate_all_dispute_letters_with_ai
 from logic.generate_goodwill_letters import generate_goodwill_letter_with_ai
+from tests.helpers.fake_ai_client import FakeAIClient
 
 
 def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
@@ -34,7 +35,7 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     def fake_generate_strategy(sess_id, bureau_data):
         return {"dispute_items": structured}
 
-    def fake_call_gpt(client_info, bureau_name, disputes, inquiries, is_identity_theft, structured_summaries, state):
+    def fake_call_gpt(client_info, bureau_name, disputes, inquiries, is_identity_theft, structured_summaries, state, ai_client=None):
         text = json.dumps(client_info)
         assert "furious" not in text
         assert "heartbroken" not in text
@@ -57,6 +58,7 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     monkeypatch.setattr("logic.letter_generator.call_gpt_dispute_letter", fake_call_gpt)
     monkeypatch.setattr("logic.letter_generator.render_html_to_pdf", lambda html, path: None)
     monkeypatch.setattr("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: None)
+    fake = FakeAIClient()
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
 
     client_info = {
@@ -74,7 +76,7 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     }
 
     with pytest.warns(UserWarning):
-        generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False)
+        generate_all_dispute_letters_with_ai(client_info, bureau_data, tmp_path, False, ai_client=fake)
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)
     dump = json.dumps(data)
@@ -99,6 +101,7 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
         session_id=None,
         structured_summaries=None,
         state=None,
+        ai_client=None,
     ):
         assert "devastated" not in (personal_story or "")
         return {
@@ -118,6 +121,7 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "logic.generate_goodwill_letters.fix_draft_with_guardrails", lambda *a, **k: None
     )
+    fake2 = FakeAIClient()
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
 
     client_info = {
@@ -129,7 +133,7 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
         {"name": "Creditor", "account_number": "1", "action_tag": "goodwill"}
     ]
 
-    generate_goodwill_letter_with_ai("Creditor", accounts, client_info, tmp_path)
+    generate_goodwill_letter_with_ai("Creditor", accounts, client_info, tmp_path, ai_client=fake2)
     with open(tmp_path / "Creditor_gpt_response.json") as f:
         data = json.load(f)
     dump = json.dumps(data)


### PR DESCRIPTION
## Summary
- centralize OpenAI usage behind new `AIClient` and `AIConfig`
- load environment data lazily via `config.get_ai_config`
- refactor GPT modules and orchestrators to accept injected clients and remove import-time side effects
- add `FakeAIClient` helper and update tests to inject it

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895350f8600832e9271b16d5db688eb