### PR TITLE
Centralize compliance pipeline for document rendering

### DIFF
--- a/dev_scripts/test_logic_fixes.py
+++ b/dev_scripts/test_logic_fixes.py
@@ -333,7 +333,10 @@ def test_letter_duplicate_accounts_removed():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter") as mock_d,
         mock.patch("logic.letter_generator.render_html_to_pdf"),
-        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
+        mock.patch(
+            "logic.compliance_pipeline.run_compliance_pipeline",
+            lambda html, state, session_id, doc_type, ai_client=None: html,
+        ),
         mock.patch("logic.letter_generator.generate_strategy", return_value=strategy),
     ):
         out_dir = Path("output/tmp_dupes")
@@ -385,7 +388,10 @@ def test_partial_account_number_deduplication():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter") as mock_d,
         mock.patch("logic.letter_generator.render_html_to_pdf"),
-        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
+        mock.patch(
+            "logic.compliance_pipeline.run_compliance_pipeline",
+            lambda html, state, session_id, doc_type, ai_client=None: html,
+        ),
         mock.patch("logic.letter_generator.generate_strategy", return_value=strategy),
     ):
         out_dir = Path("output/tmp_dupe_nums")
@@ -435,7 +441,10 @@ def test_merge_custom_note_with_default():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter", return_value=gpt_resp),
         mock.patch("logic.letter_generator.render_html_to_pdf"),
-        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
+        mock.patch(
+            "logic.compliance_pipeline.run_compliance_pipeline",
+            lambda html, state, session_id, doc_type, ai_client=None: html,
+        ),
         mock.patch("logic.letter_generator.generate_strategy", return_value=strategy),
     ):
         out_dir = Path("output/tmp_merge")
