### PR TITLE
refactor: centralize credit repair orchestration

### DIFF
--- a/dev_scripts/test_my_version_backup.py
+++ b/dev_scripts/test_my_version_backup.py
@@ -7,7 +7,7 @@ import pytest
 # הוספת הנתיב למודולים
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from main import run_credit_repair_process
+from orchestrators import run_credit_repair_process
 
 # 💼 פרטי לקוח - Alirio Exposito Sr
 client_info = {

--- a/dev_scripts/test_run_local.py
+++ b/dev_scripts/test_run_local.py
@@ -124,7 +124,7 @@ def run_checks():
 
 def test_skip_goodwill_when_identity_theft():
     import tempfile
-    from main import run_credit_repair_process
+    from orchestrators import run_credit_repair_process
 
     client_info = {"name": "Jane Test", "email": "jane@example.com", "session_id": "test"}
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
@@ -140,14 +140,14 @@ def test_skip_goodwill_when_identity_theft():
                     "SMTP_PASSWORD": "x",
                 },
             ),
-            mock.patch("main.process_client_intake", return_value=("session", {}, {})),
-            mock.patch("main.classify_client_responses", return_value={}),
+            mock.patch("orchestrators.process_client_intake", return_value=("session", {}, {})),
+            mock.patch("orchestrators.classify_client_responses", return_value={}),
             mock.patch(
-                "main.analyze_credit_report",
+                "orchestrators.analyze_credit_report",
                 return_value=(Path(tmp.name), {}, {"Experian": {}}, Path(tmp.name).parent),
             ),
-            mock.patch("main.generate_strategy_plan", return_value={}),
-            mock.patch("main.build_ai_client", return_value=FakeAIClient()),
+            mock.patch("orchestrators.generate_strategy_plan", return_value={}),
+            mock.patch("services.ai_client.build_ai_client", return_value=FakeAIClient()),
             mock.patch("logic.letter_generator.generate_dispute_letters_for_all_bureaus"),
             mock.patch("logic.generate_goodwill_letters.generate_goodwill_letters") as mock_goodwill,
             mock.patch("logic.generate_custom_letters.generate_custom_letters"),
@@ -158,7 +158,7 @@ def test_skip_goodwill_when_identity_theft():
             mock.patch("main.extract_all_accounts", return_value=[]),
             mock.patch("logic.upload_validator.move_uploaded_file", return_value=Path(tmp.name)),
             mock.patch("logic.upload_validator.is_safe_pdf", return_value=True),
-            mock.patch("main.save_log_file"),
+            mock.patch("orchestrators.save_log_file"),
             mock.patch("shutil.copyfile"),
         ):
             run_credit_repair_process(client_info, proofs, True)

--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,7 @@ if PROJECT_ROOT not in sys.path:
 
 import config
 from celery import Celery
-from main import run_credit_repair_process, extract_problematic_accounts_from_report
+from orchestrators import run_credit_repair_process, extract_problematic_accounts_from_report
 
 BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 app = Celery('tasks', broker=BROKER_URL, backend=BROKER_URL)

--- a/tests/test_celery_session_manager_import.py
+++ b/tests/test_celery_session_manager_import.py
@@ -12,10 +12,10 @@ def test_tasks_can_import_session_manager(tmp_path):
         # Remove project root from sys.path to simulate running from elsewhere
         sys.path = [p for p in sys.path if p != {repr(str(root))}]
         import types
-        main_stub = types.ModuleType('main')
-        main_stub.run_credit_repair_process = lambda *a, **k: None
-        main_stub.extract_problematic_accounts_from_report = lambda *a, **k: None
-        sys.modules['main'] = main_stub
+        orchestrators_stub = types.ModuleType('orchestrators')
+        orchestrators_stub.run_credit_repair_process = lambda *a, **k: None
+        orchestrators_stub.extract_problematic_accounts_from_report = lambda *a, **k: None
+        sys.modules['orchestrators'] = orchestrators_stub
         spec = importlib.util.spec_from_file_location('tasks', {repr(str(root / 'tasks.py'))})
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- consolidate orchestration logic in `orchestrators.py` with `run_credit_repair_process` and helper functions
- slim down `main.py` to a thin wrapper and update imports across tasks and dev scripts
- document orchestrator role and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689614b37e3c832e9a1dd8476d891b51