### PR TITLE
refactor: adopt typed models for public APIs

### DIFF
--- a/docs/DATA_MODELS.md
+++ b/docs/DATA_MODELS.md
@@ -37,6 +37,31 @@ This document summarizes dataclasses under `models/` and their relationships.
 - `name: str`
 - `accounts: List[BureauAccount]`
 
+### `BureauPayload`
+- `disputes: List[Account]`
+- `goodwill: List[Account]`
+- `inquiries: List[Inquiry]`
+- `high_utilization: List[Account]`
+
+## client.py
+
+### `ClientInfo`
+- `name: Optional[str]`
+- `legal_name: Optional[str]`
+- `address: Optional[str]`
+- `email: Optional[str]`
+- `state: Optional[str]`
+- `goal: Optional[str]`
+- `session_id: str`
+- `custom_dispute_notes: Optional[Dict[str, Any]]`
+- `structured_summaries: Any`
+- `account_inquiry_matches: Optional[List[Dict[str, Any]]]`
+- `extras: Dict[str, Any]`
+
+### `ProofDocuments`
+- `smartcredit_report: str`
+- `extras: Dict[str, Any]`
+
 ## letter.py
 
 ### `LetterAccount`

--- a/docs/MODULE_GUIDE.md
+++ b/docs/MODULE_GUIDE.md
@@ -2,8 +2,8 @@
 
 | Module | Role | Public API | Key Dependencies |
 | ------ | ---- | ---------- | ---------------- |
-| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `process_client_intake`, `classify_client_responses`, `analyze_credit_report`, `generate_strategy_plan` | `logic.*`, `session_manager`, `analytics_tracker` |
-| `models/` | Dataclasses representing accounts, bureaus, letters and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
+| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process` (uses `ClientInfo` and `ProofDocuments` models) | `logic.*`, `session_manager`, `analytics_tracker` |
+| `models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
 | `logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
 | `services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |
 | `templates/` | Jinja2 letter templates rendered into HTML/PDF. | N/A – consumed by letter generation code | `Jinja2`, `logic.utils.pdf_ops` |

--- a/main.py
+++ b/main.py
@@ -22,16 +22,19 @@ def main() -> None:
     args = parser.parse_args()
 
     from orchestrators import run_credit_repair_process
+    from models import ClientInfo, ProofDocuments
 
-    client_info = {
-        "name": "Unknown",
-        "address": "Unknown",
-        "email": args.email,
-        "goal": args.goal,
-        "session_id": "cli",
-    }
-    proofs_files = {"smartcredit_report": args.report}
-    run_credit_repair_process(client_info, proofs_files, args.identity_theft)
+    client = ClientInfo.from_dict(
+        {
+            "name": "Unknown",
+            "address": "Unknown",
+            "email": args.email,
+            "goal": args.goal,
+            "session_id": "cli",
+        }
+    )
+    proofs = ProofDocuments.from_dict({"smartcredit_report": args.report})
+    run_credit_repair_process(client, proofs, args.identity_theft)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI usage only

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,7 +1,8 @@
 """Typed data models for the finance platform."""
 
 from .account import Account, Inquiry, LateHistory, AccountId, AccountMap
-from .bureau import BureauSection, BureauAccount
+from .bureau import BureauSection, BureauAccount, BureauPayload
+from .client import ClientInfo, ProofDocuments
 from .strategy import StrategyPlan, StrategyItem, Recommendation
 from .letter import LetterContext, LetterAccount, LetterArtifact
 
@@ -13,10 +14,13 @@ __all__ = [
     "AccountMap",
     "BureauSection",
     "BureauAccount",
+    "BureauPayload",
     "StrategyPlan",
     "StrategyItem",
     "Recommendation",
     "LetterContext",
     "LetterAccount",
     "LetterArtifact",
+    "ClientInfo",
+    "ProofDocuments",
 ]

--- a/models/bureau.py
+++ b/models/bureau.py
@@ -1,9 +1,39 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict, Type
 