@@ -489,11 +498,13 @@ def test_general_note_routed_to_goodwill():
     with (
         mock.patch("logic.letter_generator.call_gpt_dispute_letter", return_value=gpt_resp),
         mock.patch("logic.letter_generator.render_html_to_pdf"),
-        mock.patch("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
+        mock.patch(
+            "logic.compliance_pipeline.run_compliance_pipeline",
+            lambda html, state, session_id, doc_type, ai_client=None: html,
+        ),
         mock.patch("logic.letter_generator.generate_strategy", return_value=strategy),
         mock.patch("logic.generate_goodwill_letters.call_gpt_for_goodwill_letter") as mock_gw,
         mock.patch("logic.generate_goodwill_letters.render_html_to_pdf"),
-        mock.patch("logic.generate_goodwill_letters.fix_draft_with_guardrails", lambda *a, **k: ("", [], 0)),
     ):
         out_dir = Path("output/tmp_general")
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/logic/compliance_pipeline.py
+++ b/logic/compliance_pipeline.py
@@ -1,0 +1,58 @@
+"""Centralized compliance pipeline for rendered documents."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from logic.guardrails import fix_draft_with_guardrails
+from services.ai_client import AIClient
+
+# Re-export existing compliance helpers for compatibility
+from .compliance_adapter import (
+    adapt_gpt_output,
+    sanitize_client_info,
+    sanitize_disputes,
+    DEFAULT_DISPUTE_REASON,
+    ESCALATION_NOTE,
+)
+
+
+def run_compliance_pipeline(
+    html: str,
+    state: Optional[str],
+    session_id: str,
+    doc_type: str,
+    *,
+    ai_client: AIClient | None = None,
+) -> str:
+    """Apply shared compliance checks to text destined for rendering.
+
+    The pipeline strips HTML tags and routes the plain text through the
+    guardrails checker. The original HTML is returned unchanged.
+    """
+
+    plain_text = re.sub(r"<[^>]+>", " ", html)
+    fix_draft_with_guardrails(
+        plain_text,
+        state,
+        {},
+        session_id,
+        doc_type,
+        ai_client=ai_client,
+    )
+    return html
+
+
+# Backwards compatible alias
+apply_text_compliance = run_compliance_pipeline
+
+__all__ = [
+    "run_compliance_pipeline",
+    "apply_text_compliance",
+    "adapt_gpt_output",
+    "sanitize_client_info",
+    "sanitize_disputes",
+    "DEFAULT_DISPUTE_REASON",
+    "ESCALATION_NOTE",
+]

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -11,7 +11,7 @@ from logic.utils.file_paths import safe_filename
 from logic.utils.note_handling import get_client_address_lines
 from .json_utils import parse_json
 from session_manager import get_session
-from logic.guardrails import fix_draft_with_guardrails
+from logic.compliance_pipeline import run_compliance_pipeline
 from .summary_classifier import classify_client_summary
 from .rules_loader import get_neutral_phrase
 from audit import AuditLogger, AuditLevel
@@ -324,11 +324,9 @@ def generate_goodwill_letter_with_ai(
     }
 
     html = template.render(**context)
-    plain_text = re.sub(r"<[^>]+>", " ", html)
-    fix_draft_with_guardrails(
-        plain_text,
+    run_compliance_pipeline(
+        html,
         client_info.get("state"),
-        {},
         session_id or "",
         "goodwill",
         ai_client=ai_client,

--- a/logic/instructions_generator.py
+++ b/logic/instructions_generator.py
@@ -19,6 +19,7 @@ from logic.instruction_data_preparation import (
 from services.ai_client import AIClient
 from logic.instruction_renderer import build_instruction_html
 from logic import pdf_renderer
+from logic.compliance_pipeline import run_compliance_pipeline
 
 
 def get_logo_base64() -> str:
@@ -55,6 +56,13 @@ def generate_html(
         ai_client=ai_client,
     )
     html = build_instruction_html(context)
+    run_compliance_pipeline(
+        html,
+        client_info.get("state"),
+        client_info.get("session_id", ""),
+        "instructions",
+        ai_client=ai_client,
+    )
     return html, all_accounts
 
 
@@ -80,8 +88,14 @@ def generate_instruction_file(
         strategy,
         ai_client=ai_client,
     )
-
     html = build_instruction_html(context)
+    run_compliance_pipeline(
+        html,
+        client_info.get("state"),
+        client_info.get("session_id", ""),
+        "instructions",
+        ai_client=ai_client,
+    )
 
     render_pdf_from_html(html, output_path)
     save_json_output(all_accounts, output_path)

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -1,0 +1,130 @@
+import sys
+from pathlib import Path
+
+import pdfkit
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+@pytest.mark.parametrize("doc_type", ["dispute", "instructions", "goodwill"])
+def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
+    calls = []
+    monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
+
+    if doc_type == "dispute":
+        from logic.letter_generator import generate_all_dispute_letters_with_ai
+
+        monkeypatch.setattr(
+            "logic.letter_generator.run_compliance_pipeline",
+            lambda html, state, session_id, dt, ai_client=None: calls.append(dt) or html,
+        )
+        monkeypatch.setattr(
+            "logic.letter_generator.generate_strategy",
+            lambda session_id, bureau_data: {"dispute_items": {"1": {}}},
+        )
+        monkeypatch.setattr(
+            "logic.letter_generator.call_gpt_dispute_letter",
+            lambda *a, **k: {
+                "opening_paragraph": "Opening",
+                "accounts": [
+                    {
+                        "name": "Bank A",
+                        "account_number": "1",
+                        "status": "open",
+                        "paragraph": "p",
+                        "requested_action": "Delete",
+                    }
+                ],
+                "inquiries": [],
+                "closing_paragraph": "Closing",
+            },
+        )
+        monkeypatch.setattr(
+            "logic.letter_generator.render_html_to_pdf", lambda html, path: None
+        )
+        client_info = {"name": "Client", "session_id": "s1"}
+        bureau_data = {
+            "Experian": {
+                "disputes": [
+                    {
+                        "name": "Bank A",
+                        "account_number": "1",
+                        "account_id": "1",
+                        "action_tag": "dispute",
+                    }
+                ],
+                "inquiries": [],
+            }
+        }
+        generate_all_dispute_letters_with_ai(
+            client_info, bureau_data, tmp_path, False, None, ai_client=FakeAIClient()
+        )
+    elif doc_type == "instructions":
+        from logic.instructions_generator import generate_instruction_file
+        monkeypatch.setattr(
+            "logic.instructions_generator.run_compliance_pipeline",
+            lambda html, state, session_id, dt, ai_client=None: calls.append(dt) or html,
+        )
+        monkeypatch.setattr(
+            "logic.instruction_data_preparation.generate_account_action",
+            lambda acc, ai_client=None: "Do something",
+        )
+        monkeypatch.setattr(
+            "logic.pdf_renderer.render_html_to_pdf", lambda html, path: None
+        )
+        client_info = {"name": "Client", "session_id": "s2"}
+        bureau_data = {
+            "Experian": {
+                "all_accounts": [
+                    {
+                        "name": "Bank B",
+                        "status": "good",
+                        "action_tag": "positive",
+                    }
+                ],
+                "disputes": [],
+                "inquiries": [],
+            }
+        }
+        generate_instruction_file(
+            client_info, bureau_data, False, tmp_path / "inst", ai_client=FakeAIClient()
+        )
+    else:  # goodwill
+        from logic.generate_goodwill_letters import generate_goodwill_letter_with_ai
+
+        monkeypatch.setattr(
+            "logic.generate_goodwill_letters.run_compliance_pipeline",
+            lambda html, state, session_id, dt, ai_client=None: calls.append(dt) or html,
+        )
+        monkeypatch.setattr(
+            "logic.generate_goodwill_letters.call_gpt_for_goodwill_letter",
+            lambda *a, **k: {
+                "intro_paragraph": "Intro",
+                "hardship_paragraph": "Hard",
+                "recovery_paragraph": "Rec",
+                "closing_paragraph": "Close",
+                "accounts": [],
+            },
+        )
+        monkeypatch.setattr(
+            "logic.generate_goodwill_letters.render_html_to_pdf",
+            lambda html, path: None,
+        )
+        monkeypatch.setattr(
+            "logic.generate_goodwill_letters.gather_supporting_docs",
+            lambda session_id: ("", [], None),
+        )
+        output = tmp_path / "gw"
+        output.mkdir()
+        generate_goodwill_letter_with_ai(
+            "Creditor",
+            [{"name": "Creditor", "account_number": "1"}],
+            {"name": "Client", "session_id": "s3"},
+            output,
+            ai_client=FakeAIClient(),
+        )
+
+    assert doc_type in calls

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -40,7 +40,10 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr('logic.letter_generator.call_gpt_dispute_letter', fake_call_gpt)
     monkeypatch.setattr('logic.letter_generator.render_html_to_pdf', lambda html, path: None)
-    monkeypatch.setattr('logic.letter_generator.fix_draft_with_guardrails', lambda *a, **k: None)
+    monkeypatch.setattr(
+        'logic.compliance_pipeline.run_compliance_pipeline',
+        lambda html, state, session_id, doc_type, ai_client=None: html,
+    )
     import pdfkit
     monkeypatch.setattr(pdfkit, 'configuration', lambda *a, **k: None)
 

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -49,7 +49,10 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     monkeypatch.setattr("logic.letter_generator.generate_strategy", fake_generate_strategy)
     monkeypatch.setattr("logic.letter_generator.call_gpt_dispute_letter", fake_call_gpt)
     monkeypatch.setattr("logic.letter_generator.render_html_to_pdf", lambda html, path: None)
-    monkeypatch.setattr("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "logic.compliance_pipeline.run_compliance_pipeline",
+        lambda html, state, session_id, doc_type, ai_client=None: html,
+    )
     import pdfkit
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
 

--- a/tests/test_logging_edge_cases.py
+++ b/tests/test_logging_edge_cases.py
@@ -9,7 +9,10 @@ from tests.helpers.fake_ai_client import FakeAIClient
 
 def _setup(monkeypatch):
     monkeypatch.setattr("logic.letter_generator.render_html_to_pdf", lambda html, path: None)
-    monkeypatch.setattr("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "logic.compliance_pipeline.run_compliance_pipeline",
+        lambda html, state, session_id, doc_type, ai_client=None: html,
+    )
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
 
 

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -57,7 +57,10 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     monkeypatch.setattr("logic.letter_generator.generate_strategy", fake_generate_strategy)
     monkeypatch.setattr("logic.letter_generator.call_gpt_dispute_letter", fake_call_gpt)
     monkeypatch.setattr("logic.letter_generator.render_html_to_pdf", lambda html, path: None)
-    monkeypatch.setattr("logic.letter_generator.fix_draft_with_guardrails", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "logic.compliance_pipeline.run_compliance_pipeline",
+        lambda html, state, session_id, doc_type, ai_client=None: html,
+    )
     fake = FakeAIClient()
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)
 
@@ -122,7 +125,8 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
         "logic.generate_goodwill_letters.render_html_to_pdf", lambda html, path: None
     )
     monkeypatch.setattr(
-        "logic.generate_goodwill_letters.fix_draft_with_guardrails", lambda *a, **k: None
+        "logic.compliance_pipeline.run_compliance_pipeline",
+        lambda html, state, session_id, doc_type, ai_client=None: html,
     )
     fake2 = FakeAIClient()
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- Introduce `run_compliance_pipeline` to unify guardrail checks for all rendered documents
- Refactor dispute, instruction, and goodwill letter generators to use the shared pipeline
- Add tests ensuring compliance pipeline is invoked for each document type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689547c221a0832ebbbe963189607ba8