### PR TITLE
Propagate classification records across letter generation

### DIFF
--- a/backend/core/logic/letters/generate_goodwill_letters.py
+++ b/backend/core/logic/letters/generate_goodwill_letters.py
@@ -19,6 +19,7 @@ from backend.core.logic.utils.pdf_ops import gather_supporting_docs
 from backend.core.models import BureauPayload, ClientInfo
 from backend.core.models.account import Account
 from backend.core.services.ai_client import AIClient
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
 
 # ---------------------------------------------------------------------------
 # Orchestrator functions
@@ -34,6 +35,7 @@ def generate_goodwill_letter_with_ai(
     audit: AuditLogger | None = None,
     *,
     ai_client: AIClient,
+    classification_map: Mapping[str, ClassificationRecord] | None = None,
 ) -> None:
     """Generate a single goodwill letter for ``creditor``."""
 
@@ -52,10 +54,10 @@ def generate_goodwill_letter_with_ai(
     account_summaries = goodwill_preparation.prepare_account_summaries(
         account_dicts,
         structured_summaries,
+        classification_map,
         client_info.get("state"),
         session_id,
         audit=audit,
-        ai_client=ai_client,
     )
 
     gpt_data, _ = goodwill_prompting.generate_goodwill_letter_draft(
@@ -93,6 +95,7 @@ def generate_goodwill_letters(
     *,
     ai_client: AIClient,
     identity_theft: bool = False,
+    classification_map: Mapping[str, ClassificationRecord] | None = None,
 ) -> None:
     """Generate goodwill letters for all eligible creditors in ``bureau_data``.
 
@@ -138,6 +141,7 @@ def generate_goodwill_letters(
             run_date,
             audit,
             ai_client=ai_client,
+            classification_map=classification_map,
         )
 
 

--- a/backend/core/logic/letters/goodwill_preparation.py
+++ b/backend/core/logic/letters/goodwill_preparation.py
@@ -7,21 +7,15 @@ goodwill adjustment letters and shape account data for AI prompting.
 from __future__ import annotations
 
 import re
-import time
 from typing import Any, Dict, List, Mapping
 
-from backend.api.session_manager import get_session, update_session
 from backend.audit.audit import AuditLogger
 from backend.core.logic.compliance.rules_loader import get_neutral_phrase
-from backend.core.logic.strategy.summary_classifier import (
-    classify_client_summary,
-    summary_hash,
-)
 from backend.core.logic.utils.names_normalization import \
     normalize_creditor_name
 from backend.core.logic.utils.text_parsing import has_late_indicator
 from backend.core.models.client import ClientInfo
-from backend.core.services.ai_client import AIClient
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
 
 
 def select_goodwill_candidates(
@@ -144,11 +138,11 @@ def select_goodwill_candidates(
 def prepare_account_summaries(
     accounts: List[Dict[str, Any]],
     structured_summaries: Dict[str, Dict[str, Any]] | None,
+    classification_map: Mapping[str, ClassificationRecord] | None,
     state: str | None,
     session_id: str | None,
     *,
     audit: AuditLogger | None = None,
-    ai_client: AIClient,
 ) -> List[Dict[str, Any]]:
     """Merge duplicate account records and enrich with strategy metadata."""
 
@@ -219,37 +213,10 @@ def prepare_account_summaries(
         if structured_summaries:
             struct = structured_summaries.get(acc.get("account_id"), {})
             summary["structured_summary"] = struct
-            acc_id = acc.get("account_id")
-            cls = None
-            if acc_id and session_id:
-                session = get_session(session_id) or {}
-                cache = session.get("summary_classifications", {})
-                struct_hash = summary_hash(struct)
-                cached = cache.get(acc_id) if isinstance(cache, dict) else None
-                if cached and cached.get("summary_hash") == struct_hash:
-                    cls = cached.get("classification", {})
-                else:
-                    cls = classify_client_summary(
-                        struct,
-                        ai_client,
-                        state,
-                        session_id=session_id,
-                        account_id=acc_id,
-                    )
-                    cache[acc_id] = {
-                        "summary_hash": struct_hash,
-                        "classified_at": time.time(),
-                        "classification": cls,
-                    }
-                    update_session(session_id, summary_classifications=cache)
-            else:
-                cls = classify_client_summary(
-                    struct,
-                    ai_client,
-                    state,
-                    session_id=session_id,
-                    account_id=acc_id,
-                )
+            record = None
+            if classification_map:
+                record = classification_map.get(str(acc.get("account_id")))
+            cls = record.classification if record else {}
             summary.update(
                 {
                     "dispute_reason": cls.get("category"),

--- a/backend/core/logic/letters/gpt_prompting.py
+++ b/backend/core/logic/letters/gpt_prompting.py
@@ -7,8 +7,7 @@ from typing import Any, List, Mapping
 
 from backend.audit.audit import AuditLevel, AuditLogger
 from backend.core.logic.compliance.rules_loader import get_neutral_phrase
-from backend.core.logic.strategy.summary_classifier import \
-    classify_client_summary
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
 from backend.core.logic.utils.json_utils import parse_json
 from backend.core.logic.utils.pdf_ops import gather_supporting_docs
 from backend.core.models.account import Account, Inquiry
@@ -25,9 +24,9 @@ def call_gpt_dispute_letter(
     is_identity_theft: bool,
     structured_summaries: Mapping[str, Mapping[str, Any]],
     state: str,
+    classification_map: Mapping[str, ClassificationRecord] | None,
     ai_client: AIClient,
     audit: AuditLogger | None = None,
-    classifier=classify_client_summary,
 ) -> LetterContext:
     """Generate GPT-powered dispute letter content."""
 
@@ -42,13 +41,10 @@ def call_gpt_dispute_letter(
     dispute_blocks = []
     for acc in disputes:
         struct = structured_summaries.get(acc.account_id or "", {})
-        classification = classifier(
-            struct,
-            ai_client=ai_client,
-            state=state,
-            session_id=session_id,
-            account_id=acc.account_id,
-        )
+        record = None
+        if classification_map:
+            record = classification_map.get(acc.account_id or "")
+        classification = record.classification if record else {}
         neutral_phrase, neutral_reason = get_neutral_phrase(
             classification.get("category"), struct
         )

--- a/backend/core/logic/strategy/strategy_merger.py
+++ b/backend/core/logic/strategy/strategy_merger.py
@@ -202,7 +202,8 @@ def handle_strategy_fallbacks(
                             "reason": acc.get("advisor_comment")
                             or acc.get("analysis")
                             or raw_action,
-                            "classification": cls,
+                            "classification": getattr(cls, "classification", cls)
+                            or {},
                         },
                     )
 

--- a/backend/core/logic/strategy/summary_classifier.py
+++ b/backend/core/logic/strategy/summary_classifier.py
@@ -21,6 +21,15 @@ class _CacheEntry:
 _CACHE: Dict[Tuple[str, str, str], _CacheEntry] = {}
 
 
+@dataclass
+class ClassificationRecord:
+    """Cached classification details for a structured summary."""
+
+    summary: Mapping[str, Any]
+    classification: Mapping[str, str]
+    summary_hash: str
+
+
 def summary_hash(summary: Mapping[str, Any]) -> str:
     """Return a stable hash for ``summary``.
 
@@ -249,4 +258,5 @@ __all__ = [
     "classify_client_summaries",
     "invalidate_summary_cache",
     "summary_hash",
+    "ClassificationRecord",
 ]

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -49,6 +49,7 @@ def test_dispute_flow_golden(monkeypatch):
         False,
         {},
         "CA",
+        {},
         ai_client=fake_ai,
     )
     ctx.client_name = "John Doe"

--- a/tests/test_goodwill_integration.py
+++ b/tests/test_goodwill_integration.py
@@ -15,7 +15,7 @@ def test_orchestrator_invokes_compliance(monkeypatch, tmp_path):
     monkeypatch.setattr(
         generate_goodwill_letters.goodwill_preparation,
         "prepare_account_summaries",
-        lambda accounts, structured, state, session_id, audit=None, ai_client=None: accounts,
+        lambda accounts, structured, classification_map, state, session_id, audit=None: accounts,
     )
 
     def fake_prompt(**kwargs):

--- a/tests/test_goodwill_preparation.py
+++ b/tests/test_goodwill_preparation.py
@@ -28,8 +28,27 @@ def test_prepare_account_summaries_merges_and_enriches():
         {"name": "Chase", "acct_number": "1234", "status": "Open"},
     ]
     structured = {"a1": {"account_id": "a1", "dispute_type": "goodwill"}}
