### PR TITLE
Add batch summary classification and pipeline batching

### DIFF
--- a/tests/test_classification_cache.py
+++ b/tests/test_classification_cache.py
@@ -38,9 +38,11 @@ def test_classify_client_responses_writes_metadata(monkeypatch):
     client_info = {"session_id": "sess1", "state": "CA"}
 
     ai = FakeAIClient()
-    ai.add_response('{"category": "not_mine"}')
+    ai.add_response('{"1": {"category": "not_mine"}}')
 
-    classify_client_responses(structured, raw, client_info, audit=FakeAudit(), ai_client=ai)
+    classify_client_responses(
+        structured, raw, client_info, audit=FakeAudit(), ai_client=ai
+    )
 
     meta = store["sess1"]["summary_classifications"]["1"]
     assert meta["classification"]["category"] == "not_mine"

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -22,6 +22,12 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         "backend.core.logic.strategy.summary_classifier.classify_client_summary",
         lambda struct, ai_client=None, state=None, **kw: {"category": "not_mine"},
     )
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.summary_classifier.classify_client_summaries",
+        lambda summaries, ai_client=None, state=None, **kw: {
+            str(s.get("account_id")): {"category": "not_mine"} for s in summaries
+        },
+    )
     utils_pkg = types.ModuleType("backend.core.logic.letters.utils")
     pdf_ops_mod = types.SimpleNamespace(
         gather_supporting_docs=lambda *a, **k: ("", [], None)


### PR DESCRIPTION
## Summary
- add `classify_client_summaries` to classify multiple summaries with per-item fallback
- batch summary classification in intake pipeline and map results by account_id
- extend tests for batch classification and pipeline changes

## Testing
- `scripts/run_checks.sh` *(fails: would reformat tests/test_architecture.py)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bdba342d88325a42f54efe00ee3cb