### PR TITLE
refactor: isolate CLI from orchestrators

### DIFF
--- a/logic/bootstrap.py
+++ b/logic/bootstrap.py
@@ -1,0 +1,167 @@
+"""Bootstrap utilities shared across orchestration layers.
+
+These helpers are intentionally free of side effects so that they can be
+imported safely by both the CLI in ``main.py`` and the orchestration logic in
+``orchestrators.py``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+
+def get_current_month() -> str:
+    """Return the current month formatted as ``YYYY-MM``."""
+    return datetime.now().strftime("%Y-%m")
+
+
+def extract_all_accounts(sections: dict) -> List[dict]:
+    """Return a de-duplicated list of all accounts with source categories.
+
+    Accounts are considered the same only when key fields match. This prevents
+    different accounts from the same creditor from being merged together.
+    """
+    from datetime import datetime
+    import re
+    from logic.utils.names_normalization import normalize_creditor_name
+
+    def sanitize_number(num: str | None) -> str:
+        if not num:
+            return ""
+        digits = "".join(c for c in num if c.isdigit())
+        return digits[-4:] if len(digits) >= 4 else digits
+
+    def parse_date(date_str: str | None) -> datetime | None:
+        if not date_str:
+            return None
+        for fmt in ("%m/%d/%Y", "%m-%d-%Y", "%m.%d.%Y", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(date_str, fmt)
+            except Exception:  # pragma: no cover - safe fallback
+                continue
+        return None
+
+    accounts: list[dict] = []
+    categories = [
+        "negative_accounts",
+        "open_accounts_with_issues",
+        "high_utilization_accounts",
+        "positive_accounts",
+        "all_accounts",
+    ]
+
+    for key in categories:
+        for acc in sections.get(key, []):
+            acc_copy = acc.copy()
+            acc_copy.setdefault("categories", set()).add(key)
+
+            norm_name = normalize_creditor_name(acc_copy.get("name", "")).lower()
+            last4 = sanitize_number(acc_copy.get("account_number"))
+            bureaus = tuple(sorted(acc_copy.get("bureaus", [])))
+            status = (acc_copy.get("status") or "").strip().lower()
+            opened = parse_date(acc_copy.get("opened_date"))
+            closed = parse_date(acc_copy.get("closed_date"))
+
+            found = None
+            for existing in accounts:
+                if (
+                    normalize_creditor_name(existing.get("name", "")).lower() == norm_name
+                    and sanitize_number(existing.get("account_number")) == last4
+                    and tuple(sorted(existing.get("bureaus", []))) == bureaus
+                    and (existing.get("status") or "").strip().lower() == status
+                    and parse_date(existing.get("opened_date")) == opened
+                    and parse_date(existing.get("closed_date")) == closed
+                ):
+                    found = existing
+                    break
+
+            if found:
+                found.setdefault("categories", set()).add(key)
+            else:
+                accounts.append(acc_copy)
+
+    from difflib import SequenceMatcher
+
+    def _is_negative(acc: dict) -> bool:
+        cats = {c.lower() for c in acc.get("categories", [])}
+        status = str(acc.get("status") or acc.get("reported_status") or "").lower()
+        if "negative_accounts" in cats:
+            return True
+        return any(
+            kw in status
+            for kw in (
+                "chargeoff",
+                "charge-off",
+                "charge off",
+                "collection",
+                "repossession",
+                "repos",
+                "delinquent",
+                "late payments",
+            )
+        )
+
+    def _acct_suffix(num: str | None) -> str:
+        if not num:
+            return ""
+        digits = re.sub(r"\D", "", str(num))
+        return digits[-4:]
+
+    def _similar_name(a: str, b: str) -> bool:
+        n1 = normalize_creditor_name(a or "").lower()
+        n2 = normalize_creditor_name(b or "").lower()
+        if n1 == n2 or n1.startswith(n2) or n2.startswith(n1):
+            return True
+        return SequenceMatcher(None, n1, n2).ratio() >= 0.8
+
+    def _parse_amount(val: str | None) -> float | None:
+        if not val:
+            return None
+        clean = re.sub(r"[^0-9.]+", "", str(val))
+        try:
+            return float(clean)
+        except Exception:  # pragma: no cover - safe fallback
+            return None
+
+    def _potential_dupe(a: dict, b: dict) -> bool:
+        if not _similar_name(a.get("name"), b.get("name")):
+            return False
+
+        s1 = _acct_suffix(a.get("account_number"))
+        s2 = _acct_suffix(b.get("account_number"))
+        if s1 and s2 and s1 != s2:
+            return False
+
+        bal1 = _parse_amount(a.get("balance"))
+        bal2 = _parse_amount(b.get("balance"))
+        if bal1 is not None and bal2 is not None:
+            diff = abs(bal1 - bal2)
+            if diff > max(100, 0.1 * min(bal1, bal2)):
+                return False
+
+        d1 = parse_date(a.get("opened_date"))
+        d2 = parse_date(b.get("opened_date"))
+        if d1 and d2 and abs((d1 - d2).days) > 90:
+            return False
+        d1c = parse_date(a.get("closed_date"))
+        d2c = parse_date(b.get("closed_date"))
+        if d1c and d2c and abs((d1c - d2c).days) > 90:
+            return False
+
+        return True
+
+    dupe_indices: set[int] = set()
+    for i, acc_a in enumerate(accounts):
+        if not _is_negative(acc_a):
+            continue
+        for j in range(i + 1, len(accounts)):
+            acc_b = accounts[j]
+            if not _is_negative(acc_b):
+                continue
+            if _potential_dupe(acc_a, acc_b):
+                dupe_indices.update({i, j})
+
+    for idx in dupe_indices:
+        accounts[idx]["duplicate_suspect"] = True
+
+    return accounts

--- a/main.py
+++ b/main.py
@@ -1,169 +1,37 @@
-import logging
-from datetime import datetime
+"""Command line entry point for the credit repair workflow."""
+from __future__ import annotations
 
-from orchestrators import (
-    run_credit_repair_process,
-    extract_problematic_accounts_from_report,
-)
-from logic.strategy_merger import merge_strategy_data
+import argparse
+import logging
 
 logger = logging.getLogger(__name__)
 
 
-def get_current_month():
-    return datetime.now().strftime("%Y-%m")
+def main() -> None:
+    """Run the credit repair process using CLI arguments."""
+    parser = argparse.ArgumentParser(description="Run the credit repair workflow")
+    parser.add_argument("report", help="Path to the SmartCredit report PDF")
+    parser.add_argument("email", help="Client email address")
+    parser.add_argument("--goal", default="Not specified", help="Client goal")
+    parser.add_argument(
+        "--identity-theft",
+        action="store_true",
+        help="Flag the run as an identity theft case",
+    )
+    args = parser.parse_args()
+
+    from orchestrators import run_credit_repair_process
+
+    client_info = {
+        "name": "Unknown",
+        "address": "Unknown",
+        "email": args.email,
+        "goal": args.goal,
+        "session_id": "cli",
+    }
+    proofs_files = {"smartcredit_report": args.report}
+    run_credit_repair_process(client_info, proofs_files, args.identity_theft)
 
 
-def extract_all_accounts(sections: dict) -> list:
-    """Return a de-duplicated list of all accounts with source categories.
-
-    Accounts are considered the same only when key fields match. This prevents
-    different accounts from the same creditor from being merged together.
-    """
-
-    from datetime import datetime
-    import re
-    from logic.utils.names_normalization import normalize_creditor_name
-
-    def sanitize_number(num: str | None) -> str:
-        if not num:
-            return ""
-        digits = "".join(c for c in num if c.isdigit())
-        return digits[-4:] if len(digits) >= 4 else digits
-
-    def parse_date(date_str: str | None) -> datetime | None:
-        if not date_str:
-            return None
-        for fmt in ("%m/%d/%Y", "%m-%d-%Y", "%m.%d.%Y", "%Y-%m-%d"):
-            try:
-                return datetime.strptime(date_str, fmt)
-            except Exception:
-                continue
-        return None
-
-    accounts: list[dict] = []
-    categories = [
-        "negative_accounts",
-        "open_accounts_with_issues",
-        "high_utilization_accounts",
-        "positive_accounts",
-        "all_accounts",
-    ]
-
-    for key in categories:
-        for acc in sections.get(key, []):
-            acc_copy = acc.copy()
-            acc_copy.setdefault("categories", set()).add(key)
-
-            norm_name = normalize_creditor_name(acc_copy.get("name", "")).lower()
-            last4 = sanitize_number(acc_copy.get("account_number"))
-            bureaus = tuple(sorted(acc_copy.get("bureaus", [])))
-            status = (acc_copy.get("status") or "").strip().lower()
-            opened = parse_date(acc_copy.get("opened_date"))
-            closed = parse_date(acc_copy.get("closed_date"))
-
-            found = None
-            for existing in accounts:
-                if (
-                    normalize_creditor_name(existing.get("name", "")).lower() == norm_name
-                    and sanitize_number(existing.get("account_number")) == last4
-                    and tuple(sorted(existing.get("bureaus", []))) == bureaus
-                    and (existing.get("status") or "").strip().lower() == status
-                    and parse_date(existing.get("opened_date")) == opened
-                    and parse_date(existing.get("closed_date")) == closed
-                ):
-                    found = existing
-                    break
-
-            if found:
-                found.setdefault("categories", set()).add(key)
-            else:
-                accounts.append(acc_copy)
-
-    # Flag potential duplicate negatives across all bureaus
-    from difflib import SequenceMatcher
-
-    def _is_negative(acc: dict) -> bool:
-        cats = {c.lower() for c in acc.get("categories", [])}
-        status = str(acc.get("status") or acc.get("reported_status") or "").lower()
-        if "negative_accounts" in cats:
-            return True
-        return any(
-            kw in status
-            for kw in (
-                "chargeoff",
-                "charge-off",
-                "charge off",
-                "collection",
-                "repossession",
-                "repos",
-                "delinquent",
-                "late payments",
-            )
-        )
-
-    def _acct_suffix(num: str | None) -> str:
-        if not num:
-            return ""
-        digits = re.sub(r"\D", "", str(num))
-        return digits[-4:]
-
-    def _similar_name(a: str, b: str) -> bool:
-        n1 = normalize_creditor_name(a or "").lower()
-        n2 = normalize_creditor_name(b or "").lower()
-        if n1 == n2 or n1.startswith(n2) or n2.startswith(n1):
-            return True
-        return SequenceMatcher(None, n1, n2).ratio() >= 0.8
-
-    def _parse_amount(val: str | None) -> float | None:
-        if not val:
-            return None
-        clean = re.sub(r"[^0-9.]+", "", str(val))
-        try:
-            return float(clean)
-        except Exception:
-            return None
-
-    def _potential_dupe(a: dict, b: dict) -> bool:
-        if not _similar_name(a.get("name"), b.get("name")):
-            return False
-
-        s1 = _acct_suffix(a.get("account_number"))
-        s2 = _acct_suffix(b.get("account_number"))
-        if s1 and s2 and s1 != s2:
-            return False
-
-        bal1 = _parse_amount(a.get("balance"))
-        bal2 = _parse_amount(b.get("balance"))
-        if bal1 is not None and bal2 is not None:
-            diff = abs(bal1 - bal2)
-            if diff > max(100, 0.1 * min(bal1, bal2)):
-                return False
-
-        d1 = parse_date(a.get("opened_date"))
-        d2 = parse_date(b.get("opened_date"))
-        if d1 and d2 and abs((d1 - d2).days) > 90:
-            return False
-        d1c = parse_date(a.get("closed_date"))
-        d2c = parse_date(b.get("closed_date"))
-        if d1c and d2c and abs((d1c - d2c).days) > 90:
-            return False
-
-        return True
-
-    dupe_indices: set[int] = set()
-    for i, acc_a in enumerate(accounts):
-        if not _is_negative(acc_a):
-            continue
-        for j in range(i + 1, len(accounts)):
-            acc_b = accounts[j]
-            if not _is_negative(acc_b):
-                continue
-            if _potential_dupe(acc_a, acc_b):
-                dupe_indices.update({i, j})
-
-    for idx in dupe_indices:
-        accounts[idx]["duplicate_suspect"] = True
-
-    return accounts
-
+if __name__ == "__main__":  # pragma: no cover - CLI usage only
+    main()

--- a/orchestrators.py
+++ b/orchestrators.py
@@ -84,7 +84,7 @@ def analyze_credit_report(proofs_files, session_id, client_info, audit, log_mess
     from logic.upload_validator import is_safe_pdf, move_uploaded_file
     from session_manager import update_session
     from logic.analyze_report import analyze_credit_report as analyze_report_logic
-    from main import get_current_month
+    from logic.bootstrap import get_current_month
 
     uploaded_path = proofs_files.get("smartcredit_report")
     if not uploaded_path or not os.path.exists(uploaded_path):
@@ -154,7 +154,7 @@ def analyze_credit_report(proofs_files, session_id, client_info, audit, log_mess
 
 def generate_strategy_plan(client_info, bureau_data, classification_map, session_id, audit, log_messages, ai_client: AIClient | None = None):
     """Generate and merge the strategy plan."""
-    from main import merge_strategy_data
+    from logic.strategy_merger import merge_strategy_data
     from logic.generate_strategy_report import StrategyGenerator
 
     docs_text = gather_supporting_docs_text(session_id)
@@ -215,7 +215,7 @@ def generate_letters(
     app_config: AppConfig | None = None,
 ):
     """Create all client letters and supporting files."""
-    from main import extract_all_accounts
+    from logic.bootstrap import extract_all_accounts
     from logic.letter_generator import generate_all_dispute_letters_with_ai
     from logic.instructions_generator import generate_instruction_file
     from logic.generate_goodwill_letters import generate_goodwill_letters

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -39,3 +39,14 @@ def test_features_do_not_import_app() -> None:
     for file_path in features_dir.rglob("*.py"):
         imports = _imports(file_path)
         assert "app" not in imports, f"{file_path} imports app.py"
+
+
+def test_no_module_imports_main() -> None:
+    """Ensure core modules do not depend on the CLI layer."""
+    for file_path in PROJECT_ROOT.rglob("*.py"):
+        if file_path.name == "main.py" or "tests" in file_path.parts:
+            continue
+        imports = _imports(file_path)
+        assert "main" not in imports and not any(
+            name.startswith("main.") for name in imports
+        ), f"{file_path} imports main"

--- a/tests/test_audit_fallback_reasons.py
+++ b/tests/test_audit_fallback_reasons.py
@@ -33,7 +33,7 @@ def test_apply_fallback_tags_logs_keyword_match(tmp_path, monkeypatch):
 def test_merge_strategy_data_audit_reasons(tmp_path):
     import types
     sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
-    import main
+    from logic.strategy_merger import merge_strategy_data
 
     audit = create_audit_logger("test")
     strategy = StrategyPlan.from_dict(
@@ -57,7 +57,7 @@ def test_merge_strategy_data_audit_reasons(tmp_path):
     }
     classification_map = {}
     log_list = []
-    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, log_list)
+    merge_strategy_data(strategy, bureau_data, classification_map, audit, log_list)
     audit_file = audit.save(tmp_path)
     data = json.loads(audit_file.read_text())
     bad_logs = data["accounts"]["Bad Corp"]

--- a/tests/test_audit_fallback_tally.py
+++ b/tests/test_audit_fallback_tally.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from pathlib import Path
 
@@ -13,7 +12,7 @@ from models.strategy import StrategyPlan
 def test_tally_fallback_vs_decision(tmp_path):
     import types
     sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
-    import main
+    from logic.strategy_merger import merge_strategy_data
 
     audit = create_audit_logger("test")
     strategy = StrategyPlan.from_dict(
@@ -36,7 +35,7 @@ def test_tally_fallback_vs_decision(tmp_path):
         }
     }
     classification_map = {}
-    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
+    merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
 
     counts = tally_fallback_vs_decision(audit)
     assert counts["strategy_fallback"] == 2

--- a/tests/test_local_workflow.py
+++ b/tests/test_local_workflow.py
@@ -31,11 +31,11 @@ sys.modules.setdefault("fpdf", types.SimpleNamespace(FPDF=object))
 sys.modules.setdefault("pdfplumber", types.SimpleNamespace(open=lambda *_, **__: None))
 sys.modules.setdefault("fitz", types.SimpleNamespace(open=lambda *_, **__: None))
 
-from logic.letter_generator import generate_dispute_letters_for_all_bureaus
-from logic.generate_goodwill_letters import generate_goodwill_letters
-from logic.instructions_generator import generate_instruction_file
-import logic.instructions_generator as instructions_generator
-from tests.helpers.fake_ai_client import FakeAIClient
+from logic.letter_generator import generate_dispute_letters_for_all_bureaus  # noqa: E402
+from logic.generate_goodwill_letters import generate_goodwill_letters  # noqa: E402
+from logic.instructions_generator import generate_instruction_file  # noqa: E402
+import logic.instructions_generator as instructions_generator  # noqa: E402
+from tests.helpers.fake_ai_client import FakeAIClient  # noqa: E402
 
 
 def test_minimal_workflow():
@@ -169,7 +169,7 @@ def test_skip_goodwill_when_identity_theft():
             mock.patch("logic.utils.pdf_ops.convert_txts_to_pdfs"),
             mock.patch("orchestrators.send_email_with_attachment"),
             mock.patch("orchestrators.save_analytics_snapshot"),
-            mock.patch("main.extract_all_accounts", return_value=[]),
+            mock.patch("logic.bootstrap.extract_all_accounts", return_value=[]),
             mock.patch("logic.upload_validator.move_uploaded_file", return_value=Path(tmp.name)),
             mock.patch("logic.upload_validator.is_safe_pdf", return_value=True),
             mock.patch("orchestrators.save_log_file"),

--- a/tests/test_strategist_failure_tally.py
+++ b/tests/test_strategist_failure_tally.py
@@ -3,12 +3,12 @@ import types
 
 sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
 
-import main
-from audit import create_audit_logger
-from analytics.strategist_failures import tally_failure_reasons
-from logic.constants import StrategistFailureReason
-from models.account import Account
-from models.strategy import StrategyPlan
+from audit import create_audit_logger  # noqa: E402
+from analytics.strategist_failures import tally_failure_reasons  # noqa: E402
+from logic.constants import StrategistFailureReason  # noqa: E402
+from logic.strategy_merger import merge_strategy_data  # noqa: E402
+from models.account import Account  # noqa: E402
+from models.strategy import StrategyPlan  # noqa: E402
 
 
 def test_tally_failure_reasons():
@@ -34,7 +34,7 @@ def test_tally_failure_reasons():
         }
     }
 
-    main.merge_strategy_data(strategy, bureau_data, {}, audit, [])
+    merge_strategy_data(strategy, bureau_data, {}, audit, [])
 
     counts = tally_failure_reasons(audit)
 

--- a/tests/test_strategy_decision_logging.py
+++ b/tests/test_strategy_decision_logging.py
@@ -12,7 +12,7 @@ from models.strategy import StrategyPlan
 def test_strategy_decision_logged_for_all_accounts(tmp_path):
     import types
     sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
-    import main
+    from logic.strategy_merger import merge_strategy_data
 
     audit = create_audit_logger("test")
     strategy = StrategyPlan.from_dict(
@@ -36,7 +36,7 @@ def test_strategy_decision_logged_for_all_accounts(tmp_path):
         }
     }
     classification_map = {}
-    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
+    merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
     audit_file = audit.save(tmp_path)
     data = json.loads(audit_file.read_text())
 

--- a/tests/test_strategy_fallback_logging.py
+++ b/tests/test_strategy_fallback_logging.py
@@ -13,7 +13,7 @@ from models.strategy import StrategyPlan
 def test_strategy_fallback_logs_include_reason_and_override(tmp_path):
     import types
     sys.modules['pdfkit'] = types.SimpleNamespace(configuration=lambda **kwargs: None)
-    import main
+    from logic.strategy_merger import merge_strategy_data
 
     audit = create_audit_logger("test")
     strategy = StrategyPlan.from_dict(
@@ -34,7 +34,7 @@ def test_strategy_fallback_logs_include_reason_and_override(tmp_path):
         }
     }
     classification_map = {}
-    main.merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
+    merge_strategy_data(strategy, bureau_data, classification_map, audit, [])
     audit_file = audit.save(tmp_path)
     data = json.loads(audit_file.read_text())
 


### PR DESCRIPTION
## Summary
- move shared helpers into logic/bootstrap.py and drop orchestrators → main dependency
- slim main.py down to a CLI wrapper
- assert in architecture tests that no module imports main

## Testing
- `ruff check orchestrators.py logic/bootstrap.py main.py tests/test_audit_fallback_reasons.py tests/test_strategist_failure_tally.py tests/test_strategy_fallback_logging.py tests/test_strategy_decision_logging.py tests/test_audit_fallback_tally.py tests/test_local_workflow.py tests/test_architecture.py` *(fails: E501 line too long in orchestrators.py)*
- `black --check orchestrators.py logic/bootstrap.py main.py tests/test_audit_fallback_reasons.py tests/test_strategist_failure_tally.py tests/test_strategy_fallback_logging.py tests/test_strategy_decision_logging.py tests/test_audit_fallback_tally.py tests/test_local_workflow.py tests/test_architecture.py` *(fails: would reformat multiple files)*
- `mypy .` *(fails: No parent module -- cannot perform relative import in logic/generate_goodwill_letters.py)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963becee78832ebdb1545b3655d808