### PR TITLE
Add public dict-based API inventory

### DIFF
--- a/dict_api_inventory.json
+++ b/dict_api_inventory.json
@@ -1,0 +1,302 @@
+[
+  {
+    "module": "orchestrators.py",
+    "function": "extract_problematic_accounts_from_report_dict",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/bootstrap.py",
+    "function": "extract_all_accounts",
+    "signature": "param:sections",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/process_accounts.py",
+    "function": "load_analyzed_report",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/process_accounts.py",
+    "function": "process_analyzed_report",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/process_accounts.py",
+    "function": "save_bureau_outputs",
+    "signature": "param:output_data",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/instruction_renderer.py",
+    "function": "render_instruction_html",
+    "signature": "param:context",
+    "suggested_model": "LetterContext"
+  },
+  {
+    "module": "logic/instruction_renderer.py",
+    "function": "build_instruction_html",
+    "signature": "param:context",
+    "suggested_model": "LetterContext"
+  },
+  {
+    "module": "logic/generate_custom_letters.py",
+    "function": "call_gpt_for_custom_letter",
+    "signature": "param:structured_summary",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/generate_custom_letters.py",
+    "function": "generate_custom_letter",
+    "signature": "param:account",
+    "suggested_model": "Account"
+  },
+  {
+    "module": "logic/generate_custom_letters.py",
+    "function": "generate_custom_letter",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/generate_custom_letters.py",
+    "function": "generate_custom_letters",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/generate_custom_letters.py",
+    "function": "generate_custom_letters",
+    "signature": "param:bureau_data",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/generate_goodwill_letters.py",
+    "function": "generate_goodwill_letters",
+    "signature": "param:bureau_map",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/dispute_preparation.py",
+    "function": "prepare_disputes_and_inquiries",
+    "signature": "param:payload",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/dispute_preparation.py",
+    "function": "prepare_disputes_and_inquiries",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/report_parsing.py",
+    "function": "bureau_data_from_dict",
+    "signature": "param:data",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/report_parsing.py",
+    "function": "bureau_data_from_dict",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/instructions_generator.py",
+    "function": "generate_instruction_file",
+    "signature": "param:bureau_map",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/instruction_data_preparation.py",
+    "function": "generate_account_action",
+    "signature": "param:account",
+    "suggested_model": "Account"
+  },
+  {
+    "module": "logic/summary_classifier.py",
+    "function": "classify_client_summary",
+    "signature": "param:summary",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/summary_classifier.py",
+    "function": "classify_client_summary",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/letter_generator.py",
+    "function": "generate_all_dispute_letters_with_ai",
+    "signature": "param:bureau_map",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/compliance_adapter.py",
+    "function": "sanitize_disputes",
+    "signature": "param:strategy_summaries",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/compliance_adapter.py",
+    "function": "sanitize_client_info",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/compliance_adapter.py",
+    "function": "adapt_gpt_output",
+    "signature": "param:gpt_data",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/compliance_adapter.py",
+    "function": "adapt_gpt_output",
+    "signature": "param:acc_type_map",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/goodwill_rendering.py",
+    "function": "load_creditor_address_map",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/goodwill_rendering.py",
+    "function": "render_goodwill_letter",
+    "signature": "param:gpt_data",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/goodwill_rendering.py",
+    "function": "render_goodwill_letter",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/report_postprocessing.py",
+    "function": "validate_analysis_sanity",
+    "signature": "param:analysis",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/strategy_merger.py",
+    "function": "merge_strategy_outputs",
+    "signature": "param:bureau_data_obj",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/strategy_merger.py",
+    "function": "handle_strategy_fallbacks",
+    "signature": "param:bureau_data_obj",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/strategy_merger.py",
+    "function": "handle_strategy_fallbacks",
+    "signature": "param:classification_map",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/strategy_merger.py",
+    "function": "merge_strategy_data",
+    "signature": "param:bureau_data_obj",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/strategy_merger.py",
+    "function": "merge_strategy_data",
+    "signature": "param:classification_map",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/rules_loader.py",
+    "function": "load_neutral_phrases",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/rules_loader.py",
+    "function": "load_state_rules",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/extract_info.py",
+    "function": "extract_bureau_info_column_refined",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/gpt_prompting.py",
+    "function": "call_gpt_dispute_letter",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/gpt_prompting.py",
+    "function": "call_gpt_dispute_letter",
+    "signature": "param:structured_summaries",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/goodwill_preparation.py",
+    "function": "select_goodwill_candidates",
+    "signature": "param:client_info",
+    "suggested_model": "ClientInfo"
+  },
+  {
+    "module": "logic/goodwill_preparation.py",
+    "function": "select_goodwill_candidates",
+    "signature": "param:bureau_data",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/goodwill_preparation.py",
+    "function": "select_goodwill_candidates",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/guardrails.py",
+    "function": "generate_letter_with_guardrails",
+    "signature": "param:context",
+    "suggested_model": "LetterContext"
+  },
+  {
+    "module": "logic/guardrails.py",
+    "function": "fix_draft_with_guardrails",
+    "signature": "param:context",
+    "suggested_model": "LetterContext"
+  },
+  {
+    "module": "logic/explanations_normalizer.py",
+    "function": "extract_structured",
+    "signature": "param:account_ctx",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/explanations_normalizer.py",
+    "function": "extract_structured",
+    "signature": "return",
+    "suggested_model": "?"
+  },
+  {
+    "module": "logic/rule_checker.py",
+    "function": "check_letter",
+    "signature": "param:context",
+    "suggested_model": "LetterContext"
+  },
+  {
+    "module": "logic/strategy_engine.py",
+    "function": "generate_strategy",
+    "signature": "param:bureau_data",
+    "suggested_model": "BureauPayload"
+  },
+  {
+    "module": "logic/strategy_engine.py",
+    "function": "generate_strategy",
+    "signature": "return",
+    "suggested_model": "?"
+  }
+]