+    from backend.core.logic.strategy.summary_classifier import (
+        ClassificationRecord,
+        summary_hash,
+    )
+    record = ClassificationRecord(
+        structured["a1"],
+        {
+            "category": "goodwill",
+            "legal_tag": "FCRA §623(a)(1)",
+            "dispute_approach": "goodwill_adjustment",
+            "tone": "conciliatory",
+            "state_hook": "California Consumer Credit Reporting Agencies Act",
+        },
+        summary_hash(structured["a1"]),
+    )
     summaries = prepare_account_summaries(
-        accounts, structured, state="CA", session_id="sess", ai_client=FakeAIClient()
+        accounts,
+        structured,
+        {"a1": record},
+        state="CA",
+        session_id="sess",
     )
     assert len(summaries) == 1
     summary = summaries[0]

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -78,8 +78,19 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
 
     with pytest.warns(UserWarning):
         fake = FakeAIClient()
+        from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+        classification_map = {
+            "1": ClassificationRecord({}, {"category": "inaccurate_reporting"}, "")
+        }
         generate_all_dispute_letters_with_ai(
-            client_info, bureau_data, tmp_path, False, None, ai_client=fake
+            client_info,
+            bureau_data,
+            tmp_path,
+            False,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
         )
 
     with open(tmp_path / "Experian_gpt_response.json") as f:

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -39,6 +39,7 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -95,9 +96,20 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     }
 
     fake = FakeAIClient()
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord(structured["1"], {"category": "late"}, "")
+    }
     with pytest.warns(UserWarning):
         generate_all_dispute_letters_with_ai(
-            client_info, bureau_data, tmp_path, False, None, ai_client=fake
+            client_info,
+            bureau_data,
+            tmp_path,
+            False,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
         )
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)

