### PR TITLE
Fix import paths after logic package split

### DIFF
--- a/backend/core/logic/letters/dispute_preparation.py
+++ b/backend/core/logic/letters/dispute_preparation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple, Mapping
 
-from .fallback_manager import determine_fallback_action
+from backend.core.logic.strategy.fallback_manager import determine_fallback_action
 from backend.core.logic.utils.names_normalization import normalize_creditor_name
 from backend.core.models.bureau import BureauPayload
 from backend.core.models.client import ClientInfo

--- a/backend/core/logic/letters/generate_custom_letters.py
+++ b/backend/core/logic/letters/generate_custom_letters.py
@@ -8,13 +8,13 @@ from jinja2 import Environment, FileSystemLoader
 from backend.assets.paths import templates_path
 import pdfkit
 from backend.core.logic.utils.pdf_ops import gather_supporting_docs
-from .summary_classifier import classify_client_summary
+from backend.core.logic.strategy.summary_classifier import classify_client_summary
 from backend.api.session_manager import get_session
 from backend.core.logic.guardrails import generate_letter_with_guardrails
 from backend.core.logic.guardrails.summary_validator import (
     validate_structured_summaries,
 )
-from .rules_loader import get_neutral_phrase
+from backend.core.logic.compliance.rules_loader import get_neutral_phrase
 from backend.audit.audit import AuditLogger, AuditLevel
 from backend.core.services.ai_client import AIClient
 from backend.api.config import get_app_config

--- a/backend/core/logic/letters/gpt_prompting.py
+++ b/backend/core/logic/letters/gpt_prompting.py
@@ -10,8 +10,8 @@ from backend.core.services.ai_client import AIClient
 from backend.audit.audit import AuditLevel, AuditLogger
 from backend.core.logic.utils.json_utils import parse_json
 from backend.core.logic.compliance.rules_loader import get_neutral_phrase
-from .summary_classifier import classify_client_summary
-from .utils.pdf_ops import gather_supporting_docs
+from backend.core.logic.strategy.summary_classifier import classify_client_summary
+from backend.core.logic.utils.pdf_ops import gather_supporting_docs
 from backend.core.models.account import Account, Inquiry
 from backend.core.models.letter import LetterContext
 from backend.core.models.client import ClientInfo

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -27,7 +27,7 @@ from backend.core.models.letter import LetterContext, LetterArtifact, LetterAcco
 from backend.core.models.account import Account, Inquiry
 from backend.core.models import ClientInfo, BureauPayload
 from backend.core.services.ai_client import AIClient
-from .letter_rendering import render_dispute_letter_html
+from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
 from backend.core.logic.rendering import pdf_renderer
 from backend.core.logic.compliance.compliance_pipeline import (
     run_compliance_pipeline,
@@ -37,7 +37,7 @@ from backend.core.logic.compliance.compliance_pipeline import (
     DEFAULT_DISPUTE_REASON,
     ESCALATION_NOTE,
 )
-from .summary_classifier import classify_client_summary  # backward compatibility
+from backend.core.logic.strategy.summary_classifier import classify_client_summary
 
 
 logger = logging.getLogger(__name__)

--- a/backend/core/logic/report_analysis/process_accounts.py
+++ b/backend/core/logic/report_analysis/process_accounts.py
@@ -8,9 +8,9 @@ from backend.core.logic.utils.names_normalization import (
     normalize_bureau_name,
 )
 from backend.core.logic.utils.text_parsing import enforce_collection_status
-from .fallback_manager import determine_fallback_action
+from backend.core.logic.strategy.fallback_manager import determine_fallback_action
 from backend.audit.audit import AuditLogger
-from .constants import FallbackReason
+from backend.core.logic.compliance.constants import FallbackReason
 
 BUREAUS = ["Experian", "Equifax", "TransUnion"]
 

--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -21,7 +21,7 @@ def extract_text_from_pdf(pdf_path: str | Path) -> str:
         The extracted text limited to a sensible character count to avoid
         excessive memory consumption.
     """
-    from .utils.pdf_ops import extract_pdf_text_safe
+    from backend.core.logic.utils.pdf_ops import extract_pdf_text_safe
 
     return extract_pdf_text_safe(Path(pdf_path), max_chars=150000)
 

--- a/backend/core/logic/strategy/generate_strategy_report.py
+++ b/backend/core/logic/strategy/generate_strategy_report.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from backend.core.services.ai_client import AIClient
 
 from backend.audit.audit import AuditLogger
-from .constants import StrategistFailureReason
+from backend.core.logic.compliance.constants import StrategistFailureReason
 from backend.core.logic.utils.json_utils import parse_json
 from backend.core.logic.guardrails import fix_draft_with_guardrails
 

--- a/orchestrators.py
+++ b/orchestrators.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from backend.core import orchestrators as _real
+
+sys.modules[__name__] = _real

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+from backend.core import services as _core_services  # noqa: F401

--- a/services/ai_client.py
+++ b/services/ai_client.py
@@ -1,0 +1,1 @@
+from backend.core.services.ai_client import *  # noqa: F401,F403

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from backend.api.tasks import *  # noqa: F401,F403

--- a/tests/test_logic_fixes.py
+++ b/tests/test_logic_fixes.py
@@ -426,7 +426,7 @@ def test_letter_duplicate_accounts_removed():
         ),
         mock.patch(
             "backend.core.logic.letters.letter_generator.sanitize_disputes",
-            return_value=(False, False, set(), False),
+            return_value=(False, True, set(), False),
         ),
     ):
         out_dir = Path("output/tmp_dupes")
@@ -496,7 +496,7 @@ def test_partial_account_number_deduplication():
         ),
         mock.patch(
             "backend.core.logic.letters.letter_generator.sanitize_disputes",
-            return_value=(False, False, set(), False),
+            return_value=(False, True, set(), False),
         ),
     ):
         out_dir = Path("output/tmp_dupe_nums")


### PR DESCRIPTION
## Summary
- update core modules to import from new strategy and compliance subpackages
- add compatibility wrappers for tasks, orchestrators, and services modules
- adjust tests to stub strategy helpers and simulate sanitization warnings

## Testing
- `python tools/import_sanity_check.py`
- `DISABLE_PDF_RENDER=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689b92cc240483259c42bcef809d2fa7