### PR TITLE
Export per-account trace breakdown files

### DIFF
--- a/orchestrators.py
+++ b/orchestrators.py
@@ -420,6 +420,7 @@ def run_credit_repair_process(
 
     audit = create_audit_logger(session_id)
     ai_client = build_ai_client(app_config.ai)
+    strategy = None
 
     try:
         print("\n✅ Starting Credit Repair Process (B2C Mode)...")
@@ -464,9 +465,15 @@ def run_credit_repair_process(
         if today_folder:
             audit.save(today_folder)
             if app_config.export_trace_file:
-                from trace_exporter import export_trace_file
+                from trace_exporter import export_trace_file, export_trace_breakdown
 
                 export_trace_file(audit, session_id)
+                export_trace_breakdown(
+                    audit,
+                    strategy,
+                    strategy.get("accounts") if isinstance(strategy, dict) else getattr(strategy, "accounts", None),
+                    Path("client_output"),
+                )
         if pdf_path and os.path.exists(pdf_path):
             try:
                 os.remove(pdf_path)

--- a/tests/test_trace_breakdown_exporter.py
+++ b/tests/test_trace_breakdown_exporter.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+from audit import AuditLogger
+from logic.constants import FallbackReason
+from trace_exporter import export_trace_breakdown
+
+
+def _build_sample_audit() -> AuditLogger:
+    audit = AuditLogger()
+    audit.data["session_id"] = "sess1"
+    audit.log_account(
+        "1",
+        {
+            "stage": "strategy_decision",
+            "action": "dispute",
+            "recommended_action": "Dispute",
+            "reason": "Incorrect info",
+        },
+    )
+    audit.log_account(
+        "1",
+        {
+            "stage": "strategy_fallback",
+            "fallback_reason": FallbackReason.UNRECOGNIZED_TAG.value,
+            "strategist_action": "remove",
+        },
+    )
+    return audit
+
+
+def _build_strategy() -> dict:
+    return {
+        "accounts": [
+            {
+                "account_id": "1",
+                "name": "Acct 1",
+                "recommendation": {
+                    "action_tag": "dispute",
+                    "recommended_action": "Dispute",
+                    "advisor_comment": "Incorrect info",
+                },
+            }
+        ]
+    }
+
+
+def test_export_trace_breakdown_files_exist(tmp_path: Path) -> None:
+    audit = _build_sample_audit()
+    strategy = _build_strategy()
+    export_trace_breakdown(audit, strategy, strategy["accounts"], tmp_path)
+
+    base = tmp_path / audit.data["session_id"] / "trace"
+    names = {
+        "strategist_raw_output.json",
+        "strategy_decision.json",
+        "fallback_reason.json",
+        "recommendation_summary.json",
+    }
+    for name in names:
+        file_path = base / name
+        assert file_path.exists(), f"missing {name}"
+        data = json.loads(file_path.read_text())
+        assert data["session_id"] == "sess1"
+        assert "run_date" in data
+        assert "1" in data.get("accounts", {})
+
+
+def test_export_trace_breakdown_strategy_vs_fallback_consistency(tmp_path: Path) -> None:
+    audit = _build_sample_audit()
+    strategy = _build_strategy()
+    export_trace_breakdown(audit, strategy, strategy["accounts"], tmp_path)
+
+    base = tmp_path / audit.data["session_id"] / "trace"
+    decisions = json.loads((base / "strategy_decision.json").read_text())
+    fallbacks = json.loads((base / "fallback_reason.json").read_text())
+
+    assert decisions["accounts"]["1"]["source"] == "fallback"
+    assert "1" in fallbacks["accounts"]

--- a/trace_exporter.py
+++ b/trace_exporter.py
@@ -1,6 +1,9 @@
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
+
+from models.strategy import StrategyPlan
 
 
 def export_trace_file(audit: Any, session_id: str) -> Path:
@@ -93,4 +96,132 @@ def export_trace_file(audit: Any, session_id: str) -> Path:
         json.dump(trace, f, indent=2)
     return trace_path
 
-__all__ = ["export_trace_file"]
+def export_trace_breakdown(
+    audit: Any, strategy: Any, accounts: Any, output_dir: Path | str
+) -> None:
+    """Export per-account trace breakdown files.
+
+    Parameters
+    ----------
+    audit: AuditLogger or dict
+        Audit logger containing per-account logs.
+    strategy: StrategyPlan or mapping
+        Raw strategist plan prior to fallback handling.
+    accounts: iterable
+        Final accounts considered in the run. Only used to determine
+        which account IDs to include.
+    output_dir: Path or str
+        Base output directory (e.g. ``client_output``).
+    """
+
+    data: Dict[str, Any] = audit.data if hasattr(audit, "data") else audit
+    session_id = data.get("session_id", "session")
+    run_date = datetime.now().strftime("%Y-%m-%d")
+
+    trace_folder = Path(output_dir) / session_id / "trace"
+    trace_folder.mkdir(parents=True, exist_ok=True)
+
+    # Normalize strategist plan
+    plan = StrategyPlan.from_dict(strategy) if isinstance(strategy, dict) else strategy
+    raw_accounts: Dict[str, Any] = {}
+    if plan is not None:
+        for item in getattr(plan, "accounts", []):
+            acc_id = str(getattr(item, "account_id", "") or "")
+            rec = getattr(item, "recommendation", None)
+            raw_accounts[acc_id] = rec.to_dict() if rec else {}
+
+    with (trace_folder / "strategist_raw_output.json").open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "run_date": run_date,
+                "session_id": session_id,
+                "accounts": raw_accounts,
+            },
+            f,
+            indent=2,
+        )
+
+    # Build decision and fallback maps
+    decision_map: Dict[str, Dict[str, Any]] = {}
+    fallback_map: Dict[str, Dict[str, Any]] = {}
+    summary_map: Dict[str, str] = {}
+
+    reason_text = {
+        "keyword_match": "Fallback dispute triggered by keywords",
+        "unrecognized_tag": "Strategist action unrecognized",
+        "no_recommendation": "No strategist recommendation provided",
+    }
+
+    acc_ids: list[str] = []
+    try:
+        for acc in accounts or []:
+            acc_id = str(getattr(acc, "account_id", None) or getattr(acc, "id", None) or acc.get("account_id") if isinstance(acc, dict) else "")
+            if acc_id:
+                acc_ids.append(acc_id)
+    except Exception:
+        pass
+    if not acc_ids:
+        acc_ids = list(data.get("accounts", {}).keys())
+
+    for acc_id in acc_ids:
+        entries = data.get("accounts", {}).get(str(acc_id), [])
+        decision_entry = next((e for e in entries if e.get("stage") == "strategy_decision"), None)
+        fallback_entry = next((e for e in entries if e.get("stage") == "strategy_fallback"), None)
+        if decision_entry:
+            decision_map[str(acc_id)] = {
+                "action_tag": decision_entry.get("action"),
+                "recommended_action": decision_entry.get("recommended_action"),
+                "source": "fallback" if fallback_entry else "strategist",
+            }
+            summary = decision_entry.get("reason") or ""
+            if not summary and fallback_entry:
+                summary = reason_text.get(fallback_entry.get("fallback_reason"), "")
+            summary_map[str(acc_id)] = summary
+        if fallback_entry:
+            fb: Dict[str, Any] = {
+                "fallback_reason": fallback_entry.get("fallback_reason"),
+            }
+            if fallback_entry.get("failure_reason"):
+                fb["failure_reason"] = fallback_entry.get("failure_reason")
+            if fallback_entry.get("strategist_action"):
+                fb["strategist_action"] = fallback_entry.get("strategist_action")
+            fb["summary"] = reason_text.get(fallback_entry.get("fallback_reason"), "")
+            fallback_map[str(acc_id)] = fb
+
+    with (trace_folder / "strategy_decision.json").open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "run_date": run_date,
+                "session_id": session_id,
+                "accounts": decision_map,
+            },
+            f,
+            indent=2,
+        )
+
+    with (trace_folder / "fallback_reason.json").open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "run_date": run_date,
+                "session_id": session_id,
+                "accounts": fallback_map,
+            },
+            f,
+            indent=2,
+        )
+
+    with (trace_folder / "recommendation_summary.json").open(
+        "w", encoding="utf-8"
+    ) as f:
+        json.dump(
+            {
+                "run_date": run_date,
+                "session_id": session_id,
+                "accounts": summary_map,
+            },
+            f,
+            indent=2,
+        )
+
+
+__all__ = ["export_trace_file", "export_trace_breakdown"]


### PR DESCRIPTION
## Summary
- add export_trace_breakdown to write per-account strategist, decision, and fallback trace JSONs
- invoke detailed trace export at end of run_credit_repair_process
- test per-account trace file creation and consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689621f44120832eb4cc0588b1247148