### PR TITLE
Avoid import-time AppConfig loading

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -17,8 +17,6 @@ from config import get_app_config
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
-ADMIN_PASSWORD = get_app_config().admin_password
-
 
 def is_authenticated():
     return session.get("admin_authenticated") is True
@@ -36,7 +34,8 @@ def require_login():
 def login():
     if request.method == "POST":
         password = request.form.get("password", "")
-        if ADMIN_PASSWORD and password == ADMIN_PASSWORD:
+        admin_password = get_app_config().admin_password
+        if admin_password and password == admin_password:
             session["admin_authenticated"] = True
             send_admin_login_alert(request.remote_addr)
             return redirect(url_for("admin.index"))

--- a/tasks.py
+++ b/tasks.py
@@ -16,19 +16,10 @@ from orchestrators import (
     run_credit_repair_process,
     extract_problematic_accounts_from_report,
 )
-from config import get_app_config
-
-_app_config = get_app_config()
-app = Celery(
-    "tasks",
-    broker=_app_config.celery_broker_url,
-    backend=_app_config.celery_broker_url,
-)
+app = Celery("tasks", loader="default", fixups=[])
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.info("Celery worker starting with OPENAI_BASE_URL=%s", _app_config.ai.base_url)
-logger.info("Celery worker OPENAI_API_KEY present=%s", bool(_app_config.ai.api_key))
 
 # Verify that session_manager is importable at startup. This helps catch
 # cases where the worker is launched from a directory that omits the

--- a/tests/test_api_summaries.py
+++ b/tests/test_api_summaries.py
@@ -15,7 +15,7 @@ def test_summaries_endpoint_returns_clean_data(monkeypatch):
         return Dummy()
 
     monkeypatch.setattr("pdfkit.configuration", fake_config)
-    app = importlib.import_module("app").app
+    app = importlib.import_module("app").create_app()
 
     session_id = "sess-summary"
     raw = {

--- a/tests/test_explanations_api.py
+++ b/tests/test_explanations_api.py
@@ -19,7 +19,7 @@ def test_explanations_endpoint_stores_raw_and_structured(monkeypatch):
     monkeypatch.setattr("pdfkit.configuration", fake_config)
 
     app_module = importlib.import_module("app")
-    app = app_module.app
+    app = app_module.create_app()
 
     def fake_extract(text, ctx):
         return {

--- a/tests/test_no_import_time_config.py
+++ b/tests/test_no_import_time_config.py
@@ -1,0 +1,70 @@
+import ast
+import importlib
+import os
+import sys
+from pathlib import Path
+
+MODULES = ["app", "tasks", "admin"]
+
+
+def has_import_time_get_app_config(path: Path) -> bool:
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for call in ast.walk(node):
+            if isinstance(call, ast.Call):
+                func = call.func
+                if isinstance(func, ast.Name) and func.id == "get_app_config":
+                    return True
+                if isinstance(func, ast.Attribute) and func.attr == "get_app_config":
+                    return True
+    return False
+
+
+def test_no_get_app_config_at_import_time():
+    offenders = []
+    for path in Path(".").rglob("*.py"):
+        if has_import_time_get_app_config(path):
+            offenders.append(str(path))
+    assert not offenders, f"get_app_config() used at import time in: {offenders}"
+
+
+class EnvGuard(dict):
+    def __getitem__(self, key):  # pragma: no cover - used for guarding
+        raise AssertionError(f"environment variable {key} accessed during import")
+
+    def get(self, key, default=None):  # pragma: no cover - used for guarding
+        raise AssertionError(f"environment variable {key} accessed during import")
+
+    def __contains__(self, key):  # pragma: no cover - used for guarding
+        raise AssertionError(f"environment variable {key} accessed during import")
+
+
+def import_fresh(module_name: str):
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    return importlib.import_module(module_name)
+
+
+def test_imports_do_not_load_app_config(monkeypatch):
+    monkeypatch.setattr(os, "environ", EnvGuard())
+    monkeypatch.setattr(
+        os,
+        "getenv",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("environment variable accessed")
+        ),
+    )
+    import config
+
+    monkeypatch.setattr(
+        config,
+        "get_app_config",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("get_app_config accessed")
+        ),
+    )
+
+    for mod in MODULES:
+        import_fresh(mod)


### PR DESCRIPTION
## Summary
- Refactor admin and task modules to remove get_app_config calls at import
- Rework app into a blueprint-based factory that loads config on demand
- Add tests guarding against import-time AppConfig access or environment reads

## Testing
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68964d53fd9c832eb0348b0129bea092