### PR TITLE
feat: fail build on public dict APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for your interest in improving this project.
 - Follow PEP8 for Python code.
 - Use 2-space indentation for frontend JavaScript/React files.
 - Include tests for any new feature or bug fix.
+- Public function signatures must use typed models instead of raw ``dict`` values.
 
 ## Development Workflow
 1. Fork the repository and create your changes on a new branch.

--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -4,4 +4,5 @@ set -euo pipefail
 ruff check tests/test_architecture.py
 black --check tests/test_architecture.py
 mypy models
+python scripts/scan_public_dict_apis.py
 pytest -q

--- a/tests/test_no_public_dict_api.py
+++ b/tests/test_no_public_dict_api.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+# Modules that are allowed to expose raw dicts.
+# These are explicit edge adapters such as the HTTP app or CLI layers.
+ALLOWLIST_PREFIXES = ("app.py", "app/", "cli/")
+
+def test_no_public_dict_api() -> None:
+    inventory = Path(__file__).resolve().parent.parent / "dict_api_inventory.json"
+    data = json.loads(inventory.read_text())
+    offenders = [
+        entry
+        for entry in data
+        if not any(entry["module"].startswith(prefix) for prefix in ALLOWLIST_PREFIXES)
+    ]
+    assert not offenders, (
+        "Public APIs should use typed models instead of dicts: "
+        + ", ".join(f"{o['module']}::{o['function']}" for o in offenders)
+    )


### PR DESCRIPTION
## Summary
- add test guarding against dict usage in public APIs
- run dict API scanner before pytest
- document typed models requirement for public signatures

## Testing
- `scripts/run_checks.sh` *(fails: Public APIs should use typed models instead of dicts)*

------
https://chatgpt.com/codex/tasks/task_e_68966142adc0832ebdce6aafe157fa3d