### PR TITLE
Handle identity theft workflow edge cases

### DIFF
--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -87,8 +87,20 @@ def generate_goodwill_letters(
     run_date: str | None = None,
     *,
     ai_client: AIClient,
+    identity_theft: bool = False,
 ) -> None:
-    """Generate goodwill letters for all eligible creditors in ``bureau_data``."""
+    """Generate goodwill letters for all eligible creditors in ``bureau_data``.
+
+    Parameters
+    ----------
+    identity_theft:
+        When ``True`` the function returns immediately without generating any
+        letters.  This mirrors the higher level orchestration logic and acts as
+        a defensive guard should callers invoke this helper directly.
+    """
+
+    if identity_theft:
+        return
 
     if isinstance(client, dict):  # pragma: no cover - backward compat
         client = ClientInfo.from_dict(client)

--- a/logic/instruction_data_preparation.py
+++ b/logic/instruction_data_preparation.py
@@ -167,6 +167,15 @@ def prepare_instruction_data(
 
     all_accounts = list({id(v): v for v in deduped.values()}.values())
 
+    # Remove goodwill-only items entirely if this is an identity theft case.
+    if is_identity_theft:
+        all_accounts = [
+            acc
+            for acc in all_accounts
+            if str(acc.get("action_tag", "")).lower() != "goodwill"
+            and str(acc.get("recommended_action", "")).lower() != "goodwill"
+        ]
+
     has_dupes = any(acc.get("duplicate_suspect") for acc in all_accounts)
 
     sections: Dict[str, List[dict]] = {
@@ -235,7 +244,7 @@ def prepare_instruction_data(
         letters = []
         if action_tag.lower() == "dispute":
             letters.append("Dispute")
-        if action_tag.lower() == "goodwill":
+        if action_tag.lower() == "goodwill" and not is_identity_theft:
             letters.append("Goodwill")
         if acc.get("letter_type") == "custom" or action_tag.lower() == "custom_letter":
             letters.append("Custom")


### PR DESCRIPTION
## Summary
- Guard goodwill orchestration with an `identity_theft` flag to make the function a no-op when needed
- Strip goodwill actions from instruction data when identity theft is reported so the instructions and letters align

## Testing
- `pytest -q --disable-warnings`
- `pytest tests/test_local_workflow.py::test_skip_goodwill_when_identity_theft -q`


------
https://chatgpt.com/codex/tasks/task_b_689a29249b1c83278e145ef43b3c217d