-from .account import Account
+from .account import Account, Inquiry
+
+
+@dataclass
+class BureauPayload:
+    """Structured data for a single bureau.
+
+    Replaces the previous free-form ``dict`` layout used across the codebase.
+    """
+
+    disputes: List[Account] = field(default_factory=list)
+    goodwill: List[Account] = field(default_factory=list)
+    inquiries: List[Inquiry] = field(default_factory=list)
+    high_utilization: List[Account] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls: Type["BureauPayload"], data: Dict[str, Any]) -> "BureauPayload":
+        return cls(
+            disputes=[Account.from_dict(d) if isinstance(d, dict) else d for d in data.get("disputes", [])],
+            goodwill=[Account.from_dict(d) if isinstance(d, dict) else d for d in data.get("goodwill", [])],
+            inquiries=[Inquiry.from_dict(i) if isinstance(i, dict) else i for i in data.get("inquiries", [])],
+            high_utilization=[Account.from_dict(d) if isinstance(d, dict) else d for d in data.get("high_utilization", [])],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "disputes": [a.to_dict() for a in self.disputes],
+            "goodwill": [a.to_dict() for a in self.goodwill],
+            "inquiries": [i.to_dict() for i in self.inquiries],
+            "high_utilization": [a.to_dict() for a in self.high_utilization],
+        }
 
 
 @dataclass

--- a/models/client.py
+++ b/models/client.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Type
+
+
+@dataclass
+class ClientInfo:
+    """Client metadata used across the workflow.
+
+    This model replaces the previous free-form ``dict`` usage. Additional
+    attributes are stored in ``extras``.
+    """
+
+    name: str | None = None
+    legal_name: str | None = None
+    address: str | None = None
+    email: str | None = None
+    state: str | None = None
+    goal: str | None = None
+    session_id: str = "session"
+    custom_dispute_notes: Dict[str, Any] | None = None
+    structured_summaries: Any = None
+    account_inquiry_matches: List[Dict[str, Any]] | None = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls: Type["ClientInfo"], data: Dict[str, Any]) -> "ClientInfo":
+        known_keys = {
+            "name",
+            "legal_name",
+            "address",
+            "email",
+            "state",
+            "goal",
+            "session_id",
+            "custom_dispute_notes",
+            "structured_summaries",
+            "account_inquiry_matches",
+        }
+        extras = {k: v for k, v in data.items() if k not in known_keys}
+        return cls(
+            name=data.get("name"),
+            legal_name=data.get("legal_name"),
+            address=data.get("address"),
+            email=data.get("email"),
+            state=data.get("state"),
+            goal=data.get("goal"),
+            session_id=data.get("session_id", "session"),
+            custom_dispute_notes=data.get("custom_dispute_notes"),
+            structured_summaries=data.get("structured_summaries"),
+            account_inquiry_matches=data.get("account_inquiry_matches"),
+            extras=extras,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        extras = data.pop("extras", {})
+        data.update(extras)
+        return {k: v for k, v in data.items() if v is not None}
+
+
+@dataclass
+class ProofDocuments:
+    """Paths to uploaded or generated proof documents."""
+
+    smartcredit_report: str
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls: Type["ProofDocuments"], data: Dict[str, Any]) -> "ProofDocuments":
+        known = {"smartcredit_report"}
+        extras = {k: v for k, v in data.items() if k not in known}
+        return cls(smartcredit_report=data.get("smartcredit_report", ""), extras=extras)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        extras = data.pop("extras", {})
+        data.update(extras)
+        return data

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -46,23 +46,28 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         monkeypatch.setattr(
             "logic.pdf_renderer.render_html_to_pdf", lambda html, path: None
         )
-        client_info = {"name": "Client", "session_id": "s1"}
+        from models import ClientInfo, BureauPayload
+
+        client = ClientInfo.from_dict({"name": "Client", "session_id": "s1"})
         bureau_data = {
-            "Experian": {
-                "disputes": [
-                    {
-                        "name": "Bank A",
-                        "account_number": "1",
-                        "account_id": "1",
-                        "action_tag": "dispute",
-                    }
-                ],
-                "inquiries": [],
-            }
+            "Experian": BureauPayload.from_dict(
+                {
+                    "disputes": [
+                        {
+                            "name": "Bank A",
+                            "account_number": "1",
+                            "account_id": "1",
+                            "action_tag": "dispute",
+                        }
+                    ],
+                    "inquiries": [],
+                }
+            )
         }
-        generate_all_dispute_letters_with_ai(
-            client_info, bureau_data, tmp_path, False, None, ai_client=FakeAIClient()
-        )
+        with pytest.warns(UserWarning):
+            generate_all_dispute_letters_with_ai(
+                client, bureau_data, tmp_path, False, None, ai_client=FakeAIClient()
+            )
     elif doc_type == "instructions":
         from logic.instructions_generator import generate_instruction_file
 
@@ -78,22 +83,26 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         monkeypatch.setattr(
             "logic.pdf_renderer.render_html_to_pdf", lambda html, path: None
         )
