### PR TITLE
Ensure classification cache reflects rules version and state

### DIFF
--- a/backend/core/logic/compliance/rules_loader.py
+++ b/backend/core/logic/compliance/rules_loader.py
@@ -1,8 +1,11 @@
+import hashlib
 from importlib.resources import files
-import yaml
 from typing import Any, Mapping
 
+import yaml
+
 RULES_PKG = "backend.core.rules"
+_RULES_VERSION: str | None = None
 
 
 def _load_yaml(filename: str):
@@ -81,3 +84,15 @@ def load_state_rules() -> Mapping[str, Any]:
     if not isinstance(data, dict):
         raise ValueError("state_rules.yaml must define a mapping")
     return data
+
+
+def recompute_rules_version() -> str:
+    """Recompute and return the current rules version hash."""
+
+    global _RULES_VERSION
+    sha = hashlib.sha256()
+    pkg = files(RULES_PKG)
+    for path in sorted(p for p in pkg.iterdir() if p.name.endswith((".yml", ".yaml"))):
+        sha.update(path.read_bytes())
+    _RULES_VERSION = sha.hexdigest()
+    return _RULES_VERSION


### PR DESCRIPTION
## Summary
- track `rules_version` by hashing backend rule YAMLs
- include state and rules version in summary classification cache
- persist classification metadata with state and rules version in sessions
- add tests for rules version and state cache invalidation

## Testing
- `pre-commit run --files backend/core/logic/compliance/rules_loader.py backend/core/logic/strategy/summary_classifier.py backend/core/orchestrators.py tests/test_classification_cache.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689be7b384c08325b2180bbe4ce25658