--- a/tests/test_local_workflow.py
+++ b/tests/test_local_workflow.py
@@ -166,14 +166,29 @@ def test_minimal_workflow():
         out_dir = Path("output/test_local")
         fake = FakeAIClient()
         from backend.core.models import ClientInfo, BureauPayload
+        from backend.core.logic.strategy.summary_classifier import ClassificationRecord
 
         client = ClientInfo.from_dict(client_info)
         bureau_models = {k: BureauPayload.from_dict(v) for k, v in bureau_data.items()}
+        classification_map = {"1": ClassificationRecord({}, {"category": "late"}, "")}
 
         generate_dispute_letters_for_all_bureaus(
-            client, bureau_models, out_dir, False, None, ai_client=fake
+            client,
+            bureau_models,
+            out_dir,
+            False,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
         )
-        generate_goodwill_letters(client, bureau_models, out_dir, None, ai_client=fake)
+        generate_goodwill_letters(
+            client,
+            bureau_models,
+            out_dir,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
+        )
         generate_instruction_file(client, bureau_models, False, out_dir, ai_client=fake)
         context, accounts_list = instructions_generator.prepare_instruction_data(
             client_info,

--- a/tests/test_logging_edge_cases.py
+++ b/tests/test_logging_edge_cases.py
@@ -37,6 +37,7 @@ def test_warning_on_raw_client_text(monkeypatch, tmp_path, recwarn):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -79,8 +80,19 @@ def test_warning_on_raw_client_text(monkeypatch, tmp_path, recwarn):
     }
 
     fake = FakeAIClient()
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord({}, {"category": "inaccurate_reporting"}, "")
+    }
     generate_all_dispute_letters_with_ai(
-        client_info, bureau_data, tmp_path, False, None, ai_client=fake
+        client_info,
+        bureau_data,
+        tmp_path,
+        False,
+        None,
+        ai_client=fake,
+        classification_map=classification_map,
     )
 
 
@@ -102,6 +114,7 @@ def test_warning_on_missing_summary(monkeypatch, tmp_path, recwarn):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -134,8 +147,19 @@ def test_warning_on_missing_summary(monkeypatch, tmp_path, recwarn):
     }
 
     fake = FakeAIClient()
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord({}, {"category": "inaccurate_reporting"}, "")
+    }
     generate_all_dispute_letters_with_ai(
-        client_info, bureau_data, tmp_path, False, None, ai_client=fake
+        client_info,
+        bureau_data,
+        tmp_path,
+        False,
+        None,
+        ai_client=fake,
+        classification_map=classification_map,
     )
     assert any("[Sanitization]" in str(w.message) for w in recwarn)
 
@@ -158,6 +182,7 @@ def test_unrecognized_dispute_type_fallback(monkeypatch, tmp_path, recwarn):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -195,8 +220,19 @@ def test_unrecognized_dispute_type_fallback(monkeypatch, tmp_path, recwarn):
     }
 
     fake = FakeAIClient()
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord({}, {"category": "inaccurate_reporting"}, "")
+    }
     generate_all_dispute_letters_with_ai(
-        client_info, bureau_data, tmp_path, False, None, ai_client=fake
+        client_info,
+        bureau_data,
+        tmp_path,
+        False,
+        None,
+        ai_client=fake,
+        classification_map=classification_map,
     )
     assert captured["disputes"][0].dispute_type == "inaccurate_reporting"
     assert any("Unrecognized dispute type" in str(w.message) for w in recwarn)

--- a/tests/test_logic_fixes.py
+++ b/tests/test_logic_fixes.py
@@ -445,9 +445,17 @@ def test_letter_duplicate_accounts_removed():
 
         mock_d.side_effect = _cb
         fake = FakeAIClient()
