### PR TITLE
refactor: centralize asset paths

### DIFF
--- a/backend/api/session_manager.py
+++ b/backend/api/session_manager.py
@@ -3,15 +3,17 @@ import os
 import threading
 from typing import Any, Dict
 
+from backend.assets.paths import data_path
+
 
 # Standard session data that can be safely accessed by most modules.
-SESSION_FILE = os.path.join("data", "sessions.json")
+SESSION_FILE = data_path("sessions.json")
 _lock = threading.Lock()
 
 # Dedicated storage for intake-only information such as the raw client
 # explanations. These values should never be exposed to downstream
 # components like the letter generator.
-INTAKE_FILE = os.path.join("data", "intake_only.json")
+INTAKE_FILE = data_path("intake_only.json")
 _intake_lock = threading.Lock()
 
 

--- a/backend/assets/paths.py
+++ b/backend/assets/paths.py
@@ -1,0 +1,32 @@
+"""Helper functions for resolving asset paths.
+
+This module centralizes path construction for assets bundled with the
+application.  Using these helpers avoids hard-coding relative paths
+throughout the codebase.
+"""
+
+from pathlib import Path
+
+
+ASSETS_ROOT = Path(__file__).parent
+
+
+def templates_path(name: str) -> str:
+    """Return the absolute path to a template asset."""
+    return str(ASSETS_ROOT / "templates" / name)
+
+
+def data_path(name: str) -> str:
+    """Return the absolute path to a data asset."""
+    return str(ASSETS_ROOT / "data" / name)
+
+
+def fonts_path(name: str) -> str:
+    """Return the absolute path to a font asset."""
+    return str(ASSETS_ROOT / "fonts" / name)
+
+
+def static_path(name: str) -> str:
+    """Return the absolute path to a static asset."""
+    return str(ASSETS_ROOT / "static" / name)
+

--- a/backend/core/logic/generate_custom_letters.py
+++ b/backend/core/logic/generate_custom_letters.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import Any, Mapping
 from jinja2 import Environment, FileSystemLoader
+from backend.assets.paths import templates_path
 import pdfkit
 from backend.core.logic.utils.pdf_ops import gather_supporting_docs
 from .summary_classifier import classify_client_summary
@@ -21,7 +22,7 @@ from backend.core.models.account import Account
 from backend.core.models.client import ClientInfo
 from backend.core.models.bureau import BureauPayload
 
-env = Environment(loader=FileSystemLoader("templates"))
+env = Environment(loader=FileSystemLoader(templates_path("")))
 template = env.get_template("general_letter_template.html")
 
 

--- a/backend/core/logic/goodwill_rendering.py
+++ b/backend/core/logic/goodwill_rendering.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from backend.audit.audit import AuditLogger, AuditLevel
 from backend.core.services.ai_client import AIClient
