### PR TITLE
Skip AI analysis during initial account detection

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -93,13 +93,9 @@ def start_process():
             timeout=300
         )
 
-        client = ClientInfo(name=email or "Client", email=email, session_id=session_id)
-        proofs = ProofDocuments(smartcredit_report=local_filename)
-        run_credit_repair_process(client, proofs, True)
-
         return jsonify(
             {
-                "status": "ok",
+                "status": "awaiting_user_explanations",
                 "session_id": session_id,
                 "filename": unique_name,
                 "original_filename": original_name,

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -572,7 +572,14 @@ def extract_problematic_accounts_from_report(
     analyzed_json_path = Path("output/analyzed_report.json")
 
     ai_client = get_ai_client()
-    sections = analyze_report_logic(pdf_path, analyzed_json_path, {}, ai_client=ai_client)
+    sections = analyze_report_logic(
+        pdf_path,
+        analyzed_json_path,
+        {},
+        ai_client=ai_client,
+        run_ai=False,
+    )
+    update_session(session_id, status="awaiting_user_explanations")
 
     return BureauPayload(
         disputes=[
@@ -583,7 +590,8 @@ def extract_problematic_accounts_from_report(
             for d in sections.get("open_accounts_with_issues", [])
         ],
         inquiries=[
-            Inquiry.from_dict(d) for d in sections.get("unauthorized_inquiries", [])
+            Inquiry.from_dict(d)
+            for d in sections.get("unauthorized_inquiries", sections.get("inquiries", []))
         ],
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ redis
 dirtyjson
 json-repair
 pyyaml
+pytest-env
 

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -34,8 +34,8 @@ def test_start_process_success(monkeypatch, tmp_path):
     )
     assert resp.status_code == 200
     payload = json.loads(resp.data)
-    assert payload["status"] == "ok"
-    assert called.get("called")
+    assert payload["status"] == "awaiting_user_explanations"
+    assert not called.get("called")
 
 
 def test_start_process_missing_file():


### PR DESCRIPTION
## Summary
- add `run_ai` flag to `analyze_credit_report` to allow skipping AI classification
- update orchestrator and API start-process flow to skip AI during initial account detection and mark sessions `awaiting_user_explanations`
- add regression tests and dependency `pytest-env`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bc1e3e6c08325a4a5c3d5cc88915e