### PR TITLE
feat(frontend): configure API base URL via env var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ npm install
 npm run dev
 ```
 
-The development server runs at `http://localhost:5173` and expects the backend to be available at `http://localhost:5000`.
+The development server runs at `http://localhost:5173`. Configure the backend base URL via the `VITE_API_BASE_URL` environment variable (e.g., `http://localhost:5000`).
 
 ## Building for Production
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'http://localhost:5000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
 
 export async function startProcess(email, file) {
   const formData = new FormData();


### PR DESCRIPTION
## Summary
- replace hardcoded API URL with environment-driven `VITE_API_BASE_URL`
- document `VITE_API_BASE_URL` in frontend README

## Testing
- `pre-commit run --files frontend/README.md frontend/src/api.js`
- `npm test`
- `npm run lint` *(fails: 'jest' globals not defined)*
- `npx eslint src/api.js`

------
https://chatgpt.com/codex/tasks/task_b_689a104b50c08327b966339156308d7a