+        from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+        classification_map = {"1": ClassificationRecord({}, {"category": "late"}, "")}
         with pytest.warns(UserWarning):
             generate_dispute_letters_for_all_bureaus(
-                {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
+                {"name": "T"},
+                bureau_data,
+                out_dir,
+                False,
+                None,
+                ai_client=fake,
+                classification_map=classification_map,
             )
 
     assert len(sent.get("Experian", [])) == 2
@@ -515,9 +523,17 @@ def test_partial_account_number_deduplication():
 
         mock_d.side_effect = _cb
         fake = FakeAIClient()
+        from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+        classification_map = {"1": ClassificationRecord({}, {"category": "late"}, "")}
         with pytest.warns(UserWarning):
             generate_dispute_letters_for_all_bureaus(
-                {"name": "T"}, bureau_data, out_dir, False, None, ai_client=fake
+                {"name": "T"},
+                bureau_data,
+                out_dir,
+                False,
+                None,
+                ai_client=fake,
+                classification_map=classification_map,
             )
 
     assert len(sent.get("Experian", [])) == 1

--- a/tests/test_neutral_phrase_integration.py
+++ b/tests/test_neutral_phrase_integration.py
@@ -5,6 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from backend.core.logic.compliance import rules_loader
 from backend.core.logic.letters.letter_generator import call_gpt_dispute_letter
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
 from backend.core.models.account import Account
 from tests.helpers.fake_ai_client import FakeAIClient
 
@@ -15,12 +16,10 @@ def test_dispute_prompt_includes_neutral_phrase(monkeypatch):
         '{"opening_paragraph": "", "accounts": [], "inquiries": [], "closing_paragraph": ""}'
     )
 
-    monkeypatch.setattr(
-        "backend.core.logic.letters.letter_generator.classify_client_summary",
-        lambda struct, ai_client, state=None, **kw: {"category": "not_mine"},
-    )
-
     structured = {"explanation": "I never opened this"}
+    classification_map = {
+        "1": ClassificationRecord(structured, {"category": "not_mine"}, "")
+    }
     call_gpt_dispute_letter(
         {"legal_name": "Test", "session_id": ""},
         "Equifax",
@@ -33,6 +32,7 @@ def test_dispute_prompt_includes_neutral_phrase(monkeypatch):
         False,
         {"1": structured},
         "",
+        classification_map=classification_map,
         ai_client=fake_client,
     )
 

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -47,6 +47,7 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -105,9 +106,20 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
         }
     }
 
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord(structured["1"], {"category": "late"}, "")
+    }
     with pytest.warns(UserWarning):
         generate_all_dispute_letters_with_ai(
-            client_info, bureau_data, tmp_path, False, None, ai_client=fake
+            client_info,
+            bureau_data,
+            tmp_path,
+            False,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
         )
     with open(tmp_path / "Experian_gpt_response.json") as f:
         data = json.load(f)

--- a/tests/test_strategy_workflow.py
+++ b/tests/test_strategy_workflow.py
@@ -172,8 +172,16 @@ def test_full_letter_workflow():
 
         out_dir = Path("output/test_flow")
         fake = FakeAIClient()
+        from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+        classification_map = {"a": ClassificationRecord({}, {"category": "late"}, "")}
         generate_dispute_letters_for_all_bureaus(
-            client_info, bureau_data, out_dir, False, None, ai_client=fake
+            client_info,
+            bureau_data,
+            out_dir,
+            False,
+            None,
+            ai_client=fake,
+            classification_map=classification_map,
         )
         generate_instruction_file(
             client_info, bureau_data, False, out_dir, strategy=strategy, ai_client=fake

--- a/tests/test_summary_validator.py
+++ b/tests/test_summary_validator.py
@@ -30,6 +30,7 @@ def test_validator_replaces_flagged_paragraph(monkeypatch, tmp_path):
         is_identity_theft,
         structured_summaries,
         state,
+        classification_map=None,
         audit=None,
         ai_client=None,
     ):
@@ -80,6 +81,17 @@ def test_validator_replaces_flagged_paragraph(monkeypatch, tmp_path):
         }
     }
 
+    from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+
+    classification_map = {
+        "1": ClassificationRecord(tampered["1"], {"category": "inaccurate_reporting"}, "")
+    }
     generate_all_dispute_letters_with_ai(
-        client_info, bureau_data, tmp_path, False, None, ai_client=FakeAIClient()
+        client_info,
+        bureau_data,
+        tmp_path,
+        False,
+        None,
+        ai_client=FakeAIClient(),
+        classification_map=classification_map,
     )


### PR DESCRIPTION
## Summary
- add `ClassificationRecord` dataclass to cache summary classifications
- propagate classification data from intake through strategy and letter modules
- remove repeated `classify_client_summary` calls by reusing `ClassificationRecord`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bdf518d408325bf621a0eb3b007af