-        client_info = {"name": "Client", "session_id": "s2"}
+        from models import ClientInfo, BureauPayload
+
+        client = ClientInfo.from_dict({"name": "Client", "session_id": "s2"})
         bureau_data = {
-            "Experian": {
-                "all_accounts": [
-                    {
-                        "name": "Bank B",
-                        "status": "good",
-                        "action_tag": "positive",
-                    }
-                ],
-                "disputes": [],
-                "inquiries": [],
-            }
+            "Experian": BureauPayload.from_dict(
+                {
+                    "all_accounts": [
+                        {
+                            "name": "Bank B",
+                            "status": "good",
+                            "action_tag": "positive",
+                        }
+                    ],
+                    "disputes": [],
+                    "inquiries": [],
+                }
+            )
         }
         generate_instruction_file(
-            client_info, bureau_data, False, tmp_path / "inst", ai_client=FakeAIClient()
+            client, bureau_data, False, tmp_path / "inst", ai_client=FakeAIClient()
         )
     else:  # goodwill
         from logic.generate_goodwill_letters import generate_goodwill_letter_with_ai

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -89,9 +90,10 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     }
 
     fake = FakeAIClient()
-    generate_all_dispute_letters_with_ai(
-        client_info, bureau_data, tmp_path, False, None, ai_client=fake
-    )
+    with pytest.warns(UserWarning):
+        generate_all_dispute_letters_with_ai(
+            client_info, bureau_data, tmp_path, False, None, ai_client=fake
+        )
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)
     assert "SECRET RAW" not in json.dumps(data)

--- a/tests/test_local_workflow.py
+++ b/tests/test_local_workflow.py
@@ -155,14 +155,19 @@ def test_minimal_workflow():
 
         out_dir = Path("output/test_local")
         fake = FakeAIClient()
+        from models import ClientInfo, BureauPayload
+
+        client = ClientInfo.from_dict(client_info)
+        bureau_models = {k: BureauPayload.from_dict(v) for k, v in bureau_data.items()}
+
         generate_dispute_letters_for_all_bureaus(
-            client_info, bureau_data, out_dir, False, None, ai_client=fake
+            client, bureau_models, out_dir, False, None, ai_client=fake
         )
         generate_goodwill_letters(
-            client_info, bureau_data, out_dir, None, ai_client=fake
+            client, bureau_models, out_dir, None, ai_client=fake
         )
         generate_instruction_file(
-            client_info, bureau_data, False, out_dir, ai_client=fake
+            client, bureau_models, False, out_dir, ai_client=fake
         )
         context, accounts_list = instructions_generator.prepare_instruction_data(
             client_info,
@@ -193,13 +198,17 @@ def test_skip_goodwill_when_identity_theft():
     import tempfile
     from orchestrators import run_credit_repair_process
 
-    client_info = {
-        "name": "Jane Test",
-        "email": "jane@example.com",
-        "session_id": "test",
-    }
+    from models import ClientInfo, ProofDocuments
+
+    client_info = ClientInfo.from_dict(
+        {
+            "name": "Jane Test",
+            "email": "jane@example.com",
+            "session_id": "test",
+        }
+    )
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-        proofs = {"smartcredit_report": tmp.name}
+        proofs = ProofDocuments.from_dict({"smartcredit_report": tmp.name})
         with (
             mock.patch.dict(
                 os.environ,

--- a/tests/test_logic_fixes.py
+++ b/tests/test_logic_fixes.py
@@ -432,9 +432,10 @@ def test_letter_duplicate_accounts_removed():
 
         mock_d.side_effect = _cb
         fake = FakeAIClient()
-        generate_dispute_letters_for_all_bureaus(
-            {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
-        )
+        with pytest.warns(UserWarning):
+            generate_dispute_letters_for_all_bureaus(
+                {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
+            )
 
     assert len(sent.get("Experian", [])) == 2
     names = {d.name.lower() for d in sent["Experian"]}
@@ -492,9 +493,10 @@ def test_partial_account_number_deduplication():
 
         mock_d.side_effect = _cb
         fake = FakeAIClient()
-        generate_dispute_letters_for_all_bureaus(
-            {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
-        )
+        with pytest.warns(UserWarning):
+            generate_dispute_letters_for_all_bureaus(
+                {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
+            )
 
     assert len(sent.get("Experian", [])) == 1
     print("partial dedupe ok")


### PR DESCRIPTION
## Summary
- add ClientInfo, ProofDocuments, and BureauPayload dataclasses
- require typed models for orchestrator and letter/instruction generators
- update docs and tests to describe model-only public APIs

## Testing
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68965147ac48832e99e3b67fcd01e823