### PR TITLE
feat: summarize account headings in AI analysis

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -70,6 +70,41 @@ def _merge_parser_inquiries(result: dict, parsed: List[dict]):
 
 
 # ---------------------------------------------------------------------------
+# Account heading reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _reconcile_account_headings(result: dict, headings: Mapping[str, str]) -> None:
+    """Align AI account names with parser-detected headings."""
+
+    if not headings:
+        return
+
+    seen = set()
+    sections = [
+        "all_accounts",
+        "negative_accounts",
+        "open_accounts_with_issues",
+        "positive_accounts",
+        "high_utilization_accounts",
+    ]
+    for sec in sections:
+        for acc in result.get(sec, []):
+            raw = acc.get("name", "")
+            norm = normalize_creditor_name(raw)
+            if norm in headings:
+                if headings[norm] != raw:
+                    acc["name"] = headings[norm]
+                seen.add(norm)
+
+    for norm, raw in headings.items():
+        if norm not in seen:
+            print(
+                f"[WARN] Parser detected account heading '{raw}' missing from AI output"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Late payment utilities
 # ---------------------------------------------------------------------------
 

--- a/backend/core/logic/utils/text_parsing.py
+++ b/backend/core/logic/utils/text_parsing.py
@@ -204,6 +204,40 @@ def extract_account_blocks(text: str, debug: bool = False) -> list[list[str]]:
     return blocks
 
 
+def extract_account_headings(text: str) -> list[tuple[str, str]]:
+    """Return unique normalized account headings found in ``text``.
+
+    The function leverages :func:`extract_account_blocks` to locate candidate
+    account sections and then normalizes their headings using
+    :func:`names_normalization.normalize_creditor_name`.  Only the first
+    occurrence of each normalized name is retained in the returned list.
+
+    Parameters
+    ----------
+    text:
+        Raw text extracted from a credit report PDF.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        Tuples of ``(normalized_name, raw_heading)``.
+    """
+
+    from .names_normalization import normalize_creditor_name
+
+    headings: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for block in extract_account_blocks(text):
+        if not block:
+            continue
+        raw = block[0].strip()
+        norm = normalize_creditor_name(raw)
+        if norm and norm not in seen:
+            headings.append((norm, raw))
+            seen.add(norm)
+    return headings
+
+
 def parse_late_history_from_block(
     block: list[str], debug: bool = False
 ) -> dict[str, dict[str, int]]:

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -174,6 +174,9 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
         report_postprocessing, "_merge_parser_inquiries", lambda res, parsed: None
     )
     monkeypatch.setattr(
+        report_postprocessing, "_reconcile_account_headings", lambda res, headings: None
+    )
+    monkeypatch.setattr(
         report_postprocessing, "validate_analysis_sanity", lambda res: []
     )
 


### PR DESCRIPTION
## Summary
- parse account headings deterministically and normalize creditor names
- prepend parsed account headings summary to Stage 3 analysis prompt
- reconcile AI output account names with parser-detected headings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ca0616ed483258c88a9b80a9e94fc