### PR TITLE
test: expand batch summary classification coverage

### DIFF
--- a/tests/test_summary_classifier.py
+++ b/tests/test_summary_classifier.py
@@ -1,7 +1,10 @@
+import json
+
 from backend.core.logic.strategy.summary_classifier import (
     classify_client_summary,
     classify_client_summaries,
     invalidate_summary_cache,
+    reset_cache,
 )
 from tests.helpers.fake_ai_client import FakeAIClient
 
@@ -72,3 +75,50 @@ def test_batch_classification():
     res = classify_client_summaries(summaries, ai_client=ai)
     assert res["1"]["category"] == "not_mine"
     assert res["2"]["category"] == "goodwill"
+
+
+def test_batch_empty_summary_skips_ai():
+    ai = FakeAIClient()
+    ai.add_response('{"2": {"category": "goodwill"}}')
+    summaries = [
+        {"account_id": "1", "facts_summary": "   ", "claimed_errors": []},
+        {"account_id": "2", "facts_summary": "goodwill", "claimed_errors": []},
+    ]
+    res = classify_client_summaries(summaries, ai_client=ai)
+    assert res["1"]["category"] == "inaccurate_reporting"
+    assert res["2"]["category"] == "goodwill"
+    assert len(ai.chat_payloads) == 1
+
+
+def test_batch_long_summary_cached_and_heuristic():
+    reset_cache()
+    long_text = ("x" * 5000) + " not mine"
+    summary = {"account_id": "1", "facts_summary": long_text, "claimed_errors": []}
+    ai = FakeAIClient()
+    ai.add_response("{}")
+    res1 = classify_client_summaries([summary], ai_client=ai, session_id="sess_long")
+    assert res1["1"]["category"] == "not_mine"
+    res2 = classify_client_summaries([summary], ai_client=ai, session_id="sess_long")
+    assert res2["1"]["category"] == "not_mine"
+    assert len(ai.chat_payloads) == 1
+
+
+def test_batch_fallback_missing_items_preserves_map():
+    ai = FakeAIClient()
+    batch_resp = {str(i): {"category": "not_mine"} for i in range(1, 9)}
+    ai.add_response(json.dumps(batch_resp))
+    ai.add_response('{"category": "goodwill"}')
+    ai.add_response('{"category": "identity_theft"}')
+    summaries = [
+        {"account_id": str(i), "facts_summary": "not mine", "claimed_errors": []}
+        if i <= 8
+        else {"account_id": str(i), "facts_summary": "mystery", "claimed_errors": []}
+        for i in range(1, 11)
+    ]
+    res = classify_client_summaries(summaries, ai_client=ai)
+    assert len(res) == 10
+    for i in range(1, 9):
+        assert res[str(i)]["category"] == "not_mine"
+    assert res["9"]["category"] == "goodwill"
+    assert res["10"]["category"] == "identity_theft"
+    assert len(ai.chat_payloads) == 3


### PR DESCRIPTION
## Summary
- add batch test for empty summaries ensuring default category and no extra AI calls
- verify long summaries cache correctly with heuristic fallback
- ensure partial batch responses fall back per-item without losing map entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be9a47ab883259edc58a8f15011ff