### PR TITLE
Centralize configuration via AppConfig and inject into services

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -5,10 +5,11 @@ import io
 import zipfile
 
 from telegram_alert import send_admin_login_alert
+from config import get_app_config
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
 
-ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD')
+ADMIN_PASSWORD = get_app_config().admin_password
 
 
 def is_authenticated():

--- a/app.py
+++ b/app.py
@@ -8,7 +8,6 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 import logging
-import config
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import uuid
@@ -23,16 +22,21 @@ from session_manager import (
     update_intake,
 )
 from logic.explanations_normalizer import sanitize, extract_structured
+from config import get_app_config
 
 logger = logging.getLogger(__name__)
-_ai_conf = config.get_ai_config()
-logger.info("Flask app starting with OPENAI_BASE_URL=%s", _ai_conf.base_url)
-logger.info("Flask app OPENAI_API_KEY present=%s", bool(_ai_conf.api_key))
+_app_config = get_app_config()
+logger.info(
+    "Flask app starting with OPENAI_BASE_URL=%s", _app_config.ai.base_url
+)
+logger.info(
+    "Flask app OPENAI_API_KEY present=%s", bool(_app_config.ai.api_key)
+)
 
 app = Flask(__name__)
 CORS(app, resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)
 
-app.secret_key = os.environ.get("SECRET_KEY", "change-me")
+app.secret_key = _app_config.secret_key
 app.register_blueprint(admin_bp)
 
 @app.route("/")

--- a/config.py
+++ b/config.py
@@ -1,11 +1,8 @@
 import os
 import logging
+from dataclasses import dataclass
 
 from services.ai_client import AIConfig
-
-RULEBOOK_FALLBACK_ENABLED = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
-EXPORT_TRACE_FILE = os.getenv("EXPORT_TRACE_FILE", "1") != "0"
-WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
 
 _logger = logging.getLogger("config")
 if not _logger.handlers:
@@ -15,26 +12,74 @@ if not _logger.handlers:
 _logger.setLevel(logging.INFO)
 
 
-def get_ai_config() -> AIConfig:
-    """Return AI configuration loaded from the environment."""
+@dataclass
+class AppConfig:
+    """Application configuration loaded from the environment."""
+
+    ai: AIConfig
+    wkhtmltopdf_path: str
+    rulebook_fallback_enabled: bool
+    export_trace_file: bool
+    smtp_server: str
+    smtp_port: int
+    smtp_username: str
+    smtp_password: str
+    celery_broker_url: str
+    admin_password: str | None = None
+    secret_key: str = "change-me"
+
+
+def get_app_config() -> AppConfig:
+    """Load and validate application configuration from environment variables."""
 
     api_key = os.getenv("OPENAI_API_KEY")
     base_url = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
     os.environ.setdefault("OPENAI_BASE_URL", base_url)
 
+    wkhtmltopdf_path = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
+    rulebook_fallback_enabled = os.getenv("RULEBOOK_FALLBACK_ENABLED", "1") != "0"
+    export_trace_file = os.getenv("EXPORT_TRACE_FILE", "1") != "0"
+    smtp_server = os.getenv("SMTP_SERVER", "localhost")
+    smtp_port = int(os.getenv("SMTP_PORT", "1025"))
+    smtp_username = os.getenv("SMTP_USERNAME", "noreply@example.com")
+    smtp_password = os.getenv("SMTP_PASSWORD", "")
+    celery_broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    admin_password = os.getenv("ADMIN_PASSWORD")
+    secret_key = os.getenv("SECRET_KEY", "change-me")
+
     _logger.info("OPENAI_BASE_URL=%s", base_url)
     _logger.info("OPENAI_API_KEY present=%s", bool(api_key))
-    _logger.info("RULEBOOK_FALLBACK_ENABLED=%s", RULEBOOK_FALLBACK_ENABLED)
-    _logger.info("EXPORT_TRACE_FILE=%s", EXPORT_TRACE_FILE)
+    _logger.info("RULEBOOK_FALLBACK_ENABLED=%s", rulebook_fallback_enabled)
+    _logger.info("EXPORT_TRACE_FILE=%s", export_trace_file)
 
     if not api_key:
         raise EnvironmentError("OPENAI_API_KEY is not set")
     if "localhost" in base_url:
         raise EnvironmentError("OPENAI_BASE_URL points to localhost")
 
