### PR TITLE
Fix AI client propagation and add smoke test

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -14,7 +14,7 @@ from flask_cors import CORS
 import uuid
 from werkzeug.utils import secure_filename
 
-from backend.api.tasks import extract_problematic_accounts
+from backend.api.tasks import extract_problematic_accounts, smoke_task
 from backend.api.admin import admin_bp
 from backend.api.session_manager import (
     set_session,
@@ -35,6 +35,13 @@ api_bp = Blueprint("api", __name__)
 @api_bp.route("/")
 def index():
     return jsonify({"status": "ok", "message": "API is up"})
+
+
+@api_bp.route("/api/smoke", methods=["GET"])
+def smoke():
+    """Lightweight health check verifying Celery round-trip."""
+    result = smoke_task.delay().get(timeout=10)
+    return jsonify({"ok": True, "celery": result})
 
 
 @api_bp.route("/api/start-process", methods=["POST"])

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -23,6 +23,8 @@ app = Celery("tasks", loader="default", fixups=[])
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logging.getLogger("pdfminer").setLevel(logging.ERROR)
+warnings.filterwarnings("ignore", message=".*FontBBox.*")
 
 # Verify that session_manager is importable at startup. This helps catch
 # cases where the worker is launched from a directory that omits the
@@ -64,6 +66,12 @@ def extract_problematic_accounts(self, file_path: str, session_id: str | None = 
     except Exception as exc:
         logger.exception("[ERROR] Error extracting accounts")
         raise exc
+
+
+@app.task(bind=True, name="smoke_task")
+def smoke_task(self):
+    """Minimal task used for health checks."""
+    return {"status": "ok"}
 
 
 @app.task(bind=True, name="process_report")

--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -33,7 +33,7 @@ from .report_postprocessing import (
     validate_analysis_sanity,
 )
 
-from backend.core.services.ai_client import AIClient
+from backend.core.services.ai_client import AIClient, get_ai_client
 
 
 # ---------------------------------------------------------------------------
@@ -45,9 +45,10 @@ def analyze_credit_report(
     pdf_path,
     output_json_path,
     client_info,
-    ai_client: AIClient,
+    ai_client: AIClient | None = None,
 ):
     """Analyze ``pdf_path`` and write structured analysis to ``output_json_path``."""
+    ai_client = ai_client or get_ai_client()
     text = extract_text_from_pdf(pdf_path)
     if not text.strip():
         raise ValueError("[ERROR] No text extracted from PDF")


### PR DESCRIPTION
## Summary
- add `get_ai_client` factory with safe stub and use it throughout analysis
- allow report analysis to default to a factory-provided client
- add `/api/smoke` endpoint and celery `smoke_task`
- suppress noisy PDF font warnings in worker

## Testing
- `PYTHONPATH=backend/api pytest tests/test_extract_problematic_accounts.py -q`
- `PYTHONPATH=backend/api pytest tests/test_celery_session_manager_import.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689babadf3bc8325922676bac56a4e02