### PR TITLE
chore: align black and isort settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["backend"]
+combine_as_imports = true
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]


### PR DESCRIPTION
## Summary
- configure isort to use black profile and project defaults
- configure black formatting

## Testing
- `pre-commit run -a` *(fails: files modified by trailing-whitespace)*

------
https://chatgpt.com/codex/tasks/task_b_689be3f73d00832582192421442e07f5