--- a/scripts/scan_public_dict_apis.py
+++ b/scripts/scan_public_dict_apis.py
@@ -1,0 +1,68 @@
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+TARGETS = [
+    BASE_DIR / "orchestrators.py",
+]
+TARGETS += list((BASE_DIR / "logic").glob("*.py"))
+
+SUGGESTIONS = {
+    "client_info": "ClientInfo",
+    "client": "ClientInfo",
+    "proofs_files": "ProofDocuments",
+    "account": "Account",
+    "acc": "Account",
+    "accounts": "Account",
+    "bureau_data": "BureauPayload",
+    "bureau_map": "BureauPayload",
+    "payload": "BureauPayload",
+    "strategy": "StrategyItem",
+    "context": "LetterContext",
+    "artifact": "LetterArtifact",
+}
+
+results: list[dict[str, Any]] = []
+
+for path in TARGETS:
+    mod = path.relative_to(BASE_DIR).as_posix()
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_"):
+            func = node.name
+            # parameters
+            for arg in node.args.args + node.args.kwonlyargs:
+                ann = arg.annotation
+                if ann is None:
+                    continue
+                if isinstance(ann, ast.Subscript):
+                    base = ann.value
+                else:
+                    base = ann
+                if isinstance(base, ast.Name) and base.id in {"dict", "Dict"}:
+                    suggested = SUGGESTIONS.get(arg.arg, "?")
+                    results.append({
+                        "module": mod,
+                        "function": func,
+                        "signature": f"param:{arg.arg}",
+                        "suggested_model": suggested,
+                    })
+            # return annotation
+            if node.returns:
+                ret = node.returns
+                base = ret.value if isinstance(ret, ast.Subscript) else ret
+                if isinstance(base, ast.Name) and base.id in {"dict", "Dict"}:
+                    results.append({
+                        "module": mod,
+                        "function": func,
+                        "signature": "return",
+                        "suggested_model": "?",
+                    })
+
+outfile = BASE_DIR / "dict_api_inventory.json"
+outfile.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+print(json.dumps(results, indent=2))


### PR DESCRIPTION
## Summary
- script to scan orchestrators and logic modules for public dict signatures
- generated JSON inventory of dict-typed parameters and returns

## Testing
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68965e19b824832e8dde607e7ca27093