### PR TITLE
Return typed BureauPayload from problematic account extraction

### DIFF
--- a/docs/DATA_MODELS.md
+++ b/docs/DATA_MODELS.md
@@ -42,6 +42,7 @@ This document summarizes dataclasses under `models/` and their relationships.
 - `goodwill: List[Account]`
 - `inquiries: List[Inquiry]`
 - `high_utilization: List[Account]`
+- Returned by `extract_problematic_accounts_from_report` instead of a raw `dict`.
 
 ## client.py
 

--- a/docs/MODULE_GUIDE.md
+++ b/docs/MODULE_GUIDE.md
@@ -2,7 +2,7 @@
 
 | Module | Role | Public API | Key Dependencies |
 | ------ | ---- | ---------- | ---------------- |
-| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process` (uses `ClientInfo` and `ProofDocuments` models) | `logic.*`, `session_manager`, `analytics_tracker` |
+| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process`, `extract_problematic_accounts_from_report` → `BureauPayload` | `logic.*`, `session_manager`, `analytics_tracker` |
 | `models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
 | `logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
 | `services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -1,0 +1,48 @@
+import pytest
+from orchestrators import (
+    extract_problematic_accounts_from_report,
+    extract_problematic_accounts_from_report_dict,
+)
+from models import BureauPayload
+
+
+def _mock_dependencies(monkeypatch, sections):
+    monkeypatch.setattr(
+        "logic.upload_validator.move_uploaded_file", lambda path, session_id: path
+    )
+    monkeypatch.setattr("logic.upload_validator.is_safe_pdf", lambda path: True)
+    monkeypatch.setattr("session_manager.update_session", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "logic.analyze_report.analyze_credit_report", lambda *a, **k: sections
+    )
+
+
+def test_extract_problematic_accounts_returns_models(monkeypatch):
+    sections = {
+        "negative_accounts": [{"name": "Acc1"}],
+        "open_accounts_with_issues": [{"name": "Acc2"}],
+        "unauthorized_inquiries": [
+            {"creditor_name": "Bank", "date": "2024-01-01"}
+        ],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    payload = extract_problematic_accounts_from_report("dummy.pdf")
+    assert isinstance(payload, BureauPayload)
+    assert payload.disputes[0].name == "Acc1"
+    assert payload.goodwill[0].name == "Acc2"
+    assert payload.inquiries[0].creditor_name == "Bank"
+
+
+def test_extract_problematic_accounts_dict_adapter(monkeypatch):
+    sections = {
+        "negative_accounts": [{"name": "Acc1"}],
+        "open_accounts_with_issues": [{"name": "Acc2"}],
+        "unauthorized_inquiries": [
+            {"creditor_name": "Bank", "date": "2024-01-01"}
+        ],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    with pytest.deprecated_call():
+        result = extract_problematic_accounts_from_report_dict("dummy.pdf")
+    assert isinstance(result, dict)
+    assert result["negative_accounts"][0]["name"] == "Acc1"


### PR DESCRIPTION
## Summary
- return BureauPayload from `extract_problematic_accounts_from_report`
- add deprecated adapter for dict output and update Celery task
- document new return type and cover with tests

## Testing
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68965a883334832e9855b85c829c3e06