### PR TITLE
docs: refresh root README and update path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,46 @@
-# Credit Repair Cloud (Demo)
+# Finance Platform
 
-This repository contains a simplified demo of a credit repair automation flow used for testing.
+This project ingests a PDF credit report and optional email, analyzes the report, highlights issues with explanations, builds a strategy, and generates guardrail-compliant letters as HTML/PDF alongside audit logs.
 
-## Documentation
+## Project Structure
 
-- [System Overview](docs/SYSTEM_OVERVIEW.md)
-- [Module Guide](docs/MODULE_GUIDE.md)
-- [Data Models](docs/DATA_MODELS.md)
-- [Contributing](docs/CONTRIBUTING.md)
-
-## Environment
-
-All backend components read configuration from a `.env` file on startup via
-[python-dotenv](https://pypi.org/project/python-dotenv/). Provide
-`OPENAI_API_KEY` and optionally `OPENAI_BASE_URL` in this file. When
-`OPENAI_BASE_URL` is absent, the default `https://api.openai.com/v1` is used.
-The Flask server, Celery workers and any CLI scripts load this file
-automatically when they start.
-
-## AI JSON Handling
-
-OpenAI responses are parsed using a repair utility backed by the
-[`dirtyjson`](https://pypi.org/project/dirtyjson/) library. When the model
-returns nearly valid JSON (e.g., with trailing commas or single quotes), the
-utility attempts to clean it so processing can continue without manual
-intervention.
-
-## Action Tags
-
-Accounts may contain an `action_tag` field used to control which letters are generated. The allowed values are:
-
-- `dispute` – generate dispute letters for the bureaus
-- `goodwill` – create goodwill request letters to creditors
-- `custom_letter` – produce a one-off custom letter
-- `ignore` – no letters are generated
-
-`action_tag` is preferred over the older `recommended_action` field. When both are present, the tag takes priority.
-
-### Automatic Tagging
-
-Accounts with derogatory statuses are automatically tagged for dispute. Both `process_analyzed_report()` and `merge_strategy_data()` assign `action_tag: "dispute"` whenever the status text contains keywords such as "collection", "chargeoff"/"charge off", "repossession", "repos", "delinquent", or "late payments", or when a `dispute_type` is present. This prevents obvious dispute items from being skipped even if the strategist omits a tag.
-
-Goodwill letters are only generated for late-payment accounts that are not in collections, chargeoff, repossession, or other clearly derogatory statuses.
-
-## Frontend
-
-A React-based client is available in the `frontend/` directory for uploading PDF credit reports and tracking processing status.
-
-### Upload step inputs
-
-Only two fields are accepted when starting the process:
-
-- **email** (optional)
-- **file** – the credit report PDF
-
-### Running the frontend
-
-```bash
-cd frontend
-npm install
-npm run dev
+```
+backend/
+  api/
+  core/
+    logic/
+      report_analysis/
+      strategy/
+      letters/
+      rendering/
+      compliance/
+      utils/
+      guardrails/
+  analytics/
+  audit/
+  assets/
+    templates/
+    static/
+    fonts/
+    data/
+frontend/
+tools/
+scripts/
+tests/
+docs/
+archive/
+examples/
 ```
 
-The app runs on http://localhost:5173 and communicates with the Flask backend at http://localhost:5000.
+## Getting Started (Local)
 
-## Celery Workers
+### Backend (PowerShell)
 
-Always start Celery from the project root so that Python can locate the
-local modules:
-
-```bash
-cd path/to/finance-platform
-celery -A tasks worker --loglevel=info
-```
-
-The worker bootstrap ensures the repository root is added to
-`sys.path`, allowing modules such as `session_manager` to be imported
-even if the current working directory differs.
-
-## Rulebook Overview
-
-The system enforces guardrails defined in YAML files under the `rules/` directory:
-
-- `rules/dispute_rules.yaml` – core systemic rules such as `RULE_NO_ADMISSION`,
-  `RULE_PII_LIMIT`, and `RULE_NEUTRAL_LANGUAGE`.
-- `rules/neutral_phrases.yaml` – predefined neutral statements referenced in summaries.
-- `rules/state_rules.yaml` – state-specific clauses, disclosures, and prohibitions.
-
-Each rule has a **severity** (`critical` or `warning`). Critical violations are
-automatically fixed when a `fix_template` is provided; otherwise they are surfaced
-to callers for remediation.
-
-To add or modify a rule, edit the appropriate YAML file and include the new
-`id`, `description`, `severity`, `block_patterns`, and optional `fix_template`.
-
-## Letter Generation Flow
-
-1. **Upload** – users upload a credit report PDF.
-2. **Extraction** – accounts and explanations are parsed.
-3. **Explanation Normalization** – user text is sanitized and paraphrased into a
-   structured summary.
-4. **Letter Generation** – templates are filled using the structured summary
-   only; raw user text is never inserted.
-5. **Guardrail Enforcement** – the draft letter passes through the rule checker
-   which masks PII, replaces admissions, enforces neutral tone, and injects
-   applicable state clauses or disclosures.
-6. **Outcome Recording** – when results arrive from bureaus, outcomes are stored
-   and can be exported weekly.
-
-An overview diagram is available in `architecture.svg`.
-
-## State Compliance
-
-State rules are automatically applied based on the provided state code. Clauses
-are appended for certain debt types (e.g., New York medical debt), disclosures
-are added where required, and service is blocked in prohibited states such as
-Georgia. Update `rules/state_rules.yaml` to introduce new clauses or
-disclosures.
-
-## Development Setup
-
-### Backend
-
-```bash
-pip install -r requirements.txt
-python app.py
+```powershell
+.\.venv\Scripts\Activate.ps1
+set FLASK_DEBUG=1
+set DISABLE_PDF_RENDER=true
+python -m backend.api.app
 ```
 
 ### Frontend
@@ -135,41 +51,40 @@ npm install
 npm run dev
 ```
 
-### Environment Variables
+## Manual Scenario
 
-Create a `.env` file in the project root. The most important variable is
-`OPENAI_API_KEY`. A sample:
+1. Open http://localhost:5173.
+2. Upload a credit report PDF (email optional).
+3. Review the analysis and strategy.
+4. Letters are written to the `examples/` folder or a configured output path.
 
-```env
-OPENAI_API_KEY=your-key
-OPENAI_BASE_URL=https://api.openai.com/v1
-```
+## Environment Variables
 
-## Testing
+Provide these in a `.env` file:
 
-Run backend tests with a dummy API key to avoid live requests:
+- `OPENAI_API_KEY` – required for LLM calls.
+- `ADMIN_PASSWORD` – password for admin endpoints.
+- `OPENAI_BASE_URL` – optional override for OpenAI's URL.
+
+Secrets are never committed to the repository.
+
+## PDF Rendering
+
+PDF generation is disabled by default with `DISABLE_PDF_RENDER=true`. To enable PDFs, install [wkhtmltopdf](https://wkhtmltopdf.org/) and unset the flag.
+
+## Folder READMEs
+
+See the README files inside `backend/api`, `backend/core`, `backend/analytics`, `backend/audit`, `backend/assets`, and other folders for more details.
+
+## Tests (optional for now)
 
 ```bash
-OPENAI_API_KEY=dummy pytest --maxfail=1 --disable-warnings -q
+DISABLE_PDF_RENDER=true python -m pytest -q
+# or
+python tools/import_sanity_check.py
 ```
 
-Frontend Jest tests:
+## Contributing / Changelog
 
-```bash
-cd frontend
-npm test
-```
-
-## Extending the System
-
-- **New dispute types** – add neutral phrasing in `neutral_phrases.yaml` and
-  handle any bespoke rules in `dispute_rules.yaml`.
-- **New state rules** – extend `state_rules.yaml` with clauses, disclosures, or
-  prohibitions.
-- **Additional compliance checks** – introduce new systemic rules in
-  `dispute_rules.yaml` and corresponding tests.
-
-## Contributing
-
-See `CONTRIBUTING.md` for coding standards, testing requirements, and the pull
-request process.
+- [Contributing Guide](docs/CONTRIBUTING.md)
+- [Changelog](CHANGELOG.md)

--- a/docs/MODULE_GUIDE.md
+++ b/docs/MODULE_GUIDE.md
@@ -2,11 +2,11 @@
 
 | Module | Role | Public API | Key Dependencies |
 | ------ | ---- | ---------- | ---------------- |
-| `orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process`, `extract_problematic_accounts_from_report` → `BureauPayload` | `logic.*`, `session_manager`, `analytics_tracker` |
-| `models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
-| `logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
-| `services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |
-| `templates/` | Jinja2 letter templates rendered into HTML/PDF. | N/A – consumed by letter generation code | `Jinja2`, `logic.utils.pdf_ops` |
+| `backend/core/orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process`, `extract_problematic_accounts_from_report` → `BureauPayload` | `backend.core.logic.*`, `session_manager`, `analytics_tracker` |
+| `backend/core/models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
+| `backend/core/logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
+| `backend/core/services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |
+| `backend/assets/templates/` | Jinja2 letter templates rendered into HTML/PDF. | N/A – consumed by letter generation code | `Jinja2`, `backend.core.logic.utils.pdf_ops` |
 
 All GPT-enabled functions now require an explicit `AIClient` instance; no global
 fallback is provided. The orchestrators build a single client and inject it into

--- a/docs/POST_REFACTOR_AUDIT.md
+++ b/docs/POST_REFACTOR_AUDIT.md
@@ -7,19 +7,19 @@ _Date: 2025-08-08_
 ### Package-Level Module Graph
 ```mermaid
 graph TD
-    app.py --> logic
-    config.py --> services
-    logic --> models
-    logic --> services
-    main.py --> models
-    orchestrators.py --> analytics
-    orchestrators.py --> logic
-    orchestrators.py --> models
-    orchestrators.py --> services
-    scripts --> logic
-    tasks.py --> models
-    tools --> logic
-    trace_exporter.py --> models
+    backend/api/app.py --> backend/core/logic
+    backend/api/config.py --> backend/core/services
+    backend/core/logic --> backend/core/models
+    backend/core/logic --> backend/core/services
+    main.py --> backend/core/models
+    backend/core/orchestrators.py --> backend/analytics
+    backend/core/orchestrators.py --> backend/core/logic
+    backend/core/orchestrators.py --> backend/core/models
+    backend/core/orchestrators.py --> backend/core/services
+    scripts --> backend/core/logic
+    backend/api/tasks.py --> backend/core/models
+    tools --> backend/core/logic
+    backend/audit/trace_exporter.py --> backend/core/models
 ```
 
 ### Cross-Module Function Graph (logic package)
@@ -131,16 +131,16 @@ No import-time calls to `get_app_config()` were detected.
 
 ## 3. Public API Signatures
 - 55 functions still expose `dict` in public signatures (see console output).
-- Example: `extract_problematic_accounts_from_report` returns a `dict`【F:orchestrators.py†L535-L556】
+- Example: `extract_problematic_accounts_from_report` returns a `dict`【F:backend/core/orchestrators.py†L535-L556】
 - **Status:** **HIGH**
 
 ## 4. Fallback and Compliance
-- Fallback logic centralized in `determine_fallback_action`【F:logic/fallback_manager.py†L1-L41】
-- Compliance pipeline invoked once per letter generation【F:logic/letter_generator.py†L201-L209】
+- Fallback logic centralized in `determine_fallback_action`【F:backend/core/logic/strategy/fallback_manager.py†L1-L41】
+- Compliance pipeline invoked once per letter generation【F:backend/core/logic/letters/letter_generator.py†L201-L209】
 - **Status:** OK
 
 ## 5. Trace Exporter
-`export_trace_breakdown` writes four files (`strategist_raw_output.json`, `strategy_decision.json`, `fallback_reason.json`, `recommendation_summary.json`) each containing `run_date`, `session_id`, and per-account data【F:trace_exporter.py†L134-L235】
+`export_trace_breakdown` writes four files (`strategist_raw_output.json`, `strategy_decision.json`, `fallback_reason.json`, `recommendation_summary.json`) each containing `run_date`, `session_id`, and per-account data【F:backend/audit/trace_exporter.py†L134-L235】
 
 ## Summary
 - **HIGH:** Dict-based public APIs remain (55 functions).

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -2,15 +2,15 @@
 
 This document outlines the high-level architecture of the credit repair pipeline.
 
-The orchestrators module (`orchestrators.py`) serves as the single entry point for the backend.  It coordinates the following phases:
+The orchestrators module (`backend/core/orchestrators.py`) serves as the single entry point for the backend.  It coordinates the following phases:
 
 1. **Intake** – `process_client_intake` collects client information and initial session state.
 2. **Analysis** – `analyze_credit_report` ingests the uploaded report and extracts bureau data.
 3. **Strategy** – `generate_strategy_plan` merges classification results and bureau findings into a plan.
-4. **Letters** – dedicated generators create dispute or goodwill letters.  Draft HTML passes through the compliance pipeline and the PDF renderer (`logic.compliance_pipeline`, `logic.utils.pdf_ops`) before returning artifacts.
+4. **Letters** – dedicated generators create dispute or goodwill letters.  Draft HTML passes through the compliance pipeline and the PDF renderer (`backend.core.logic.compliance`, `backend.core.logic.utils.pdf_ops`) before returning artifacts.
 5. **Finalization** – orchestrators save artifacts, record analytics, and send notifications to finish the workflow.
 
 The orchestrators construct a single `AIClient` at startup and pass it to all
 LLM-powered functions, eliminating hidden global dependencies.
 
-Compliance checks and PDF rendering live inside the `logic` package and are invoked during letter generation to ensure all outbound documents meet guardrails and are rendered to PDF.
+Compliance checks and PDF rendering live inside `backend/core/logic` and are invoked during letter generation to ensure all outbound documents meet guardrails and are rendered to PDF.


### PR DESCRIPTION
## Summary
- rewrite top-level README with new project structure, local setup, env vars and testing guidance
- update Module Guide and overview docs to match backend folder reorganization
- fix audit doc links to backend/api and backend/core paths

## Testing
- `pre-commit run --files README.md docs/MODULE_GUIDE.md docs/POST_REFACTOR_AUDIT.md docs/SYSTEM_OVERVIEW.md`
- `DISABLE_PDF_RENDER=true python -m pytest -q` *(fails: Missing required rules file: backend/core/logic/rules/dispute_rules.yaml)*
- `python tools/import_sanity_check.py`


------
https://chatgpt.com/codex/tasks/task_b_689b8deec6608325bdfe4a2399734dfd