### PR TITLE
Add audit logging and AI analytics metrics

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -13,6 +13,15 @@ _CACHE_METRICS: Dict[str, int] = {"hits": 0, "misses": 0, "evictions": 0}
 _OPS = 0
 _SNAPSHOT_INTERVAL = 100
 
+# AI usage metrics -----------------------------------------------------------
+
+_AI_METRICS: Dict[str, float] = {
+    "tokens_in": 0,
+    "tokens_out": 0,
+    "cost": 0.0,
+    "latency_ms": 0.0,
+}
+
 
 def _write_cache_snapshot() -> None:
     """Persist current cache metrics to ``analytics_data`` and reset counters."""
@@ -76,6 +85,29 @@ def reset_cache_counters() -> None:
     for k in _CACHE_METRICS:
         _CACHE_METRICS[k] = 0
     _OPS = 0
+
+
+# AI usage helpers -----------------------------------------------------------
+
+def log_ai_request(tokens_in: int, tokens_out: int, cost: float, latency_ms: float) -> None:
+    """Record tokens, estimated cost, and latency for an AI call."""
+
+    _AI_METRICS["tokens_in"] += tokens_in
+    _AI_METRICS["tokens_out"] += tokens_out
+    _AI_METRICS["cost"] += cost
+    _AI_METRICS["latency_ms"] += latency_ms
+
+
+def get_ai_stats() -> Dict[str, float]:
+    """Return current AI usage metrics (for tests)."""
+
+    return _AI_METRICS.copy()
+
+
+def reset_ai_stats() -> None:
+    """Reset AI usage metrics (for tests)."""
+
+    _AI_METRICS.update(tokens_in=0, tokens_out=0, cost=0.0, latency_ms=0.0)
 
 
 def _flush_on_exit() -> None:

--- a/backend/audit/audit.py
+++ b/backend/audit/audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
@@ -76,3 +77,12 @@ def create_audit_logger(
     audit = AuditLogger(level=level)
     audit.data["session_id"] = session_id
     return audit
+
+
+_logger = logging.getLogger(__name__)
+
+
+def emit_event(event: str, payload: Dict[str, Any]) -> None:
+    """Emit a structured audit log entry for external monitoring."""
+
+    _logger.info("%s %s", event, json.dumps(payload))

--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -12,6 +12,7 @@ reason about. The functionality has been split into dedicated modules:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -47,6 +48,8 @@ def analyze_credit_report(
     client_info,
     ai_client: AIClient | None = None,
     run_ai: bool = True,
+    *,
+    request_id: str,
 ):
     """Analyze ``pdf_path`` and write structured analysis to ``output_json_path``."""
     ai_client = ai_client or get_ai_client()
@@ -70,6 +73,7 @@ def analyze_credit_report(
         strategic_context = client_info.get("goal", "Not specified")
 
     is_identity_theft = client_info.get("is_identity_theft", False)
+    doc_fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()
     if run_ai:
         result = call_ai_analysis(
             text,
@@ -77,6 +81,8 @@ def analyze_credit_report(
             Path(output_json_path),
             ai_client=ai_client,
             strategic_context=strategic_context,
+            request_id=request_id,
+            doc_fingerprint=doc_fingerprint,
         )
     else:
         result = {

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -212,7 +212,7 @@ def analyze_credit_report(
     print("[INFO] Analyzing report with GPT...")
     analyzed_json_path = Path("output/analyzed_report.json")
     sections = analyze_report_logic(
-        pdf_path, analyzed_json_path, client_info, ai_client=ai_client
+        pdf_path, analyzed_json_path, client_info, ai_client=ai_client, request_id=session_id
     )
     client_info.update(sections)
     log_messages.append("[INFO] Report analyzed.")
@@ -679,6 +679,7 @@ def extract_problematic_accounts_from_report(
         {},
         ai_client=ai_client,
         run_ai=False,
+        request_id=session_id,
     )
     update_session(session_id, status="awaiting_user_explanations")
 

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -60,7 +60,13 @@ def test_call_ai_analysis_parses_json(tmp_path):
     client.add_chat_response('{"inquiries": [], "all_accounts": []}')
     out = tmp_path / "result.json"
     data = report_prompting.call_ai_analysis(
-        "text", False, out, ai_client=client, strategic_context="goal"
+        "text",
+        False,
+        out,
+        ai_client=client,
+        strategic_context="goal",
+        request_id="req",
+        doc_fingerprint="fp",
     )
     assert data["inquiries"] == []
     assert out.with_name(out.stem + "_raw.txt").exists()
@@ -95,7 +101,14 @@ def test_call_ai_analysis_merges_segments(tmp_path):
     )
     out = tmp_path / "result.json"
     text = "Experian section Equifax section"
-    data = report_prompting.call_ai_analysis(text, False, out, ai_client=client)
+    data = report_prompting.call_ai_analysis(
+        text,
+        False,
+        out,
+        ai_client=client,
+        request_id="req",
+        doc_fingerprint="fp",
+    )
     assert len(data["inquiries"]) == 2
     assert sorted(data["all_accounts"][0]["bureaus"]) == [
         "Equifax",
@@ -228,6 +241,8 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
         tmp_path / "baseline.json",
         ai_client=client,
         strategic_context=default_goal,
+        request_id="req",
+        doc_fingerprint="fp",
     )
 
     result = analyze_report.analyze_credit_report(
@@ -235,6 +250,7 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
         tmp_path / "out.json",
         {"goal": "improve credit", "is_identity_theft": identity_theft},
         ai_client=client,
+        request_id="req",
     )
     assert result == baseline
 
@@ -258,5 +274,6 @@ def test_analyze_credit_report_skips_ai(monkeypatch, tmp_path):
         {},
         ai_client=None,
         run_ai=False,
+        request_id="req",
     )
     assert result["negative_accounts"] == []


### PR DESCRIPTION
## Summary
- log report segment calls with request id, document fingerprint, bureau and AI usage metrics
- funnel logging through audit utilities and aggregate cost/latency in analytics tracker
- plumb request identifiers through analysis pipeline

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cb0413e54832585efd9774ae9936b