+from backend.assets.paths import data_path
 
 from backend.core.logic.pdf_renderer import (
     ensure_template_env,
@@ -29,7 +30,7 @@ _template = ensure_template_env().get_template("goodwill_letter_template.html")
 def load_creditor_address_map() -> Mapping[str, str]:
     """Load a mapping of normalized creditor names to addresses."""
     try:
-        with open("data/creditor_addresses.json", encoding="utf-8") as f:
+        with open(data_path("creditor_addresses.json"), encoding="utf-8") as f:
             raw = json.load(f)
             if isinstance(raw, list):
                 return {

--- a/backend/core/logic/instruction_renderer.py
+++ b/backend/core/logic/instruction_renderer.py
@@ -12,11 +12,12 @@ import random
 from typing import Any
 from backend.core.logic import pdf_renderer
 from backend.core.models.letter import LetterContext
+from backend.assets.paths import templates_path
 
 
 def render_instruction_html(context: LetterContext | dict[str, Any]) -> str:
     """Render the Jinja2 template with the provided context."""
-    env = pdf_renderer.ensure_template_env("templates")
+    env = pdf_renderer.ensure_template_env(templates_path(""))
     template = env.get_template("instruction_template.html")
     return template.render(**context)
 

--- a/backend/core/logic/instructions_generator.py
+++ b/backend/core/logic/instructions_generator.py
@@ -19,11 +19,12 @@ from backend.core.logic.instruction_renderer import build_instruction_html
 from backend.core.logic import pdf_renderer
 from backend.core.logic.compliance_pipeline import run_compliance_pipeline
 from backend.core.models import ClientInfo, BureauPayload
+from backend.assets.paths import templates_path
 
 
 def get_logo_base64() -> str:
     """Return the Credit Impact logo encoded as a base64 data URI."""
-    logo_path = Path("templates/Logo_CreditImpact.png")
+    logo_path = Path(templates_path("Logo_CreditImpact.png"))
     if logo_path.exists():
         with open(logo_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("ascii")

--- a/backend/core/logic/letter_rendering.py
+++ b/backend/core/logic/letter_rendering.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from backend.core.logic import pdf_renderer
 from backend.core.models.letter import LetterContext, LetterArtifact
+from backend.assets.paths import templates_path
 
 
 def render_dispute_letter_html(context: LetterContext) -> LetterArtifact:
     """Render the dispute letter HTML using the Jinja template."""
 
-    env = pdf_renderer.ensure_template_env("templates")
+    env = pdf_renderer.ensure_template_env(templates_path(""))
     template = env.get_template("dispute_letter_template.html")
     html = template.render(**context.to_dict())
     return LetterArtifact(html=html)

--- a/backend/core/logic/outcomes_store.py
+++ b/backend/core/logic/outcomes_store.py
@@ -4,7 +4,9 @@ import threading
 from datetime import datetime, UTC
 from typing import Dict, List, Optional
 
-OUTCOMES_FILE = os.path.join("data", "outcomes.json")
+from backend.assets.paths import data_path
+
+OUTCOMES_FILE = data_path("outcomes.json")
 _lock = threading.Lock()
 
 

--- a/backend/core/logic/pdf_renderer.py
+++ b/backend/core/logic/pdf_renderer.py
@@ -7,6 +7,7 @@ import pdfkit
 from jinja2 import Environment, FileSystemLoader
 
 from backend.api.config import get_app_config
+from backend.assets.paths import templates_path
 
 _template_env: Environment | None = None
 
@@ -17,7 +18,7 @@ def ensure_template_env(base_template_dir: Optional[str] = None) -> Environment:
     The environment is cached so multiple calls reuse the same loader.
     """
     global _template_env
-    base_dir = base_template_dir or "templates"
+    base_dir = base_template_dir or templates_path("")
     if (
         _template_env is None
         or getattr(_template_env.loader, "searchpath", [None])[0] != base_dir

--- a/backend/core/logic/utils/pdf_ops.py
+++ b/backend/core/logic/utils/pdf_ops.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from typing import Any, Iterable, List, Tuple
 
+from backend.assets.paths import fonts_path
+
 
 def convert_txts_to_pdfs(folder: Path):
     """
@@ -28,7 +30,7 @@ def convert_txts_to_pdfs(folder: Path):
         pdf = FPDF()
         pdf.add_page()
         # If you have a Unicode TTF, you can register it here. For now, use core font.
-        # pdf.add_font("DejaVu", "", "assets/fonts/DejaVuSans.ttf", uni=True)
+        # pdf.add_font("DejaVu", "", fonts_path("DejaVuSans.ttf"), uni=True)
         # pdf.set_font("DejaVu", size=12)
         pdf.set_font("Helvetica", size=12)
 

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -30,6 +30,7 @@ from backend.analytics.analytics.strategist_failures import tally_failure_reason
 from backend.core.email_sender import send_email_with_attachment
 from backend.core.services.ai_client import AIClient
 from backend.api.config import AppConfig, get_app_config
+from backend.assets.paths import templates_path
 from backend.core.models import (
     ClientInfo,
     ProofDocuments,
@@ -336,7 +337,7 @@ def generate_letters(
 
     if is_identity_theft:
         print("[INFO] Adding FCRA rights PDF...")
-        frca_source_path = "templates/FTC_FCRA_605b.pdf"
+        frca_source_path = templates_path("FTC_FCRA_605b.pdf")
         frca_target_path = today_folder / "Your Rights - FCRA.pdf"
         if os.path.exists(frca_source_path):
             copyfile(frca_source_path, frca_target_path)


### PR DESCRIPTION
## Summary
- add backend.assets.paths helper for asset directories
- replace hardcoded asset strings with helper functions across logic modules
- point template loaders and data stores to new backend/assets locations

## Testing
- `python - <<'PY'
from backend.assets.paths import templates_path, fonts_path, data_path
from pathlib import Path

paths = [
    ("template", templates_path("FTC_FCRA_605b.pdf")),
    ("font", fonts_path("DejaVuSans.ttf")),
    ("data", data_path("creditor_addresses.json")),
]
for kind, p_str in paths:
    p = Path(p_str)
    if p.exists():
        print(f"{kind} path resolved: {p}")
    else:
        print(f"Warning: {kind} path not found at {p}")
PY`
- `pytest -q` (fails: ModuleNotFoundError: No module named 'logic')

------
https://chatgpt.com/codex/tasks/task_b_689b7fc912308325bda4dc90d7bcf8e1