### PR TITLE
docs: scaffold architecture docs and CI check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains a simplified demo of a credit repair automation flow used for testing.
 
+## Documentation
+
+- [System Overview](docs/SYSTEM_OVERVIEW.md)
+- [Module Guide](docs/MODULE_GUIDE.md)
+- [Data Models](docs/DATA_MODELS.md)
+- [Contributing](docs/CONTRIBUTING.md)
+
 ## Environment
 
 All backend components read configuration from a `.env` file on startup via

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+## Pull Request Checklist
+- Update architecture and model docs when public APIs or data models change.
+- Run all tests: `pytest -q` and frontend checks if touched.
+- Ensure linting passes.
+- Run type checking on Python code where available.

--- a/docs/DATA_MODELS.md
+++ b/docs/DATA_MODELS.md
@@ -1,0 +1,83 @@
+# Data Models
+
+This document summarizes dataclasses under `models/` and their relationships.
+
+## account.py
+
+### `LateHistory`
+- `date: str`
+- `status: str`
+
+### `Inquiry`
+- `creditor_name: str`
+- `date: str`
+- `bureau: Optional[str]`
+
+### `Account`
+- `account_id: Optional[str]`
+- `name: str`
+- `account_number: Optional[str]`
+- `reported_status: Optional[str]`
+- `status: Optional[str]`
+- `dispute_type: Optional[str]`
+- `advisor_comment: Optional[str]`
+- `action_tag: Optional[str]`
+- `recommended_action: Optional[str]`
+- `flags: List[str]`
+- `extras: Dict[str, object]`
+
+## bureau.py
+
+### `BureauAccount`
+- extends `Account`
+- `bureau: Optional[str]`
+- `section: Optional[str]`
+
+### `BureauSection`
+- `name: str`
+- `accounts: List[BureauAccount]`
+
+## letter.py
+
+### `LetterAccount`
+- `name: str`
+- `account_number: str`
+- `status: str`
+- `paragraph: Optional[str]`
+- `requested_action: Optional[str]`
+- `personal_note: Optional[str]`
+
+### `LetterContext`
+- `client_name: str`
+- `client_address_lines: List[str]`
+- `bureau_name: str`
+- `bureau_address: str`
+- `date: str`
+- `opening_paragraph: str`
+- `accounts: List[LetterAccount]`
+- `inquiries: List[Inquiry]`
+- `closing_paragraph: str`
+- `is_identity_theft: bool`
+
+### `LetterArtifact`
+- `html: str`
+- `pdf_path: Optional[str]`
+
+## strategy.py
+
+### `Recommendation`
+- `action_tag: Optional[str]`
+- `recommended_action: Optional[str]`
+- `advisor_comment: Optional[str]`
+- `flags: List[str]`
+
+### `StrategyItem`
+- `account_id: str`
+- `name: str`
+- `account_number: Optional[str]`
+- `recommendation: Recommendation | None`
+
+### `StrategyPlan`
+- `accounts: List[StrategyItem]`
+
+All models expose `from_dict()` and `to_dict()` helpers for conversion to and from plain dictionaries.

--- a/docs/MODULE_GUIDE.md
+++ b/docs/MODULE_GUIDE.md
@@ -1,0 +1,9 @@
+# Module Guide
+
+| Module | Role | Public API | Key Dependencies |
+| ------ | ---- | ---------- | ---------------- |
+| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `process_client_intake`, `classify_client_responses`, `analyze_credit_report`, `generate_strategy_plan` | `logic.*`, `session_manager`, `analytics_tracker` |
+| `models/` | Dataclasses representing accounts, bureaus, letters and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
+| `logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
+| `services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |
+| `templates/` | Jinja2 letter templates rendered into HTML/PDF. | N/A – consumed by letter generation code | `Jinja2`, `logic.utils.pdf_ops` |

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -1,0 +1,13 @@
+# System Overview
+
+This document outlines the high-level architecture of the credit repair pipeline.
+
+The orchestrators module (`orchestrators.py`) serves as the single entry point for the backend.  It coordinates the following phases:
+
+1. **Intake** – `process_client_intake` collects client information and initial session state.
+2. **Analysis** – `analyze_credit_report` ingests the uploaded report and extracts bureau data.
+3. **Strategy** – `generate_strategy_plan` merges classification results and bureau findings into a plan.
+4. **Letters** – dedicated generators create dispute or goodwill letters.  Draft HTML passes through the compliance pipeline and the PDF renderer (`logic.compliance_pipeline`, `logic.utils.pdf_ops`) before returning artifacts.
+5. **Finalization** – orchestrators save artifacts, record analytics, and send notifications to finish the workflow.
+
+Compliance checks and PDF rendering live inside the `logic` package and are invoked during letter generation to ensure all outbound documents meet guardrails and are rendered to PDF.

--- a/tests/test_docs_updated.py
+++ b/tests/test_docs_updated.py
@@ -1,0 +1,42 @@
+import subprocess
+from pathlib import Path
+
+
+def _changed_files() -> set[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD^", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return set()
+    return {Path(p) for p in result.stdout.splitlines() if p}
+
+
+def test_model_docs_updated():
+    changed = _changed_files()
+    model_changed = any(p.parts and p.parts[0] == "models" and p.suffix == ".py" for p in changed)
+    if model_changed:
+        assert Path("docs/DATA_MODELS.md") in changed, (
+            "models/ changed without updating docs/DATA_MODELS.md"
+        )
+
+
+def test_system_overview_updated():
+    changed = _changed_files()
+    if Path("orchestrators.py") in changed:
+        diff = subprocess.run(
+            ["git", "diff", "HEAD^", "HEAD", "--", "orchestrators.py"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout
+        api_changed = any(
+            line.startswith("+def ") or line.startswith("-def ") for line in diff.splitlines()
+        )
+        if api_changed:
+            assert Path("docs/SYSTEM_OVERVIEW.md") in changed, (
+                "orchestrators.py public API changed without updating docs/SYSTEM_OVERVIEW.md"
+            )


### PR DESCRIPTION
## Summary
- add living architecture docs outlining pipeline and module roles
- document data models and contributing guidelines
- add CI test verifying docs updates for models and orchestrators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962a2ca8d4832eac232290087a7c03