### PR TITLE
Use importlib.resources for rule loading

### DIFF
--- a/backend/core/logic/compliance/rules_loader.py
+++ b/backend/core/logic/compliance/rules_loader.py
@@ -1,19 +1,23 @@
-from pathlib import Path
+from importlib.resources import files
 import yaml
 from typing import Any, Mapping
 
-RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+RULES_PKG = "backend.core.rules"
 
 
 def _load_yaml(filename: str):
-    path = RULES_DIR / filename
-    if not path.exists():
-        raise FileNotFoundError(f"Missing required rules file: {path}")
     try:
+        path = files(RULES_PKG) / filename
         with path.open("r", encoding="utf-8") as f:
             return yaml.safe_load(f)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Missing required rules file: {RULES_PKG}/{filename}"
+        ) from exc
+    except ModuleNotFoundError as exc:
+        raise FileNotFoundError(f"Missing rules package: {RULES_PKG}") from exc
     except yaml.YAMLError as exc:
-        raise RuntimeError(f"Invalid YAML in {path}: {exc}") from exc
+        raise RuntimeError(f"Invalid YAML in {filename}: {exc}") from exc
 
 
 def load_rules() -> list:

--- a/backend/core/logic/letters/gpt_prompting.py
+++ b/backend/core/logic/letters/gpt_prompting.py
@@ -9,7 +9,7 @@ from backend.core.services.ai_client import AIClient
 
 from backend.audit.audit import AuditLevel, AuditLogger
 from backend.core.logic.utils.json_utils import parse_json
-from .rules_loader import get_neutral_phrase
+from backend.core.logic.compliance.rules_loader import get_neutral_phrase
 from .summary_classifier import classify_client_summary
 from .utils.pdf_ops import gather_supporting_docs
 from backend.core.models.account import Account, Inquiry

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -1,10 +1,30 @@
 import sys
 from pathlib import Path
+import types
 
 import pdfkit
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault(
+    "backend.core.logic.letters.fallback_manager",
+    types.SimpleNamespace(determine_fallback_action=lambda *a, **k: "dispute"),
+)
+sys.modules.setdefault(
+    "backend.core.logic.letters.summary_classifier",
+    types.SimpleNamespace(classify_client_summary=lambda struct, state=None: {"category": "not_mine"}),
+)
+
+utils_pkg = types.ModuleType("backend.core.logic.letters.utils")
+pdf_ops_mod = types.SimpleNamespace(gather_supporting_docs=lambda *a, **k: ("", [], None))
+utils_pkg.pdf_ops = pdf_ops_mod
+sys.modules.setdefault("backend.core.logic.letters.utils", utils_pkg)
+sys.modules.setdefault("backend.core.logic.letters.utils.pdf_ops", pdf_ops_mod)
+sys.modules.setdefault(
+    "backend.core.logic.letters.letter_rendering",
+    types.SimpleNamespace(render_dispute_letter_html=lambda *a, **k: ""),
+)
 
 from tests.helpers.fake_ai_client import FakeAIClient
 

--- a/tests/test_rules_loader.py
+++ b/tests/test_rules_loader.py
@@ -34,13 +34,13 @@ def test_load_state_rules():
 
 
 def test_missing_file(tmp_path, monkeypatch):
-    monkeypatch.setattr(rules_loader, "RULES_DIR", tmp_path)
+    monkeypatch.setattr(rules_loader, "files", lambda pkg: tmp_path)
     with pytest.raises(FileNotFoundError):
         rules_loader.load_rules()
 
 
 def test_invalid_yaml(tmp_path, monkeypatch):
     (tmp_path / "dispute_rules.yaml").write_text(": bad\n", encoding="utf-8")
-    monkeypatch.setattr(rules_loader, "RULES_DIR", tmp_path)
+    monkeypatch.setattr(rules_loader, "files", lambda pkg: tmp_path)
     with pytest.raises(RuntimeError):
         rules_loader.load_rules()


### PR DESCRIPTION
## Summary
- load dispute, state, and neutral phrase rules via `importlib.resources` instead of filesystem paths
- update imports and tests to reference centralized loader
- patch test pipeline helpers with lightweight stubs for missing letter modules

## Testing
- `pytest -q tests/test_rules_loader.py tests/test_rule_checker.py tests/test_compliance_pipeline_usage.py`
- `DISABLE_PDF_RENDER=true pytest -q` *(fails: ModuleNotFoundError: No module named 'backend.core.logic.report_analysis.fallback_manager'; ModuleNotFoundError: No module named 'backend.core.logic.strategy.constants')*
- `python - <<'PY'
from importlib.resources import files
for name in ['dispute_rules.yaml', 'state_rules.yaml', 'neutral_phrases.yaml']:
    with (files('backend.core.rules') / name).open('r', encoding='utf-8') as f:
        f.read(1)
print('loaded')
PY`


------
https://chatgpt.com/codex/tasks/task_b_689b9063841083258b6731a0ed0001d9