### PR TITLE
feat: add bounded summary classification cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Provide these in a `.env` file:
 - `OPENAI_API_KEY` – required for LLM calls.
 - `ADMIN_PASSWORD` – password for admin endpoints.
 - `OPENAI_BASE_URL` – optional override for OpenAI's URL.
+- `CLASSIFY_CACHE_ENABLED` – set to `0` to disable summary classification caching (default `1`).
+- `CLASSIFY_CACHE_MAXSIZE` – maximum entries for the summary classification cache (default `5000`).
+- `CLASSIFY_CACHE_TTL_SEC` – expiration in seconds for cached classifications; `0` disables TTL.
 
 Secrets are never committed to the repository.
 

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -12,6 +12,30 @@ if not _logger.handlers:
 _logger.setLevel(logging.INFO)
 
 
+def env_bool(name: str, default: bool) -> bool:
+    """Read a boolean environment variable."""
+
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no"}
+
+
+def env_int(name: str, default: int) -> int:
+    """Read an integer environment variable with fallback."""
+
+    value = os.getenv(name)
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+CLASSIFY_CACHE_ENABLED = env_bool("CLASSIFY_CACHE_ENABLED", True)
+CLASSIFY_CACHE_MAXSIZE = env_int("CLASSIFY_CACHE_MAXSIZE", 5000)
+CLASSIFY_CACHE_TTL_SEC = env_int("CLASSIFY_CACHE_TTL_SEC", 0)
+
+
 @dataclass
 class AppConfig:
     """Application configuration loaded from the environment."""


### PR DESCRIPTION
## Summary
- add env-controlled settings for summary classification cache
- implement LRU summary classification cache with TTL and stats
- test cache disable, eviction and TTL expiry

## Testing
- `python tools/import_sanity_check.py`
- `DISABLE_PDF_RENDER=true python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689be5abc7a083258f1a48bd6c9fae22