### PR TITLE
feat: add PII redaction and raw storage flag

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -34,6 +34,7 @@ def env_int(name: str, default: int) -> int:
 CLASSIFY_CACHE_ENABLED = env_bool("CLASSIFY_CACHE_ENABLED", True)
 CLASSIFY_CACHE_MAXSIZE = env_int("CLASSIFY_CACHE_MAXSIZE", 5000)
 CLASSIFY_CACHE_TTL_SEC = env_int("CLASSIFY_CACHE_TTL_SEC", 0)
+ANALYSIS_DEBUG_STORE_RAW = env_bool("ANALYSIS_DEBUG_STORE_RAW", False)
 
 
 @dataclass

--- a/backend/core/logic/utils/pii.py
+++ b/backend/core/logic/utils/pii.py
@@ -1,0 +1,22 @@
+"""Helpers for redacting personally identifiable information from text."""
+
+from __future__ import annotations
+
+import re
+
+_EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+_PHONE_RE = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_ACCOUNT_RE = re.compile(r"\b\d{12,16}\b")
+
+_PATTERNS = (_EMAIL_RE, _PHONE_RE, _SSN_RE, _ACCOUNT_RE)
+
+
+def redact_pii(text: str) -> str:
+    """Return ``text`` with common PII patterns replaced by ``[REDACTED]``."""
+    if not text:
+        return ""
+    redacted = text
+    for pattern in _PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -41,7 +41,12 @@ def test_extract_text_from_pdf_calls_pdf_ops(monkeypatch):
     assert called["max_chars"] == 150000
 
 
-def test_call_ai_analysis_parses_json(tmp_path):
+def test_call_ai_analysis_parses_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYSIS_DEBUG_STORE_RAW", "1")
+    import backend.api.config as conf
+
+    importlib.reload(conf)
+
     utils_pkg = types.ModuleType("backend.core.logic.utils")
     utils_pkg.__path__ = [
         str(
@@ -71,6 +76,7 @@ def test_call_ai_analysis_parses_json(tmp_path):
     )
     assert data["inquiries"] == []
     assert out.with_name(out.stem + "_raw.txt").exists()
+    report_prompting.ANALYSIS_DEBUG_STORE_RAW = False
 
 
 def test_call_ai_analysis_populates_defaults_and_logs(tmp_path, caplog):

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -5,6 +5,7 @@ from backend.core.logic.utils.inquiries import extract_inquiries
 from backend.core.logic.utils.names_normalization import normalize_bureau_name
 from backend.core.logic.utils.note_handling import get_client_address_lines
 from backend.core.logic.utils.pdf_ops import gather_supporting_docs_text
+from backend.core.logic.utils.pii import redact_pii
 from backend.core.logic.utils.report_sections import filter_sections_by_bureau
 from backend.core.logic.utils.text_parsing import has_late_indicator
 
@@ -26,3 +27,8 @@ def test_utils_smoke(tmp_path: Path):
     sections = {"negative_accounts": [{"name": "Cap One", "bureaus": ["Experian"]}]}
     filtered = filter_sections_by_bureau(sections, "Experian")
     assert filtered["disputes"]
+
+    red = redact_pii("email test@example.com phone 555-111-2222 ssn 123-45-6789")
+    assert "test@example.com" not in red
+    assert "555-111-2222" not in red
+    assert "123-45-6789" not in red


### PR DESCRIPTION
## Summary
- add redact_pii utility to strip emails, phones, SSNs and account numbers
- gate saving analysis raw text behind ANALYSIS_DEBUG_STORE_RAW flag
- sanitize raw analysis output before writing debug file

## Testing
- `pre-commit run --files backend/api/config.py backend/core/logic/report_analysis/report_prompting.py backend/core/logic/utils/pii.py tests/test_report_modules.py tests/test_utils_smoke.py`
- `pytest tests/test_utils_smoke.py::test_utils_smoke tests/test_report_modules.py::test_call_ai_analysis_parses_json -q`


------
https://chatgpt.com/codex/tasks/task_b_689cb79d7c088325a68c211c980ea3ac