### PR TITLE
docs: add system map and deep module guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,49 @@ archive/
 examples/
 ```
 
+## System Map (Directory Guide)
+
+### Table of Contents
+- [archive](#archive)
+- [backend](#backend)
+- [docs](#docs)
+- [frontend](#frontend)
+- [scripts](#scripts)
+- [services](#services)
+- [tests](#tests)
+- [tools](#tools)
+
+### How pieces connect
+- Intake/API: [`backend/api`](backend/api/README.md) accepts the PDF report and optional email, storing session data.
+- Core processing: [`backend/core`](backend/core/README.md) orchestrates analysis via `logic/report_analysis`, builds strategies in `logic/strategy`, generates letters through `logic/letters`, and enforces rules from `logic/compliance` and `logic/guardrails`.
+- Rendering & assets: [`backend/core/logic/rendering`](backend/core/logic/rendering/README.md) converts text to HTML/PDF using templates and fonts from [`backend/assets`](backend/assets/README.md).
+- Audit & analytics: [`backend/audit`](backend/audit/README.md) captures structured logs while [`backend/analytics`](backend/analytics/README.md) records run metrics.
+- Frontend & tooling: [`frontend`](frontend/README.md) provides the React UI; [`scripts`](scripts) and [`tools`](tools/README.md) host developer utilities; reference docs live in [`docs`](docs) and legacy materials in [`archive`](archive/README.md); service stubs sit under [`services`](services); tests reside in [`tests`](tests).
+
+### archive
+Legacy documentation and sample artifacts retained for historical reference. See [archive/README.md](archive/README.md) for file-level details.
+
+### backend
+Python backend powering ingestion, analysis, strategy generation, letter creation, analytics, and auditing. Key subpackages include [api](backend/api/README.md), [core](backend/core/README.md), [analytics](backend/analytics/README.md), [audit](backend/audit/README.md), and [assets](backend/assets/README.md).
+
+### docs
+Reference materials such as data models and contributing guides. No dedicated README; browse files within [`docs`](docs) for deeper documentation.
+
+### frontend
+React client that interacts with the API to upload reports and display results. See [frontend/README.md](frontend/README.md) for build and run instructions.
+
+### scripts
+Standalone Python utilities for maintenance tasks (encoding fixes, data exports). No README; inspect individual scripts in [`scripts`](scripts).
+
+### services
+Lightweight connectors to external services (e.g., OpenAI client). This folder currently lacks a README; see [`services`](services) for modules.
+
+### tests
+Automated tests exercising API endpoints and core logic. The [`tests`](tests) folder has no README; individual test files provide context.
+
+### tools
+Developer-facing command-line helpers and checks. See [tools/README.md](tools/README.md) for usage examples.
+
 ## Getting Started (Local)
 
 ### Backend (PowerShell)
@@ -94,4 +137,3 @@ python tools/import_sanity_check.py
 - Install hooks: `pip install pre-commit && pre-commit install`
 - Run import smoke: `python tools/import_sanity_check.py`
 - Run tests: `DISABLE_PDF_RENDER=true python -m pytest -q`
-

--- a/backend/analytics/README.md
+++ b/backend/analytics/README.md
@@ -1,17 +1,20 @@
 # Analytics
+
 ## Purpose
-Utilities for tracking analytics snapshots and internal metrics.
-## Subfolders / Key Files
-- analytics/ — helper functions and counters
-- analytics_tracker.py — writes analytics snapshots to disk
-## Entry Points
-- TODO
-## Internal Dependencies
-- config (environment settings)
-## External Dependencies
-- json
-- logging
-- pathlib
-- datetime
-## Notes / Guardrails
-- Intended for internal diagnostics; avoid leaking user data.
+Capture lightweight metrics and snapshots about each credit repair run for internal diagnostics.
+
+## Pipeline position
+Invoked after report analysis and strategy generation to persist summary statistics and failure reasons.
+
+## Files
+- `__init__.py`: package marker.
+- `analytics_tracker.py`: write JSON analytics snapshots to disk.
+  - Key function: `save_analytics_snapshot()`.
+  - Internal deps: `backend.api.config`.
+- `analytics/` – helper subpackage (e.g., `strategist_failures.py`) providing counters; no separate README.
+
+## Entry points
+- `analytics_tracker.save_analytics_snapshot`
+
+## Guardrails / constraints
+- Intended for internal use only; avoid storing sensitive client data in snapshots.

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,28 +1,40 @@
 # API
+
 ## Purpose
-Hosts the Flask API layer with admin routes, session helpers, Celery tasks, and configuration utilities.
-## Subfolders / Key Files
-- __init__.py — package marker
-- app.py — main API blueprint and routes
-- admin.py — admin-only endpoints
-- tasks.py — Celery worker tasks
-- session_manager.py — JSON-backed session store
-- config.py — environment-driven configuration
-- telegram_alert.py — console alert for admin logins
-## Entry Points
-- api_bp.start_process
-- api_bp.explanations_endpoint
-- api_bp.get_summaries
-- admin_bp.login
-- extract_problematic_accounts task
-## Internal Dependencies
-- backend.core.orchestrators
-- backend.core.models
-- backend.core.logic.explanations_normalizer
-## External Dependencies
-- Flask
-- Flask-CORS
-- Celery
-## Notes / Guardrails
-- Session data should contain only sanitized client input.
-- Secrets come from environment variables; never commit credentials.
+Expose Flask endpoints for uploading credit reports, collecting client explanations, and dispatching Celery tasks.
+
+## Pipeline position
+Receives the PDF report and optional email, persists session data, and triggers core orchestration. Returns JSON summaries and task results.
+
+## Files
+- `__init__.py`: package marker.
+- `admin.py`: admin dashboard and download routes.
+  - Key functions: `login()` authenticates admin users; `index()` lists client folders and analytics; `download_client()` and `download_analytics()` stream archives.
+  - Internal deps: `backend.api.config`, `backend.api.telegram_alert`.
+- `app.py`: main API blueprint and route handlers.
+  - Key functions: `start_process()` saves uploads and launches analysis; `explanations_endpoint()` stores sanitized summaries; `get_summaries()` returns structured data; `create_app()` assembles the Flask app.
+  - Internal deps: `backend.api.tasks`, `backend.api.session_manager`, `backend.core.orchestrators`, `backend.core.models`.
+- `config.py`: environment-driven settings.
+  - Key items: `AppConfig` dataclass; helpers `get_app_config()` and `get_ai_config()`.
+  - Internal deps: `backend.core.services.ai_client`.
+- `session_manager.py`: JSON-backed session and intake stores.
+  - Key functions: `set_session()`, `get_session()`, `update_session()`, `update_intake()`, `get_intake()`.
+  - Internal deps: `backend.assets.paths`.
+- `tasks.py`: Celery task definitions for background processing.
+  - Key functions: `extract_problematic_accounts()` parses reports; `process_report()` runs the full pipeline.
+  - Internal deps: `backend.core.orchestrators`, `backend.core.models`.
+- `telegram_alert.py`: logs admin login events.
+  - Key function: `send_admin_login_alert()`.
+
+## Entry points
+- `app.create_app`
+- `app.start_process`
+- `app.explanations_endpoint`
+- `app.get_summaries`
+- `admin.login`
+- `tasks.extract_problematic_accounts`
+- `tasks.process_report`
+
+## Guardrails / constraints
+- Session files store sanitized data; raw explanations remain in intake-only storage.
+- Secrets and API keys must come from environment variables.

--- a/backend/assets/README.md
+++ b/backend/assets/README.md
@@ -1,17 +1,25 @@
 # Assets
+
 ## Purpose
-Central home for templates, static files, fonts, and data fixtures.
-## Subfolders / Key Files
-- templates/ — HTML and PDF templates
-- static/ — CSS, images, and other static resources
-- fonts/ — font files used for PDF rendering
-- data/ — JSON fixtures (no secrets)
-## Entry Points
-- TODO
-## Internal Dependencies
-- orchestrators and PDF utilities reference these paths (TODO)
-## External Dependencies
-- TODO
-## Notes / Guardrails
-- Set DISABLE_PDF_RENDER=1 to skip font-dependent PDF rendering when fonts are unavailable.
-- Keep data/ free of credentials and other secrets.
+Provide templates, static files, fonts, and data fixtures used during rendering and letter generation.
+
+## Pipeline position
+Referenced by rendering modules to locate HTML templates, fonts for PDF conversion, and helper data such as creditor addresses.
+
+## Files
+- `paths.py`: resolve asset locations.
+  - Key functions: `templates_path()`, `data_path()`, `fonts_path()`, `static_path()`.
+  - Internal deps: standard library `pathlib`.
+
+## Subfolders
+- `templates/` – HTML templates for letters and instructions.
+- `static/` – CSS, images, and other assets bundled into PDFs.
+- `fonts/` – font files required for PDF rendering.
+- `data/` – JSON fixtures (e.g., creditor address maps); contains no secrets.
+
+## Entry points
+- `paths.templates_path`
+- `paths.data_path`
+
+## Guardrails / constraints
+- Keep `data/` free of credentials; set `DISABLE_PDF_RENDER=1` when fonts are unavailable.

--- a/backend/audit/README.md
+++ b/backend/audit/README.md
@@ -1,16 +1,23 @@
 # Audit
+
 ## Purpose
-Audit logging and trace export utilities for strategy runs.
-## Subfolders / Key Files
-- audit.py — structured audit logger
-- trace_exporter.py — exports diagnostics per account
-## Entry Points
-- TODO
-## Internal Dependencies
-- TODO
-## External Dependencies
-- json
-- datetime
-- pathlib
-## Notes / Guardrails
-- Logs may include sensitive account details; handle outputs securely.
+Record structured logs and export trace files for each processing run.
+
+## Pipeline position
+Receives step and account events from orchestrators and letters modules, then writes audit JSON and optional trace breakdowns.
+
+## Files
+- `__init__.py`: package marker.
+- `audit.py`: structured audit logger.
+  - Key items: `AuditLevel` enum; class `AuditLogger` with methods `log_step()`, `log_account()`, `log_error()`, `save()`; helper `create_audit_logger()`.
+  - Internal deps: standard library only.
+- `trace_exporter.py`: export detailed strategist traces and per-account breakdowns.
+  - Key functions: `export_trace_file()`, `export_trace_breakdown()`.
+  - Internal deps: `backend.core.models.strategy`.
+
+## Entry points
+- `audit.create_audit_logger`
+- `trace_exporter.export_trace_file`
+
+## Guardrails / constraints
+- Logs may include account details; store outputs securely and avoid sharing externally.

--- a/backend/core/README.md
+++ b/backend/core/README.md
@@ -1,21 +1,30 @@
 # Core
+
 ## Purpose
-Domain logic, models, rules, and services coordinating the credit repair workflow.
-## Subfolders / Key Files
-- logic/ — analysis algorithms and workflow steps
-- models/ — data representations for clients and accounts
-- services/ — connectors to external systems
-- rules/ — YAML rule definitions
-- orchestrators.py — coordinates end-to-end processing
-- email_sender.py — notification helpers
-## Entry Points
-- run_credit_repair_process
-## Internal Dependencies
-- backend.analytics.analytics_tracker
-- backend.audit.audit
-- backend.api.tasks
-## External Dependencies
-- OpenAI APIs (TODO)
-- email libraries (TODO)
-## Notes / Guardrails
-- Handles PII; ensure data is stored and transmitted securely.
+Central domain layer coordinating analysis, strategy, letter generation, and final delivery.
+
+## Pipeline position
+Receives sanitized inputs from the API and drives the end‑to‑end credit repair workflow before handing outputs to rendering and email.
+
+## Files
+- `__init__.py`: package marker.
+- `email_sender.py`: helpers for emailing generated PDFs.
+  - Key functions: `collect_all_files()` gathers PDFs; `send_email_with_attachment()` sends messages via SMTP.
+  - Internal deps: standard library only.
+- `orchestrators.py`: high-level pipeline controller.
+  - Key functions: `run_credit_repair_process()` executes intake→analysis→letters; `process_client_intake()`, `analyze_credit_report()`, `generate_strategy_plan()`, `generate_letters()`, `finalize_outputs()`, `extract_problematic_accounts_from_report()` expose individual stages.
+  - Internal deps: `backend.core.logic.*`, `backend.audit.audit`, `backend.analytics.analytics_tracker`.
+
+## Subfolders
+- `logic/` – processing steps for [report analysis](logic/report_analysis/README.md), [strategy](logic/strategy/README.md), [letters](logic/letters/README.md), [rendering](logic/rendering/README.md), [compliance](logic/compliance/README.md), [utils](logic/utils/README.md), and [guardrails](logic/guardrails/README.md).
+- `models/` – dataclasses representing clients, accounts, and strategy objects.
+- `services/` – connectors such as the OpenAI client.
+- `rules/` – YAML rule definitions loaded by compliance components.
+
+## Entry points
+- `orchestrators.run_credit_repair_process`
+- `orchestrators.extract_problematic_accounts_from_report`
+- `email_sender.send_email_with_attachment`
+
+## Guardrails / constraints
+- Handles PII; ensure secure storage and respect rule definitions in `rules/`.

--- a/backend/core/logic/compliance/README.md
+++ b/backend/core/logic/compliance/README.md
@@ -1,27 +1,38 @@
 # Compliance
 
 ## Purpose
-Enforce regulatory rules and validate user-provided documents to ensure safe operations.
+Apply regulatory rules, sanitize model outputs, and validate uploaded documents.
+
+## Pipeline position
+Runs alongside strategy and letter generation to ensure recommendations and documents meet legal requirements and avoid PII leaks.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-compliance_adapter.py | interface to external compliance services | compliance_pipeline
-compliance_pipeline.py | orchestrates compliance checks across modules | rule_checker, rules_loader
-constants.py | shared constants for compliance rules | --
-rule_checker.py | evaluate data against compliance rules | rules_loader
-rules_loader.py | load rule definitions and constants | constants
-upload_validator.py | validate uploaded PDFs for size & safety | pdfplumber
+- `__init__.py`: package marker.
+- `compliance_adapter.py`: normalize strategist output and client data.
+  - Key functions: `sanitize_disputes()`, `sanitize_client_info()`, `adapt_gpt_output()`.
+  - Internal deps: `backend.core.logic.compliance.constants`.
+- `compliance_pipeline.py`: orchestrate compliance checks.
+  - Key function: `run_compliance_pipeline()`.
+  - Internal deps: `backend.core.logic.compliance.rule_checker`, `backend.core.logic.compliance.rules_loader`.
+- `constants.py`: enumerations and helpers for action tags.
+  - Key items: `FallbackReason`, `StrategistFailureReason`, `normalize_action_tag()`.
+  - Internal deps: none beyond standard library.
+- `rule_checker.py`: evaluate text against rulebook and append state clauses.
+  - Key items: `RuleViolation` typed dict; function `check_letter()`.
+  - Internal deps: `backend.core.logic.compliance.rules_loader`, `backend.core.models.letter`.
+- `rules_loader.py`: load YAML rule definitions and neutral phrases.
+  - Key functions: `_load_yaml()`, `load_rules()`, `load_neutral_phrases()`, `get_neutral_phrase()`, `load_state_rules()`.
+  - Internal deps: `yaml`.
+- `upload_validator.py`: ensure uploaded PDFs are safe and stored under session folders.
+  - Key functions: `is_valid_filename()`, `contains_suspicious_pdf_elements()`, `is_safe_pdf()`, `move_uploaded_file()`.
+  - Internal deps: `pdfplumber`, `pathlib`.
 
 ## Entry points
 - `compliance_pipeline.run_compliance_pipeline`
-- `rule_checker.check_rules`
+- `rule_checker.check_letter`
+- `rules_loader.load_rules`
 - `upload_validator.is_safe_pdf`
 
-## Dependencies
-- **Internal**: `backend.core.logic.utils`, `backend.core.logic.guardrails`
-- **External**: `pdfplumber`
-
-## Notes / Guardrails
-- Ensure rules remain current with regulations.
-- Never retain uploaded documents longer than necessary.
+## Guardrails / constraints
+- Enforces PII masking and tone neutrality.
+- Rules must remain current with regulation updates; PDFs are discarded after processing.

--- a/backend/core/logic/guardrails/README.md
+++ b/backend/core/logic/guardrails/README.md
@@ -1,20 +1,19 @@
 # Guardrails
 
 ## Purpose
-Enforce content guardrails such as validation of summaries and generated text.
+Validate structured summaries and generated content to enforce neutral tone and prevent unsafe output.
+
+## Pipeline position
+Runs after client explanations are structured and before strategy or letters are finalized, ensuring only sanitized summaries flow downstream.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-summary_validator.py | validate generated summaries for safety & tone | used by strategy and letters (TODO)
+- `__init__.py`: package marker.
+- `summary_validator.py`: validate structured summaries for required fields and safe tone.
+  - Key function: `validate_structured_summaries()`.
+  - Internal deps: `typing` and standard library.
 
 ## Entry points
-- `summary_validator.validate_summary` (TODO)
+- `summary_validator.validate_structured_summaries`
 
-## Dependencies
-- **Internal**: `backend.core.logic.utils`
-- **External**: `pydantic` (TODO)
-
-## Notes / Guardrails
-- Guardrail checks must not leak sensitive data.
-- Maintain neutral, non-adversarial messaging.
+## Guardrails / constraints
+- Designed to prevent PII leakage and disallowed phrasing before interacting with models or rendering letters.

--- a/backend/core/logic/letters/README.md
+++ b/backend/core/logic/letters/README.md
@@ -1,32 +1,50 @@
 # Letters
 
 ## Purpose
-Prepare and generate dispute and goodwill letters using LLM prompting and templates.
+Prepare dispute and goodwill letters using client data, strategy outputs, and LLM prompting.
+
+## Pipeline position
+Takes bureau payloads and strategy recommendations to produce letter drafts, apply guardrails and compliance checks, and render final documents.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-dispute_preparation.py | preprocess account data for disputes | utils.text_parsing
-generate_custom_letters.py | create dispute letters for various scenarios | letter_generator
-generate_goodwill_letters.py | produce goodwill request letters | goodwill_preparation, goodwill_prompting
-goodwill_preparation.py | enrich accounts with hardship context | utils.names_normalization
-goodwill_prompting.py | craft LLM prompts for goodwill letters | services.ai_client
-goodwill_rendering.py | finalize goodwill letter text | rendering.letter_rendering
-gpt_prompting.py | shared GPT prompt helpers for letters | services.ai_client
-letter_generator.py | orchestrate letter creation | rendering.pdf_renderer
-outcomes_store.py | persist generated letter outcomes | storage layer (TODO)
-explanations_normalizer.py | sanitize and structure user-provided explanations | utils.json_utils
+- `__init__.py`: package marker.
+- `dispute_preparation.py`: deduplicate accounts and match inquiries.
+  - Key functions: `dedupe_disputes()`, `prepare_disputes_and_inquiries()`.
+  - Internal deps: `backend.core.logic.strategy.fallback_manager`, `backend.core.logic.utils.names_normalization`, `backend.core.models`.
+- `explanations_normalizer.py`: sanitize and structure user explanations.
+  - Key functions: `_redact()`, `sanitize()`, `extract_structured()`.
+  - Internal deps: `backend.core.logic.utils.json_utils`.
+- `generate_custom_letters.py`: create custom dispute letters and save PDFs.
+  - Key functions: `_pdf_config()`, `call_gpt_for_custom_letter()`, `generate_custom_letter()`, `generate_custom_letters()`.
+  - Internal deps: `backend.core.logic.guardrails`, `backend.core.logic.utils.pdf_ops`, `backend.api.session_manager`, `backend.core.logic.strategy.summary_classifier`, `backend.core.logic.compliance.rules_loader`, `backend.audit.audit`.
+- `generate_goodwill_letters.py`: orchestrate goodwill letter generation.
+  - Key functions: `generate_goodwill_letter_with_ai()`, `generate_goodwill_letters()`.
+  - Internal deps: `backend.core.logic.letters.goodwill_preparation`, `backend.core.logic.letters.goodwill_prompting`, `backend.core.logic.letters.goodwill_rendering`, `backend.core.logic.rendering.pdf_renderer`, `backend.core.logic.utils.pdf_ops`, `backend.core.logic.compliance.compliance_pipeline`.
+- `goodwill_preparation.py`: select goodwill candidates and summarize accounts.
+  - Key functions: `select_goodwill_candidates()`, `prepare_account_summaries()`.
+  - Internal deps: `backend.core.logic.utils.names_normalization`.
+- `goodwill_prompting.py`: craft LLM prompts for goodwill letters.
+  - Key function: `generate_goodwill_letter_draft()`.
+  - Internal deps: `backend.core.logic.utils.pdf_ops`, `backend.core.logic.utils.json_utils`.
+- `goodwill_rendering.py`: render goodwill letters and apply compliance checks.
+  - Key functions: `load_creditor_address_map()`, `render_goodwill_letter()`.
+  - Internal deps: `backend.assets.paths`, `backend.core.logic.rendering.pdf_renderer`, `backend.core.logic.utils.file_paths`, `backend.core.logic.utils.note_handling`, `backend.core.logic.compliance.compliance_pipeline`.
+- `gpt_prompting.py`: shared GPT helpers for dispute letters.
+  - Key function: `call_gpt_dispute_letter()`.
+  - Internal deps: `backend.core.services.ai_client`.
+- `letter_generator.py`: high-level dispute letter orchestration.
+  - Key functions: `call_gpt_dispute_letter()` (proxy), `generate_all_dispute_letters_with_ai()`.
+  - Internal deps: `backend.core.logic.strategy.strategy_engine`, `backend.core.logic.rendering`, `backend.core.logic.compliance.compliance_pipeline`, `backend.core.logic.guardrails.summary_validator`.
+- `outcomes_store.py`: record and retrieve letter outcomes.
+  - Key functions: `record_outcome()`, `get_outcomes()`.
+  - Internal deps: none significant.
 
 ## Entry points
 - `generate_custom_letters.generate_custom_letters`
 - `generate_goodwill_letters.generate_goodwill_letters`
-- `letter_generator.generate_letters` (TODO)
-- `dispute_preparation.prepare_disputes` (TODO)
+- `letter_generator.generate_all_dispute_letters_with_ai`
+- `dispute_preparation.prepare_disputes_and_inquiries`
 
-## Dependencies
-- **Internal**: `backend.core.logic.report_analysis`, `backend.core.logic.rendering`, `backend.core.logic.utils`
-- **External**: AI client, standard library
-
-## Notes / Guardrails
-- Maintain neutral, non-admitting tone in generated letters.
-- Redact or sanitize any PII before sending to models or outputs.
+## Guardrails / constraints
+- Generated letters must maintain a neutral tone and avoid admissions of fault.
+- Compliance checks (`compliance_pipeline`) sanitize client info and disputes before rendering.

--- a/backend/core/logic/rendering/README.md
+++ b/backend/core/logic/rendering/README.md
@@ -1,26 +1,33 @@
 # Rendering
 
 ## Purpose
-Render letters and instruction documents into final text and PDF outputs.
+Transform prepared letter and instruction content into final HTML and PDF artifacts.
+
+## Pipeline position
+Consumes text from letter generators and strategy modules, produces client-facing documents, and writes them to disk for emailing.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-instruction_data_preparation.py | gather data for instruction documents | utils.file_paths
-instruction_renderer.py | build textual instructions | instructions_generator
-instructions_generator.py | orchestrate instruction generation flow | compliance.rule_checker
-letter_rendering.py | assemble letter text into templates | utils.pdf_ops
-pdf_renderer.py | convert text content to PDF files | external PDF libraries
+- `__init__.py`: package marker.
+- `instruction_data_preparation.py`: assemble context for instruction packets.
+  - Key functions: `extract_clean_name()`, `generate_account_action()`, `prepare_instruction_data()`.
+  - Internal deps: `backend.core.logic.utils.file_paths`, `backend.core.logic.utils.names_normalization`.
+- `instruction_renderer.py`: turn instruction context into HTML.
+  - Key functions: `render_instruction_html()`, `build_instruction_html()`.
+  - Internal deps: `backend.core.models.letter`.
+- `instructions_generator.py`: orchestrate instruction generation and PDF conversion.
+  - Key functions: `get_logo_base64()`, `generate_instruction_file()`, `render_pdf_from_html()`, `save_json_output()`.
+  - Internal deps: `backend.core.logic.rendering.pdf_renderer`, `backend.core.logic.utils.pdf_ops`.
+- `letter_rendering.py`: create dispute letter HTML artifacts.
+  - Key function: `render_dispute_letter_html()`.
+  - Internal deps: `backend.core.models.letter`, `backend.core.logic.utils.note_handling`.
+- `pdf_renderer.py`: render HTML strings to PDF.
+  - Key functions: `ensure_template_env()`, `normalize_output_path()`, `render_html_to_pdf()`.
+  - Internal deps: `jinja2` templates, `pdfkit` or similar libraries.
 
 ## Entry points
-- `letter_rendering.render_letter`
-- `pdf_renderer.render_pdf`
-- `instructions_generator.generate_instructions` (TODO)
+- `instructions_generator.generate_instruction_file`
+- `letter_rendering.render_dispute_letter_html`
+- `pdf_renderer.render_html_to_pdf`
 
-## Dependencies
-- **Internal**: `backend.core.logic.utils`, `backend.core.logic.compliance`, `backend.core.logic.letters`
-- **External**: `pdfplumber` or similar PDF libs
-
-## Notes / Guardrails
-- Ensure generated documents avoid PII exposure.
-- Output files should be sanitized and stored securely.
+## Guardrails / constraints
+- Output files should exclude PII beyond what is required and respect compliance checks from upstream modules.

--- a/backend/core/logic/report_analysis/README.md
+++ b/backend/core/logic/report_analysis/README.md
@@ -1,27 +1,36 @@
 # Report Analysis
 
 ## Purpose
-Analyze credit reports to extract structured information and categorize accounts for downstream processing.
+Extract structured sections from SmartCredit reports and categorize accounts for downstream strategy and letter generation.
+
+## Pipeline position
+Ingests the uploaded PDF and produces bureau‑specific sections (`disputes`, `goodwill`, `inquiries`, etc.) consumed by strategy modules.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-analyze_report.py | orchestrates end-to-end report analysis | uses utils.text_parsing, services.ai_client
-extract_info.py | pull structured facts from parsed report data | utils.json_utils
-process_accounts.py | categorize accounts by bureau and tag goodwill/dispute items | utils.names_normalization, fallback_manager
-report_parsing.py | parse uploaded report into intermediate model | utils.text_parsing
-report_postprocessing.py | clean and enrich parsed report results | utils.note_handling
-report_prompting.py | build LLM prompts for analyzing report content | services.ai_client
+- `__init__.py`: package marker.
+- `analyze_report.py`: orchestrates parsing, prompting, and post‑processing.
+  - Key function: `analyze_credit_report()` runs AI analysis and merges parsed results.
+  - Internal deps: `.report_parsing`, `.report_prompting`, `.report_postprocessing`, `backend.core.logic.utils.text_parsing`, `backend.core.logic.utils.inquiries`.
+- `extract_info.py`: pull identity columns from the report.
+  - Key functions: `extract_clean_name()`, `normalize_name_order()`, `extract_bureau_info_column_refined()`.
+  - Internal deps: `backend.core.logic.utils.names_normalization`, `pdfplumber`.
+- `process_accounts.py`: convert analysis output into bureau payloads.
+  - Key items: `Account` dataclass; functions `process_analyzed_report()` and `save_bureau_outputs()`; helpers `infer_hardship_reason()`, `infer_personal_impact()`, `infer_recovery_summary()`.
+  - Internal deps: `backend.core.logic.utils.names_normalization`, `backend.core.logic.strategy.fallback_manager`, `backend.audit.audit`.
+- `report_parsing.py`: read PDF text and helper for converting dicts.
+  - Key functions: `extract_text_from_pdf()`, `bureau_data_from_dict()`.
+  - Internal deps: `pdfplumber`.
+- `report_postprocessing.py`: clean and augment AI results.
+  - Key functions: `_merge_parser_inquiries()`, `_sanitize_late_counts()`, `_cleanup_unverified_late_text()`, `_inject_missing_late_accounts()`, `validate_analysis_sanity()`.
+  - Internal deps: `backend.core.logic.utils` modules.
+- `report_prompting.py`: build LLM prompts and call the AI client.
+  - Key function: `call_ai_analysis()`.
+  - Internal deps: `backend.core.services.ai_client`.
 
 ## Entry points
-- `analyze_report.analyze_report`
+- `analyze_report.analyze_credit_report`
 - `process_accounts.process_analyzed_report`
-- TODO: confirm other external calls
 
-## Dependencies
-- **Internal**: `backend.core.logic.utils`, `backend.core.services.ai_client`
-- **External**: `dataclasses`, `json`
-
-## Notes / Guardrails
-- Maintain neutral tone when summarizing reports.
-- Avoid exposing PII; rely on sanitization helpers when needed.
+## Guardrails / constraints
+- Sanitization helpers ensure PII is normalized and late-payment data is validated.
+- Summaries should remain factual and neutral.

--- a/backend/core/logic/utils/README.md
+++ b/backend/core/logic/utils/README.md
@@ -1,30 +1,45 @@
 # Utils
 
 ## Purpose
-Shared helpers for parsing, normalization, and file operations used across the logic package.
+Shared helpers for parsing, normalization, JSON handling, and file operations used across logic modules.
+
+## Pipeline position
+Utilities are invoked by analysis, strategy, letter generation, and rendering steps for common tasks like PDF parsing and name normalization.
 
 ## Files
-File | Role in this capability | Key imports / called by
---- | --- | ---
-bootstrap.py | environment bootstrap helpers | various modules
-file_paths.py | standardize file path management | rendering, compliance
-inquiries.py | utilities for credit inquiries | report_analysis, letters
-json_utils.py | safe JSON parsing/helpers | explanations_normalizer, report_analysis
-names_normalization.py | normalize creditor & bureau names | process_accounts
-note_handling.py | utilities for note fields | report_postprocessing
-pdf_ops.py | PDF manipulation helpers | rendering.pdf_renderer
-report_sections.py | constants for report sections | report_parsing
-text_parsing.py | generic text parsing helpers | process_accounts, disputes
+- `__init__.py`: package marker.
+- `bootstrap.py`: environment bootstrap helpers.
+  - Key functions: `get_current_month()`, `extract_all_accounts()`.
+  - Internal deps: standard library.
+- `file_paths.py`: safe filename utilities.
+  - Key function: `safe_filename()`.
+  - Internal deps: `re`.
+- `inquiries.py`: parse inquiry blocks from raw text.
+  - Key function: `extract_inquiries()`.
+  - Internal deps: `re`.
+- `json_utils.py`: robust JSON parsing.
+  - Key functions: `_basic_clean()`, `_repair_json()`, `parse_json()`.
+  - Internal deps: `json`, `logging`.
+- `names_normalization.py`: normalize creditor and bureau names.
+  - Key functions: `normalize_creditor_name()`, `normalize_bureau_name()`.
+  - Internal deps: standard library; defines `BUREAUS` constant.
+- `note_handling.py`: build client address lines.
+  - Key function: `get_client_address_lines()`.
+  - Internal deps: none.
+- `pdf_ops.py`: PDF utilities and document text aggregation.
+  - Key functions: `convert_txts_to_pdfs()`, `gather_supporting_docs()`, `gather_supporting_docs_text()`.
+  - Internal deps: `pdfminer`/`pdfkit` style libraries.
+- `report_sections.py`: helpers for filtering and summarizing report sections.
+  - Key functions: `filter_sections_by_bureau()`, `extract_summary_from_sections()`.
+  - Internal deps: `.names_normalization`, `.text_parsing`.
+- `text_parsing.py`: generic text parsing and late-payment extraction.
+  - Key functions: `extract_account_blocks()`, `parse_late_history_from_block()`, `extract_late_history_blocks()`, `has_late_indicator()`, `enforce_collection_status()`.
+  - Internal deps: `re`.
 
 ## Entry points
 - `json_utils.parse_json`
 - `names_normalization.normalize_creditor_name`
-- TODO: document other commonly used helpers
+- `pdf_ops.convert_txts_to_pdfs`
 
-## Dependencies
-- **Internal**: standard library
-- **External**: `pdfplumber` (for PDF helpers)
-
-## Notes / Guardrails
-- Keep utilities side-effect free where possible.
-- Handle PII cautiously, especially in text and PDF utilities.
+## Guardrails / constraints
+- Utilities should remain side-effect free and avoid retaining PII beyond processing needs.


### PR DESCRIPTION
## Summary
- map top-level directories and cross-component flow in root README
- document API, core, and logic submodules with per-file breakdowns and guardrails
- clarify analytics, audit, and asset resources

## Testing
- `grep -nE "System Map|Directory Guide|## backend" -n README.md || true`
- `pre-commit run --files README.md backend/api/README.md backend/core/README.md backend/core/logic/report_analysis/README.md backend/core/logic/strategy/README.md backend/core/logic/letters/README.md backend/core/logic/rendering/README.md backend/core/logic/compliance/README.md backend/core/logic/utils/README.md backend/core/logic/guardrails/README.md backend/analytics/README.md backend/audit/README.md backend/assets/README.md`


------
https://chatgpt.com/codex/tasks/task_b_689ba3b9772c8325a80b1781c3bc281d