### PR TITLE
feat: introduce typed models and migrate dispute flow

### DIFF
--- a/logic/compliance_pipeline.py
+++ b/logic/compliance_pipeline.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from logic.guardrails import fix_draft_with_guardrails
 from services.ai_client import AIClient
+from models.letter import LetterArtifact
 
 # Re-export existing compliance helpers for compatibility
 from .compliance_adapter import (
@@ -19,18 +20,19 @@ from .compliance_adapter import (
 
 
 def run_compliance_pipeline(
-    html: str,
+    letter: LetterArtifact | str,
     state: Optional[str],
     session_id: str,
     doc_type: str,
     *,
     ai_client: AIClient | None = None,
-) -> str:
-    """Apply shared compliance checks to text destined for rendering.
+) -> LetterArtifact | str:
+    """Apply shared compliance checks to rendered HTML or artifacts."""
 
-    The pipeline strips HTML tags and routes the plain text through the
-    guardrails checker. The original HTML is returned unchanged.
-    """
+    if isinstance(letter, LetterArtifact):
+        html = letter.html
+    else:
+        html = letter
 
     plain_text = re.sub(r"<[^>]+>", " ", html)
     fix_draft_with_guardrails(
@@ -41,7 +43,7 @@ def run_compliance_pipeline(
         doc_type,
         ai_client=ai_client,
     )
-    return html
+    return letter
 
 
 # Backwards compatible alias

--- a/logic/letter_rendering.py
+++ b/logic/letter_rendering.py
@@ -5,14 +5,32 @@ from __future__ import annotations
 from pathlib import Path
 
 from logic import pdf_renderer
+from models.letter import LetterContext, LetterArtifact, LetterAccount
+from models.account import Inquiry
+import warnings
 
 
-def render_dispute_letter_html(context: dict) -> str:
-    """Render the dispute letter HTML using the Jinja template."""
+def render_dispute_letter_html(context: LetterContext | dict) -> LetterArtifact:
+    """Render the dispute letter HTML using the Jinja template.
+
+    Accepts either a :class:`LetterContext` or a legacy ``dict``. When a dict
+    is supplied a :class:`DeprecationWarning` is emitted and the input is
+    normalized to ``LetterContext``.
+    """
+
+    if isinstance(context, dict):
+        try:
+            warnings.warn(
+                "dict context is deprecated", DeprecationWarning, stacklevel=2
+            )
+        except DeprecationWarning:
+            pass
+        context = LetterContext.from_dict(context)
 
     env = pdf_renderer.ensure_template_env("templates")
     template = env.get_template("dispute_letter_template.html")
-    return template.render(**context)
+    html = template.render(**context.to_dict())
+    return LetterArtifact(html=html)
 
 
 def render_html_to_pdf(

--- a/logic/report_parsing.py
+++ b/logic/report_parsing.py
@@ -23,3 +23,25 @@ def extract_text_from_pdf(pdf_path: str | Path) -> str:
     from .utils.pdf_ops import extract_pdf_text_safe
 
     return extract_pdf_text_safe(Path(pdf_path), max_chars=150000)
+
+from models.bureau import BureauAccount
+
+
+def bureau_data_from_dict(data: dict) -> dict[str, list[BureauAccount]]:
+    """Convert raw bureau ``data`` to typed ``BureauAccount`` objects.
+
+    Parameters
+    ----------
+    data:
+        Mapping of section name to list of account dictionaries.
+
+    Returns
+    -------
+    dict[str, list[BureauAccount]]
+        Mapping with the same keys but ``BureauAccount`` instances as values.
+    """
+    result: dict[str, list[BureauAccount]] = {}
+    for section, items in data.items():
+        if isinstance(items, list):
+            result[section] = [BureauAccount.from_dict(it) for it in items]
+    return result

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,13 @@
+"""Typed data models for the finance platform."""
+
+from .account import Account, Inquiry, LateHistory, AccountId, AccountMap
+from .bureau import BureauSection, BureauAccount
+from .strategy import StrategyPlan, StrategyItem, Recommendation
+from .letter import LetterContext, LetterAccount, LetterArtifact
+
+__all__ = [
+    'Account', 'Inquiry', 'LateHistory', 'AccountId', 'AccountMap',
+    'BureauSection', 'BureauAccount',
+    'StrategyPlan', 'StrategyItem', 'Recommendation',
+    'LetterContext', 'LetterAccount', 'LetterArtifact',
+]

--- a/models/account.py
+++ b/models/account.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, TypeVar, Type
+
+
+AccountId = str
+AccountMap = Dict[AccountId, 'Account']
+
+
+@dataclass
+class LateHistory:
+    """History of late payments for an account.
+
+    Attributes
+    ----------
+    date: str
+        Date of the late payment in ISO format (YYYY-MM-DD).
+    status: str
+        Status of the payment at that date (e.g., '30', '60').
+    """
+
+    date: str
+    status: str
+
+    @classmethod
+    def from_dict(cls: Type['LateHistory'], data: Dict) -> 'LateHistory':
+        return cls(date=data.get('date', ''), status=data.get('status', ''))
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class Inquiry:
+    """Credit inquiry record.
+
+    Attributes
+    ----------
+    creditor_name: str
+        Name of the creditor who made the inquiry.
+    date: str
+        Date of the inquiry (YYYY-MM-DD).
+    bureau: Optional[str]
+        Name of the bureau reporting the inquiry.
+    """
+
+    creditor_name: str
+    date: str
+    bureau: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls: Type['Inquiry'], data: Dict) -> 'Inquiry':
+        return cls(
+            creditor_name=data.get('creditor_name', ''),
+            date=data.get('date', ''),
+            bureau=data.get('bureau'),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class Account:
+    """Representation of a tradeline/account on a credit report.
+
+    Attributes
+    ----------
+    account_id: Optional[str]
+        Identifier used internally for the account.
+    name: str
+        Creditor or account name.
+    account_number: Optional[str]
+        Account number as shown on the report.
+    reported_status: Optional[str]
+        Status reported by the bureau (e.g., 'Open', 'Closed').
+    status: Optional[str]
+        Additional status text if present.
+    dispute_type: Optional[str]
+        Type of dispute associated with the account.
+    advisor_comment: Optional[str]
+        Free form comment from strategist or advisor.
+    action_tag: Optional[str]
+        Normalized action tag from strategist (e.g., 'dispute').
+    recommended_action: Optional[str]
+        Human readable action recommendation.
+    flags: Optional[List[str]]
+        Miscellaneous flags passed through the pipeline.
+    """
+
+    name: str
+    account_id: Optional[str] = None
+    account_number: Optional[str] = None
+    reported_status: Optional[str] = None
+    status: Optional[str] = None
+    dispute_type: Optional[str] = None
+    advisor_comment: Optional[str] = None
+    action_tag: Optional[str] = None
+    recommended_action: Optional[str] = None
+    flags: Optional[List[str]] = field(default_factory=list)
+    extras: Dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls: Type['Account'], data: Dict) -> 'Account':
+        return cls(
+            account_id=data.get('account_id'),
+            name=data.get('name', ''),
+            account_number=data.get('account_number'),
+            reported_status=data.get('reported_status') or data.get('status'),
+            status=data.get('status'),
+            dispute_type=data.get('dispute_type'),
+            advisor_comment=data.get('advisor_comment'),
+            action_tag=data.get('action_tag'),
+            recommended_action=data.get('recommended_action'),
+            flags=list(data.get('flags', []) or []),
+            extras={k: v for k, v in data.items() if k not in {
+                'account_id', 'name', 'account_number', 'reported_status',
+                'status', 'dispute_type', 'advisor_comment', 'action_tag',
+                'recommended_action', 'flags'
+            }},
+        )
+
+    def to_dict(self) -> Dict:
+        data = asdict(self)
+        data.update(self.extras)
+        return data
+

--- a/models/bureau.py
+++ b/models/bureau.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Type
+
+from .account import Account
+
+
+@dataclass
+class BureauAccount(Account):
+    """Account entry associated with a specific credit bureau."""
+
+    bureau: Optional[str] = None
+    section: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'BureauAccount':
+        base = Account.from_dict(data)
+        return cls(
+            **base.to_dict(),
+            bureau=data.get('bureau'),
+            section=data.get('section'),
+        )
+
+    def to_dict(self) -> Dict:
+        d = super().to_dict()
+        d.update({"bureau": self.bureau, "section": self.section})
+        return d
+
+
+@dataclass
+class BureauSection:
+    """Collection of accounts belonging to a report section."""
+
+    name: str
+    accounts: List[BureauAccount] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, name: str, data: List[Dict]) -> 'BureauSection':
+        return cls(name=name, accounts=[BureauAccount.from_dict(d) for d in data])
+
+    def to_dict(self) -> Dict:
+        return {self.name: [acc.to_dict() for acc in self.accounts]}
+

--- a/models/letter.py
+++ b/models/letter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+from .account import Inquiry
+
+
+@dataclass
+class LetterAccount:
+    """Account block in the final dispute letter."""
+
+    name: str
+    account_number: str
+    status: str
+    paragraph: Optional[str] = None
+    requested_action: Optional[str] = None
+    personal_note: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'LetterAccount':
+        return cls(
+            name=data.get('name', ''),
+            account_number=data.get('account_number', ''),
+            status=data.get('status', ''),
+            paragraph=data.get('paragraph'),
+            requested_action=data.get('requested_action'),
+            personal_note=data.get('personal_note'),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class LetterContext:
+    """Structured information needed to render a letter."""
+
+    client_name: str = ''
+    client_address_lines: List[str] = field(default_factory=list)
+    bureau_name: str = ''
+    bureau_address: str = ''
+    date: str = ''
+    opening_paragraph: str = ''
+    accounts: List[LetterAccount] = field(default_factory=list)
+    inquiries: List[Inquiry] = field(default_factory=list)
+    closing_paragraph: str = ''
+    is_identity_theft: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'LetterContext':
+        return cls(
+            client_name=data.get('client_name', ''),
+            client_address_lines=list(data.get('client_address_lines', []) or []),
+            bureau_name=data.get('bureau_name', ''),
+            bureau_address=data.get('bureau_address', ''),
+            date=data.get('date', ''),
+            opening_paragraph=data.get('opening_paragraph', ''),
+            accounts=[LetterAccount.from_dict(a) for a in data.get('accounts', [])],
+            inquiries=[Inquiry.from_dict(i) for i in data.get('inquiries', [])],
+            closing_paragraph=data.get('closing_paragraph', ''),
+            is_identity_theft=bool(data.get('is_identity_theft', False)),
+        )
+
+    def to_dict(self) -> Dict:
+        d = asdict(self)
+        d['accounts'] = [a.to_dict() for a in self.accounts]
+        d['inquiries'] = [i.to_dict() for i in self.inquiries]
+        return d
+
+
+@dataclass
+class LetterArtifact:
+    """Rendered artifacts for a letter."""
+
+    html: str
+    pdf_path: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'LetterArtifact':
+        return cls(html=data.get('html', ''), pdf_path=data.get('pdf_path'))
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+

--- a/models/strategy.py
+++ b/models/strategy.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Recommendation:
+    """Strategist recommendation details."""
+
+    action_tag: Optional[str] = None
+    recommended_action: Optional[str] = None
+    advisor_comment: Optional[str] = None
+    flags: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'Recommendation':
+        return cls(
+            action_tag=data.get('action_tag'),
+            recommended_action=data.get('recommended_action'),
+            advisor_comment=data.get('advisor_comment'),
+            flags=list(data.get('flags', []) or []),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class StrategyItem:
+    """Strategy recommendation for a single account."""
+
+    account_id: str
+    name: str
+    account_number: Optional[str] = None
+    recommendation: Recommendation | None = None
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'StrategyItem':
+        return cls(
+            account_id=str(data.get('account_id') or ''),
+            name=data.get('name', ''),
+            account_number=data.get('account_number'),
+            recommendation=Recommendation.from_dict(data) if data else None,
+        )
+
+    def to_dict(self) -> Dict:
+        base = asdict(self)
+        if self.recommendation is not None:
+            base['recommendation'] = self.recommendation.to_dict()
+        return base
+
+
+@dataclass
+class StrategyPlan:
+    """Container for all strategy recommendations."""
+
+    accounts: List[StrategyItem] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'StrategyPlan':
+        accounts = [StrategyItem.from_dict(d) for d in data.get('accounts', [])]
+        return cls(accounts=accounts)
+
+    def to_dict(self) -> Dict:
+        return {'accounts': [item.to_dict() for item in self.accounts]}
+

--- a/tests/golden_letter.html
+++ b/tests/golden_letter.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dispute Letter - Experian</title>
+    <style>
+        body {
+            font-family: "DejaVu Sans", Arial, sans-serif;
+            font-size: 12pt;
+            line-height: 1.6;
+            margin: 50px;
+            color: #000;
+        }
+
+        h1 {
+            font-size: 16pt;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 5px;
+            margin-bottom: 15px;
+        }
+
+        .section {
+            margin-bottom: 30px;
+        }
+
+        .account-block {
+            background: #f0f7ff;
+            padding: 12px 15px;
+            margin-bottom: 15px;
+            border-left: 5px solid #2e5b9c;
+        }
+
+        .inquiry-block {
+            background: #fefefe;
+            padding: 10px;
+            border-left: 3px solid #888;
+            margin-bottom: 10px;
+        }
+
+        .id-theft-warning {
+            background-color: #fff3cd;
+            padding: 15px;
+            border-left: 5px solid #d39e00;
+            margin-top: 30px;
+        }
+
+        .signature {
+            margin-top: 60px;
+            padding-top: 20px;
+            border-top: 1px dashed #aaa;
+        }
+
+        .legal-footer {
+            font-size: 10pt;
+            margin-top: 30px;
+            color: #333;
+        }
+        ul {
+            margin: 5px 0 15px 20px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="section">
+    <p><strong>John Doe</strong><br>123 Main St<br>Town, ST 12345</p>
+    <p>January 1, 2024</p>
+    <p><strong>To:</strong> Experian<br>Address</p>
+</div>
+
+<div class="section">
+    <p>To whom it may concern,</p>
+    <p>I dispute the following accounts</p>
+</div>
+
+
+<div class="section">
+    <h1>Disputed Accounts</h1>
+    
+        <div class="account-block">
+            <strong>Account:</strong> ABC Bank<br>
+            <strong>Account #:</strong> 1234<br>
+            <strong>Reported Status:</strong> Late<br>
+            
+              <p>Please delete</p>
+            
+            
+              <p><strong>Requested Action:</strong> Delete</p>
+            
+            
+        </div>
+    
+</div>
+
+
+
+<div class="section">
+    <h1>Unauthorized Inquiries</h1>
+    
+        <div class="inquiry-block">
+            <strong>Creditor:</strong> XYZ Bank<br>
+            <strong>Date:</strong> 2020-01-01
+        </div>
+    
+</div>
+
+
+
+
+<div class="section">
+    <p>Thank you</p>
+    <p>Please respond in writing within 30 days, as required by the Fair Credit Reporting Act (FCRA).</p>
+    <p>Thank you for your prompt attention to this matter.</p>
+    <p>
+        To assist with the verification process, I have included a copy of my government-issued photo ID and proof of address.
+        
+    </p>
+</div>
+
+<div class="signature">
+    <p>Sincerely,<br><strong>John Doe</strong></p>
+    <p style="margin-top: 40px;">__________________________<br>Signature</p>
+</div>
+
+<div class="legal-footer">
+    <p>According to the Fair Credit Reporting Act (FCRA), you are required to complete your investigation within 30 days of receipt of this letter and provide the results in writing. Please confirm all actions taken.</p>
+</div>
+
+</body>
+</html>

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models.account import Account, Inquiry
+from models.letter import LetterContext
+from logic.letter_rendering import render_dispute_letter_html
+
+
+class FakeAI:
+    class Choice:
+        class Message:
+            def __init__(self, content):
+                self.content = content
+
+        def __init__(self, content):
+            self.message = FakeAI.Choice.Message(content)
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def chat_completion(self, **kwargs):
+        return type('Resp', (), {'choices': [FakeAI.Choice(self.payload)]})
+
+
+def test_dispute_flow_golden(monkeypatch):
+    import types, sys
+    sys.modules['fitz'] = types.ModuleType('fitz')
+    sys.modules['pymupdf'] = types.ModuleType('pymupdf')
+    from logic.gpt_prompting import call_gpt_dispute_letter
+    from logic.compliance_pipeline import run_compliance_pipeline
+
+    payload = """{\n  \"opening_paragraph\": \"I dispute the following accounts\",\n  \"accounts\": [{\n    \"name\": \"ABC Bank\",\n    \"account_number\": \"1234\",\n    \"status\": \"Late\",\n    \"paragraph\": \"Please delete\",\n    \"requested_action\": \"Delete\"\n  }],\n  \"inquiries\": [{\n    \"creditor_name\": \"XYZ Bank\",\n    \"date\": \"2020-01-01\"\n  }],\n  \"closing_paragraph\": \"Thank you\"\n}"""
+    fake_ai = FakeAI(payload)
+    ctx = call_gpt_dispute_letter(
+        {},
+        'Experian',
+        [Account(name='ABC Bank', account_id='1', account_number='1234', reported_status='Late')],
+        [Inquiry(creditor_name='XYZ Bank', date='2020-01-01')],
+        False,
+        {},
+        'CA',
+        ai_client=fake_ai,
+    )
+    ctx.client_name = 'John Doe'
+    ctx.client_address_lines = ['123 Main St', 'Town, ST 12345']
+    ctx.bureau_name = 'Experian'
+    ctx.bureau_address = 'Address'
+    ctx.date = 'January 1, 2024'
+    artifact = render_dispute_letter_html(ctx)
+    monkeypatch.setattr(
+        'logic.compliance_pipeline.fix_draft_with_guardrails',
+        lambda *a, **k: None,
+    )
+    run_compliance_pipeline(artifact, 'CA', 'sess', 'dispute')
+    html = artifact.html
+    expected = Path('tests/golden_letter.html').read_text()
+    assert html == expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from models.account import Account, Inquiry, LateHistory
+from models.bureau import BureauSection, BureauAccount
+from models.strategy import StrategyPlan, StrategyItem, Recommendation
+from models.letter import LetterContext, LetterAccount, LetterArtifact
+
+
+def test_account_roundtrip():
+    data = {
+        'account_id': '1',
+        'name': 'ABC Bank',
+        'account_number': '1234',
+        'reported_status': 'Open',
+        'flags': ['x'],
+        'extra': 'y',
+    }
+    acc = Account.from_dict(data)
+    assert acc.name == 'ABC Bank'
+    back = acc.to_dict()
+    assert back['account_id'] == '1'
+    assert back['extra'] == 'y'
+
+
+def test_inquiry_roundtrip():
+    data = {'creditor_name': 'XYZ', 'date': '2020-01-01', 'bureau': 'Experian'}
+    obj = Inquiry.from_dict(data)
+    assert obj.to_dict() == data
+
+
+def test_letter_context_roundtrip():
+    ctx = LetterContext(
+        client_name='John',
+        client_address_lines=['1 St'],
+        bureau_name='Experian',
+        bureau_address='Addr',
+        date='Today',
+        opening_paragraph='Op',
+        accounts=[LetterAccount(name='A', account_number='1', status='Open')],
+        inquiries=[Inquiry(creditor_name='B', date='2020-01-01')],
+        closing_paragraph='Bye',
+        is_identity_theft=False,
+    )
+    assert LetterContext.from_dict(ctx.to_dict()) == ctx


### PR DESCRIPTION
## Summary
- define dataclass models for accounts, bureaus, strategies and letters with dict interop helpers
- migrate dispute letter pipeline to these models across prompting, compliance and rendering
- add golden test and model round-trip tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961c32dda4832eaf62841899bb89b8