### PR TITLE
refactor: drop client_goal parameter from report analysis

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -57,21 +57,21 @@ def analyze_credit_report(
 
     raw_goal = client_info.get("goal", "").strip().lower()
     if raw_goal in ["", "not specified", "improve credit", "repair credit"]:
-        client_goal = (
+        strategic_context = (
             "Improve credit score significantly within the next 3-6 months using strategies such as authorized users, "
             "credit building tools, and removal of negative items."
         )
     else:
-        client_goal = client_info.get("goal", "Not specified")
+        strategic_context = client_info.get("goal", "Not specified")
 
     is_identity_theft = client_info.get("is_identity_theft", False)
     if run_ai:
         result = call_ai_analysis(
             text,
-            client_goal,
             is_identity_theft,
             Path(output_json_path),
             ai_client=ai_client,
+            strategic_context=strategic_context,
         )
     else:
         result = {

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -11,10 +11,10 @@ from backend.core.services.ai_client import AIClient
 
 def call_ai_analysis(
     text: str,
-    client_goal: str,
     is_identity_theft: bool,
     output_json_path: Path,
     ai_client: AIClient,
+    strategic_context: str | None = None,
 ):
     """Analyze raw report text using an AI model and return parsed JSON.
 
@@ -22,8 +22,6 @@ def call_ai_analysis(
     ----------
     text:
         Raw text extracted from the report.
-    client_goal:
-        High level goal provided by the client.
     is_identity_theft:
         Flag indicating if the report relates to an identity theft case.
     output_json_path:
@@ -32,6 +30,9 @@ def call_ai_analysis(
     ai_client:
         Instance of :class:`services.ai_client.AIClient` used to make the
         request.
+    strategic_context:
+        Optional high level context derived from server-side ``client_info``
+        fields. This string is inserted directly into the prompt if provided.
 
     Returns
     -------
@@ -72,14 +73,17 @@ def call_ai_analysis(
     else:
         inquiry_summary = "\nNo inquiries were detected by the parser."
 
+    strategic_context_line = (
+        f'Strategic context: "{strategic_context}"\n' if strategic_context else ""
+    )
+
     prompt = f"""
 You are a senior credit repair expert with deep knowledge of credit reports, FCRA regulations, dispute strategies, and client psychology.
 
 Your task: deeply analyze the following SmartCredit report text and extract a structured JSON summary for use in automated dispute and goodwill letters, and personalized client instructions.
 
-Client goal: "{client_goal}"
 Identity theft case: {"Yes" if is_identity_theft else "No"}
-
+{strategic_context_line}
 Return only valid JSON with all property names in double quotes. No comments or extra text outside the JSON object.
 
 Return this exact JSON structure:

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -60,7 +60,7 @@ def test_call_ai_analysis_parses_json(tmp_path):
     client.add_chat_response('{"inquiries": [], "all_accounts": []}')
     out = tmp_path / "result.json"
     data = report_prompting.call_ai_analysis(
-        "text", "goal", False, out, ai_client=client
+        "text", False, out, ai_client=client, strategic_context="goal"
     )
     assert data["inquiries"] == []
     assert out.with_name(out.stem + "_raw.txt").exists()
@@ -184,10 +184,10 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
 
     baseline = report_prompting.call_ai_analysis(
         "text",
-        default_goal,
         identity_theft,
         tmp_path / "baseline.json",
         ai_client=client,
+        strategic_context=default_goal,
     )
 
     result = analyze_report.analyze_credit_report(


### PR DESCRIPTION
## Summary
- remove `client_goal` argument from `call_ai_analysis`
- derive optional strategic context in `analyze_credit_report` and inject into analysis prompt
- update tests for new `call_ai_analysis` signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bfc6a89008325afbed6fcaf74b6f2