### PR TITLE
docs: document classification cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ Provide these in a `.env` file:
 
 Secrets are never committed to the repository.
 
+## Classification Cache
+
+The stage 2 summary classifier caches each account's classification to avoid
+repeated LLM calls. Keys combine `session_id`, `account_id`, the structured
+summary hash, client `state`, and the active rules version. Cache entries are
+evicted on manual invalidation, TTL expiry, or when the least recently used
+record exceeds `CLASSIFY_CACHE_MAXSIZE`.
+
+**Environment flags**
+- `CLASSIFY_CACHE_ENABLED` – disable caching when set to `0` (default `1`).
+- `CLASSIFY_CACHE_MAXSIZE` – maximum number of cached classifications.
+- `CLASSIFY_CACHE_TTL_SEC` – seconds before a cache entry expires; `0` keeps
+  entries indefinitely.
+
+**Production note:** This is an in-memory, per-process cache. Deployments with
+multiple worker processes keep separate caches, so hit rates decrease as worker
+counts grow.
+
 ## PDF Rendering
 
 PDF generation is disabled by default with `DISABLE_PDF_RENDER=true`. To enable PDFs, install [wkhtmltopdf](https://wkhtmltopdf.org/) and unset the flag.

--- a/backend/core/logic/strategy/README.md
+++ b/backend/core/logic/strategy/README.md
@@ -31,5 +31,12 @@ Consumes structured report sections and sanitized summaries to classify accounts
 - `summary_classifier.classify_client_summary`
 - `fallback_manager.determine_fallback_action`
 
+## Classification cache
+`summary_classifier` caches classification results using a key of session id,
+account id, summary hash, client state, and rules version. Entries expire when
+evicted by TTL or size limits. See
+[`tests/test_classification_cache.py`](../../../../tests/test_classification_cache.py)
+for coverage of the cache behavior.
+
 ## Guardrails / constraints
 - Recommendations must comply with `compliance.constants.VALID_ACTION_TAGS` and neutral phrasing rules.


### PR DESCRIPTION
## Summary
- detail stage 2 classification cache behavior and env flags in root README
- note classification cache in strategy README with link to tests

## Testing
- `DISABLE_PDF_RENDER=true python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bed48fe988325972696e43a0b85c3