### PR TITLE
Add PDF text extraction helper

### DIFF
--- a/backend/core/logic/utils/pdf_ops.py
+++ b/backend/core/logic/utils/pdf_ops.py
@@ -7,6 +7,34 @@ from typing import Any, Iterable, List, Tuple
 from backend.assets.paths import fonts_path
 
 
+def extract_pdf_text_safe(pdf_path: Path, max_chars: int = 150000) -> str:
+    """Return text from *pdf_path* while avoiding heavy dependencies at import time.
+
+    The function imports :mod:`fitz` (PyMuPDF) lazily so modules that merely
+    reference PDF utilities don't incur the cost of importing the library.  The
+    extracted text is truncated to ``max_chars`` characters to prevent excessive
+    memory usage.  Any exception while loading or parsing the PDF results in an
+    empty string, making the function "safe" for use in end-to-end pipelines.
+    """
+
+    try:
+        import fitz  # type: ignore
+    except Exception as exc:  # pragma: no cover - fitz missing
+        print(f"[WARN] PyMuPDF unavailable: {exc}")
+        return ""
+
+    try:
+        with fitz.open(pdf_path) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+    except Exception as exc:  # pragma: no cover - runtime PDF issues
+        print(f"[WARN] Failed to extract text from {pdf_path}: {exc}")
+        return ""
+
+    if len(text) > max_chars:
+        text = text[:max_chars] + "\n[TRUNCATED]"
+    return text
+
+
 def convert_txts_to_pdfs(folder: Path):
     """
     Converts .txt files in the given folder to styled PDFs with Unicode support.


### PR DESCRIPTION
## Summary
- implement `extract_pdf_text_safe` using PyMuPDF with error handling and truncation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689baf69f8dc83259f62f97c037bc93b