-    return AIConfig(
+    ai_conf = AIConfig(
         api_key=api_key,
         base_url=base_url,
         chat_model=os.getenv("OPENAI_MODEL", "gpt-4"),
         response_model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
     )
+
+    return AppConfig(
+        ai=ai_conf,
+        wkhtmltopdf_path=wkhtmltopdf_path,
+        rulebook_fallback_enabled=rulebook_fallback_enabled,
+        export_trace_file=export_trace_file,
+        smtp_server=smtp_server,
+        smtp_port=smtp_port,
+        smtp_username=smtp_username,
+        smtp_password=smtp_password,
+        celery_broker_url=celery_broker_url,
+        admin_password=admin_password,
+        secret_key=secret_key,
+    )
+
+
+def get_ai_config() -> AIConfig:
+    """Backward compatible helper returning the AI sub-config."""
+
+    return get_app_config().ai

--- a/email_sender.py
+++ b/email_sender.py
@@ -1,7 +1,6 @@
 import smtplib
-import os
 import logging
-import config
+import os
 from email.message import EmailMessage
 from pathlib import Path
 
@@ -9,15 +8,17 @@ def collect_all_files(folder: Path):
     """אוסף את כל קבצי ה־PDF מתוך תיקיית הלקוח לשליחה באימייל."""
     return [str(p) for p in folder.glob("*.pdf") if p.is_file()]
 
-def send_email_with_attachment(receiver_email, subject, body, files):
-    smtp_server = os.getenv("SMTP_SERVER", "localhost")
-    smtp_port = int(os.getenv("SMTP_PORT", "1025"))
-    sender_email = os.getenv("SMTP_USERNAME", "noreply@example.com")
-    sender_password = os.getenv("SMTP_PASSWORD", "")  # local dev default
-    logging.getLogger(__name__).info(
-        "Email sender using OPENAI_BASE_URL=%s", config.get_ai_config().base_url
-    )
-
+def send_email_with_attachment(
+    receiver_email,
+    subject,
+    body,
+    files,
+    *,
+    smtp_server: str,
+    smtp_port: int,
+    sender_email: str,
+    sender_password: str,
+):
     msg = EmailMessage()
     msg["From"] = sender_email
     msg["To"] = receiver_email

--- a/logic/compliance_adapter.py
+++ b/logic/compliance_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import warnings
 from typing import Dict, Iterable, List, Set, Tuple
 
-import config
 from logic.utils.names_normalization import normalize_creditor_name
 from logic.utils.text_parsing import CHARGEOFF_RE, COLLECTION_RE
 
@@ -117,12 +116,13 @@ def adapt_gpt_output(
     gpt_data: dict,
     fallback_norm_names: Iterable[str],
     acc_type_map: Dict[Tuple[str, str], dict],
+    rulebook_fallback_enabled: bool,
 ) -> None:
     """Apply compliance rules to the GPT response in-place."""
 
     for acc in gpt_data.get("accounts", []):
         name_key = normalize_creditor_name(acc.get("name", ""))
-        if config.RULEBOOK_FALLBACK_ENABLED and name_key in set(fallback_norm_names):
+        if rulebook_fallback_enabled and name_key in set(fallback_norm_names):
             acc["paragraph"] = DEFAULT_DISPUTE_REASON
             acc.pop("requested_action", None)
         acc.pop("personal_note", None)

--- a/logic/guardrails.py
+++ b/logic/guardrails.py
@@ -59,7 +59,6 @@ def generate_letter_with_guardrails(
         iterations += 1
         client = ai_client or get_default_ai_client()
         response = client.chat_completion(
-            model=os.getenv("OPENAI_MODEL", "gpt-4"),
             messages=messages,
             temperature=0.3,
         )
@@ -109,7 +108,6 @@ def fix_draft_with_guardrails(
         )
         client = ai_client or get_default_ai_client()
         response = client.chat_completion(
-            model=os.getenv("OPENAI_MODEL", "gpt-4"),
             messages=messages,
             temperature=0,
         )

--- a/logic/instructions_generator.py
+++ b/logic/instructions_generator.py
@@ -74,6 +74,7 @@ def generate_instruction_file(
     run_date: str | None = None,
     strategy: dict | None = None,
     ai_client: AIClient | None = None,
+    wkhtmltopdf_path: str | None = None,
 ):
     """Generate the instruction PDF and JSON context for the client."""
     run_date = run_date or datetime.now().strftime("%B %d, %Y")
@@ -97,17 +98,27 @@ def generate_instruction_file(
         ai_client=ai_client,
     )
 
-    render_pdf_from_html(html, output_path)
+    if wkhtmltopdf_path:
+        render_pdf_from_html(html, output_path, wkhtmltopdf_path=wkhtmltopdf_path)
+    else:
+        render_pdf_from_html(html, output_path)
     save_json_output(all_accounts, output_path)
 
     print("[✅] Instructions file generated successfully.")
 
 
-def render_pdf_from_html(html: str, output_path: Path) -> Path:
+def render_pdf_from_html(
+    html: str, output_path: Path, wkhtmltopdf_path: str | None = None
+) -> Path:
     """Persist the rendered PDF to disk."""
     output_path.mkdir(parents=True, exist_ok=True)
     filepath = output_path / "Start_Here - Instructions.pdf"
-    pdf_renderer.render_html_to_pdf(html, str(filepath))
+    if wkhtmltopdf_path:
+        pdf_renderer.render_html_to_pdf(
+            html, str(filepath), wkhtmltopdf_path=wkhtmltopdf_path
+        )
+    else:
+        pdf_renderer.render_html_to_pdf(html, str(filepath))
     return filepath
 
 

--- a/logic/letter_generator.py
+++ b/logic/letter_generator.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-import config
 from audit import AuditLevel, AuditLogger
 from logic.utils.note_handling import get_client_address_lines
 
@@ -61,6 +60,8 @@ def generate_all_dispute_letters_with_ai(
     run_date: str | None = None,
     log_messages: List[str] | None = None,
     ai_client: AIClient | None = None,
+    rulebook_fallback_enabled: bool = True,
+    wkhtmltopdf_path: str | None = None,
 ):
     """Generate dispute letters for all bureaus using GPT-derived content."""
 
@@ -131,7 +132,9 @@ def generate_all_dispute_letters_with_ai(
             ai_client=ai_client,
         )
 
-        adapt_gpt_output(gpt_data, fallback_norm_names, acc_type_map)
+        adapt_gpt_output(
+            gpt_data, fallback_norm_names, acc_type_map, rulebook_fallback_enabled
+        )
 
         included_set = {
             (
@@ -180,7 +183,10 @@ def generate_all_dispute_letters_with_ai(
         )
         filename = f"Dispute Letter - {bureau_name}.pdf"
         filepath = output_path / filename
-        render_html_to_pdf(html, filepath)
+        if wkhtmltopdf_path:
+            render_html_to_pdf(html, filepath, wkhtmltopdf_path=wkhtmltopdf_path)
+        else:
+            render_html_to_pdf(html, filepath)
 
         with open(output_path / f"{bureau_name}_gpt_response.json", "w") as f:
             json.dump(gpt_data, f, indent=2)

--- a/logic/letter_rendering.py
+++ b/logic/letter_rendering.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from config import WKHTMLTOPDF_PATH
 from logic import pdf_renderer
 
 
@@ -16,11 +15,15 @@ def render_dispute_letter_html(context: dict) -> str:
     return template.render(**context)
 
 
-def render_html_to_pdf(html_string: str, output_path: Path) -> None:
+def render_html_to_pdf(
+    html_string: str, output_path: Path, wkhtmltopdf_path: str | None = None
+) -> None:
     """Thin wrapper around :func:`logic.pdf_renderer.render_html_to_pdf`."""
 
-    pdf_renderer.render_html_to_pdf(html_string, str(output_path))
+    pdf_renderer.render_html_to_pdf(
+        html_string, str(output_path), wkhtmltopdf_path=wkhtmltopdf_path
+    )
 
 
-__all__ = ["render_dispute_letter_html", "render_html_to_pdf", "WKHTMLTOPDF_PATH"]
+__all__ = ["render_dispute_letter_html", "render_html_to_pdf"]
 

--- a/logic/pdf_renderer.py
+++ b/logic/pdf_renderer.py
@@ -6,7 +6,7 @@ from typing import Optional
 import pdfkit
 from jinja2 import Environment, FileSystemLoader
 
-from config import WKHTMLTOPDF_PATH
+from config import get_app_config
 
 _template_env: Environment | None = None
 
@@ -58,7 +58,7 @@ def render_html_to_pdf(
         repository-wide configuration.
     """
     output_path = normalize_output_path(output_path)
-    wkhtmltopdf = wkhtmltopdf_path or WKHTMLTOPDF_PATH
+    wkhtmltopdf = wkhtmltopdf_path or get_app_config().wkhtmltopdf_path
     try:
         config = pdfkit.configuration(wkhtmltopdf=wkhtmltopdf)
         options = {"quiet": ""}

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from datetime import datetime
 
@@ -9,30 +8,6 @@ from orchestrators import (
 from logic.strategy_merger import merge_strategy_data
 
 logger = logging.getLogger(__name__)
-
-
-def validate_env_variables():
-    defaults = {
-        "SMTP_SERVER": "localhost",
-        "SMTP_PORT": "1025",
-        "SMTP_USERNAME": "noreply@example.com",
-        "SMTP_PASSWORD": "",
-    }
-
-    print("🔍 Validating environment configuration...\n")
-    base_url = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
-    os.environ["OPENAI_BASE_URL"] = base_url
-    if not os.getenv("OPENAI_API_KEY"):
-        raise EnvironmentError("OPENAI_API_KEY is missing")
-    print(f"✅ OPENAI_BASE_URL: {base_url}")
-    print("✅ OPENAI_API_KEY is set.")
-    for var, default in defaults.items():
-        if not os.getenv(var):
-            print(f"⚠️ {var} not set, using default '{default}'")
-            os.environ[var] = default
-        else:
-            print(f"✅ {var} is set.")
-    print("✅ Environment variables configured.\n")
 
 
 def get_current_month():

--- a/tasks.py
+++ b/tasks.py
@@ -10,18 +10,28 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-import config
 from celery import Celery
-from orchestrators import run_credit_repair_process, extract_problematic_accounts_from_report
+from orchestrators import (
+    run_credit_repair_process,
+    extract_problematic_accounts_from_report,
+)
+from config import get_app_config
 
-BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-app = Celery('tasks', broker=BROKER_URL, backend=BROKER_URL)
+_app_config = get_app_config()
+app = Celery(
+    'tasks',
+    broker=_app_config.celery_broker_url,
+    backend=_app_config.celery_broker_url,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-_conf = config.get_ai_config()
-logger.info("Celery worker starting with OPENAI_BASE_URL=%s", _conf.base_url)
-logger.info("Celery worker OPENAI_API_KEY present=%s", bool(_conf.api_key))
+logger.info(
+    "Celery worker starting with OPENAI_BASE_URL=%s", _app_config.ai.base_url
+)
+logger.info(
+    "Celery worker OPENAI_API_KEY present=%s", bool(_app_config.ai.api_key)
+)
 
 # Verify that session_manager is importable at startup. This helps catch
 # cases where the worker is launched from a directory that omits the

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,28 @@
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import config
+
+
+def test_get_app_config_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.com/v1")
+    cfg = config.get_app_config()
+    assert cfg.ai.api_key == "key"
+    assert cfg.ai.base_url == "https://api.example.com/v1"
+    assert cfg.wkhtmltopdf_path == "wkhtmltopdf"
+    assert cfg.smtp_server == "localhost"
+
+
+def test_get_app_config_invalid(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.com/v1")
+    with pytest.raises(EnvironmentError):
+        config.get_app_config()
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost")
+    with pytest.raises(EnvironmentError):
+        config.get_app_config()


### PR DESCRIPTION
## Summary
- Introduce `AppConfig` dataclass and `get_app_config` to load and validate environment settings
- Refactor orchestrators to build config once and inject into letter generation and email sending
- Replace direct environment reads in helpers with config parameters
- Add coverage for `get_app_config` happy and failure cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689617d9543c832eac254d998eb8433e