### PR TITLE
cleanup: remove legacy upload-time fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Goodwill letters are only generated for late-payment accounts that are not in co
 
 A React-based client is available in the `frontend/` directory for uploading PDF credit reports and tracking processing status.
 
+### Upload step inputs
+
+Only two fields are accepted when starting the process:
+
+- **email** (optional)
+- **file** – the credit report PDF
+
 ### Running the frontend
 
 ```bash

--- a/docs/DATA_MODELS.md
+++ b/docs/DATA_MODELS.md
@@ -54,7 +54,6 @@ This document summarizes dataclasses under `models/` and their relationships.
 - `state: Optional[str]`
 - `goal: Optional[str]`
 - `session_id: str`
-- `custom_dispute_notes: Optional[Dict[str, Any]]`
 - `structured_summaries: Any`
 - `account_inquiry_matches: Optional[List[Dict[str, Any]]]`
 - `extras: Dict[str, Any]`

--- a/docs/POST_REFACTOR_AUDIT.md
+++ b/docs/POST_REFACTOR_AUDIT.md
@@ -112,7 +112,6 @@ graph TD
     logic_instruction_data_preparation_prepare_instruction_data --> logic_extract_info_extract_clean_name
     logic_instruction_data_preparation_prepare_instruction_data --> logic_process_accounts_get
     logic_instruction_data_preparation_prepare_instruction_data --> logic_utils_names_normalization_normalize_creditor_name
-    logic_instruction_data_preparation_prepare_instruction_data --> logic_utils_note_handling_analyze_custom_notes
     logic_instruction_renderer_build_account_lines --> logic_process_accounts_get
     logic_instruction_renderer_build_instruction_html --> logic_process_accounts_get
     logic_instruction_renderer_build_table --> logic_process_accounts_get

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -11,8 +11,8 @@ export default function UploadPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!email || !file) {
-      setError('Please provide an email and PDF file.');
+    if (!file) {
+      setError('Please provide a PDF file.');
       return;
     }
     setUploading(true);
@@ -33,17 +33,18 @@ export default function UploadPage() {
       <h2>Upload Credit Report</h2>
       <form onSubmit={handleSubmit}>
         <div>
-          <label>Email:</label>
+          <label htmlFor="email">Email:</label>
           <input
+            id="email"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            required
           />
         </div>
         <div>
-          <label>PDF File:</label>
+          <label htmlFor="file">PDF File:</label>
           <input
+            id="file"
             type="file"
             accept="application/pdf"
             onChange={(e) => setFile(e.target.files[0])}

--- a/frontend/src/pages/UploadPage.test.jsx
+++ b/frontend/src/pages/UploadPage.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UploadPage from './UploadPage';
+
+jest.mock('../api', () => ({ startProcess: jest.fn() }));
+
+describe('UploadPage', () => {
+  test('only renders email and PDF file inputs', () => {
+    render(
+      <MemoryRouter>
+        <UploadPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/PDF File/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/story/i)).toBeNull();
+    expect(screen.queryByLabelText(/note/i)).toBeNull();
+  });
+});

--- a/logic/compliance_adapter.py
+++ b/logic/compliance_adapter.py
@@ -109,18 +109,10 @@ def sanitize_client_info(
 ) -> Tuple[dict, bool]:
     """Remove raw client notes to maintain compliance."""
 
-    raw_client_text_present = bool(client_info.get("custom_dispute_notes"))
-    if raw_client_text_present:
-        warnings.warn(
-            f"[PolicyViolation] Raw client notes provided for {bureau_name}; sanitized.",
-            stacklevel=2,
-        )
-        log_messages.append(f"[{bureau_name}] Raw client notes sanitized")
     client_info_for_gpt = (
         client_info.to_dict() if isinstance(client_info, ClientInfo) else dict(client_info)
     )
-    client_info_for_gpt.pop("custom_dispute_notes", None)
-    return client_info_for_gpt, raw_client_text_present
+    return client_info_for_gpt, False
 
 
 def adapt_gpt_output(

--- a/logic/generate_goodwill_letters.py
+++ b/logic/generate_goodwill_letters.py
@@ -58,9 +58,8 @@ def generate_goodwill_letter_with_ai(
         client_info.get("legal_name") or client_info.get("name", "Your Name"),
         creditor,
         account_summaries,
-        client_info.get("story"),
-        client_info.get("tone", "neutral"),
-        session_id,
+        tone=client_info.get("tone", "neutral"),
+        session_id=session_id,
         ai_client=ai_client,
         audit=audit,
     )

--- a/logic/goodwill_prompting.py
+++ b/logic/goodwill_prompting.py
@@ -16,7 +16,6 @@ def generate_goodwill_letter_draft(
     client_name: str,
     creditor: str,
     account_summaries: List[Dict[str, Any]],
-    personal_story: str | None = None,
     tone: str = "neutral",
     session_id: str | None = None,
     *,
@@ -30,9 +29,6 @@ def generate_goodwill_letter_draft(
     included in the prompt.
     """
 
-    story_text = (
-        f"\nClient's personal story: {personal_story}" if personal_story else ""
-    )
     docs_text, doc_names, _ = gather_supporting_docs(session_id or "")
     if docs_text:
         if audit and audit.level is AuditLevel.VERBOSE:
@@ -61,7 +57,6 @@ Creditor: {creditor}
 Client name: {client_name}
 Accounts: {json.dumps(account_summaries, indent=2)}
 Supporting doc names: {', '.join(doc_names) if doc_names else 'None'}
-{story_text}
 {docs_section}
 
 Return strictly valid JSON: all property names and strings in double quotes, no trailing commas or comments, and no text outside the JSON.

--- a/logic/utils/note_handling.py
+++ b/logic/utils/note_handling.py
@@ -4,43 +4,6 @@ from __future__ import annotations
 
 import re
 
-from .names_normalization import normalize_creditor_name
-
-HARDSHIP_RE = re.compile(
-    r"(lost my job|job loss|layoff|medical|illness|hospital|covid|pandemic|family emergency|divorce|funeral|death in|financial hardship|hardship|sick)",
-    re.I,
-)
-
-
-def is_general_hardship_note(text: str | None) -> bool:
-    """Return True if the note appears to be a general hardship explanation."""
-    if not text:
-        return False
-    return bool(HARDSHIP_RE.search(text.strip().lower()))
-
-
-def analyze_custom_notes(custom_notes: dict, account_names: list[str]):
-    """Separate account-specific notes from general hardship notes.
-
-    Returns a tuple ``(specific_notes, general_notes)`` where ``specific_notes``
-    is a mapping of normalized account names to notes.
-    """
-
-    normalized_accounts = {normalize_creditor_name(n) for n in account_names}
-    specific: dict[str, str] = {}
-    general: list[str] = []
-
-    for key, note in (custom_notes or {}).items():
-        if not note:
-            continue
-        key_norm = normalize_creditor_name(key)
-        if key_norm in normalized_accounts and not is_general_hardship_note(note):
-            specific[key_norm] = note.strip()
-        else:
-            general.append(str(note).strip())
-
-    return specific, general
-
 
 def get_client_address_lines(client_info: dict) -> list[str]:
     """Return client's mailing address lines.

--- a/models/client.py
+++ b/models/client.py
@@ -19,7 +19,6 @@ class ClientInfo:
     state: str | None = None
     goal: str | None = None
     session_id: str = "session"
-    custom_dispute_notes: Dict[str, Any] | None = None
     structured_summaries: Any = None
     account_inquiry_matches: List[Dict[str, Any]] | None = None
     extras: Dict[str, Any] = field(default_factory=dict)
@@ -34,7 +33,6 @@ class ClientInfo:
             "state",
             "goal",
             "session_id",
-            "custom_dispute_notes",
             "structured_summaries",
             "account_inquiry_matches",
         }
@@ -47,7 +45,6 @@ class ClientInfo:
             state=data.get("state"),
             goal=data.get("goal"),
             session_id=data.get("session_id", "session"),
-            custom_dispute_notes=data.get("custom_dispute_notes"),
             structured_summaries=data.get("structured_summaries"),
             account_inquiry_matches=data.get("account_inquiry_matches"),
             extras=extras,

--- a/tasks.py
+++ b/tasks.py
@@ -101,9 +101,6 @@ def process_report(
                 "email": email,
                 "goal": goal,
                 "session_id": session_id,
-                # Raw client notes are intentionally excluded from the processing
-                # pipeline to prevent leakage into generated letters.
-                "custom_dispute_notes": {},
                 "structured_summaries": structured_summaries or {},
             }
         )

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -55,7 +55,6 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
     client_info = {
         "name": "Test Client",
         "session_id": "sess1",
-        "custom_dispute_notes": {"Bank A": "raw note ABCXYZ"},
     }
 
     bureau_data = {
@@ -82,8 +81,6 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)
     assert data["accounts"][0]["paragraph"] == DEFAULT_DISPUTE_REASON
-    assert "ABCXYZ" not in data["accounts"][0]["paragraph"]
 
     out, _ = capsys.readouterr()
     assert "fallback_used=True" in out
-    assert "raw_client_text_present=True" in out

--- a/tests/test_logging_edge_cases.py
+++ b/tests/test_logging_edge_cases.py
@@ -61,7 +61,6 @@ def test_warning_on_raw_client_text(monkeypatch, tmp_path, recwarn):
     client_info = {
         "name": "Client",
         "session_id": session_id,
-        "custom_dispute_notes": {"Bank A": "very sensitive info"},
     }
     bureau_data = {
         "Experian": {
@@ -76,7 +75,6 @@ def test_warning_on_raw_client_text(monkeypatch, tmp_path, recwarn):
     generate_all_dispute_letters_with_ai(
         client_info, bureau_data, tmp_path, False, None, ai_client=fake
     )
-    assert any("[PolicyViolation]" in str(w.message) for w in recwarn)
 
 
 def test_warning_on_missing_summary(monkeypatch, tmp_path, recwarn):

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -81,7 +81,6 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     client_info = {
         "name": "Test Client",
         "session_id": session_id,
-        "custom_dispute_notes": {"Bank A": "I am furious and heartbroken"},
     }
     bureau_data = {
         "Experian": {
@@ -122,7 +121,6 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
         client_name,
         creditor,
         accounts,
-        personal_story=None,
         tone="neutral",
         session_id=None,
         structured_summaries=None,
@@ -130,7 +128,6 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
         audit=None,
         ai_client=None,
     ):
-        assert "devastated" not in (personal_story or "")
         return {
             "intro_paragraph": "Intro",
             "hardship_paragraph": "Hardship",
@@ -156,7 +153,6 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
     client_info = {
         "name": "Test Client",
         "session_id": session_id,
-        "custom_dispute_notes": {"Creditor": "I am devastated and angry"},
     }
     accounts = [{"name": "Creditor", "account_number": "1", "action_tag": "goodwill"}]
 

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -1,0 +1,47 @@
+import io
+import json
+import pytest
+
+import app as app_module
+from app import create_app
+
+
+class DummyResult:
+    def get(self, timeout=None):
+        return {}
+
+
+def test_start_process_success(monkeypatch, tmp_path):
+    class DummyTask:
+        def delay(self, *a, **k):
+            return DummyResult()
+
+    monkeypatch.setattr(app_module, 'extract_problematic_accounts', DummyTask())
+    called = {}
+
+    def fake_run(client, proofs, flag):
+        called['called'] = True
+
+    monkeypatch.setattr(app_module, 'run_credit_repair_process', fake_run)
+
+    test_app = create_app()
+    client = test_app.test_client()
+    data = {
+        'email': 'a@example.com',
+        'file': (io.BytesIO(b'%PDF-1.4'), 'test.pdf'),
+    }
+    resp = client.post('/api/start-process', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    payload = json.loads(resp.data)
+    assert payload['status'] == 'ok'
+    assert called.get('called')
+
+
+def test_start_process_missing_file():
+    test_app = create_app()
+    client = test_app.test_client()
+    resp = client.post('/api/start-process', data={}, content_type='multipart/form-data')
+    assert resp.status_code == 400
+    payload = json.loads(resp.data)
+    assert 'Missing file' in payload['message']
+

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -4,10 +4,7 @@ from logic.utils.names_normalization import (
     normalize_bureau_name,
     normalize_creditor_name,
 )
-from logic.utils.note_handling import (
-    analyze_custom_notes,
-    get_client_address_lines,
-)
+from logic.utils.note_handling import get_client_address_lines
 from logic.utils.file_paths import safe_filename
 from logic.utils.text_parsing import has_late_indicator
 from logic.utils.inquiries import extract_inquiries
@@ -19,9 +16,6 @@ def test_utils_smoke(tmp_path: Path):
     assert normalize_bureau_name("tu") == "TransUnion"
     assert safe_filename("a:b") == "a_b"
 
-    notes, _ = analyze_custom_notes({"Cap One": "note"}, ["Cap One"])
-    norm_name = normalize_creditor_name("Cap One")
-    assert notes[norm_name] == "note"
     assert get_client_address_lines({"address": "123 A St, Town"})
 
     assert has_late_indicator({"status": "30 days late"})


### PR DESCRIPTION
## Summary
- drop legacy intake fields and streamline `/api/start-process` to only handle optional email and required PDF upload
- strip story/custom note support across models and goodwill prompting
- document minimal upload inputs and add tests for the reduced flow

## Testing
- `OPENAI_API_KEY=dummy pytest -q`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `npm --prefix frontend run dev`

------
https://chatgpt.com/codex/tasks/task_b_689a85da77a08325bca1f1748d811f65