### PR TITLE
chore: track analysis prompt and schema versions

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -35,7 +35,11 @@ from .report_postprocessing import (
     _reconcile_account_headings,
     validate_analysis_sanity,
 )
-from .report_prompting import call_ai_analysis
+from .report_prompting import (
+    ANALYSIS_PROMPT_VERSION,
+    ANALYSIS_SCHEMA_VERSION,
+    call_ai_analysis,
+)
 
 # ---------------------------------------------------------------------------
 # Orchestrator
@@ -73,7 +77,11 @@ def analyze_credit_report(
         strategic_context = client_info.get("goal", "Not specified")
 
     is_identity_theft = client_info.get("is_identity_theft", False)
-    doc_fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    doc_fingerprint = hashlib.sha256(
+        f"{text}|{ANALYSIS_PROMPT_VERSION}|{ANALYSIS_SCHEMA_VERSION}".encode(
+            "utf-8"
+        )
+    ).hexdigest()
     if run_ai:
         result = call_ai_analysis(
             text,
@@ -93,6 +101,9 @@ def analyze_credit_report(
             "all_accounts": [],
             "inquiries": [],
         }
+
+    result["prompt_version"] = ANALYSIS_PROMPT_VERSION
+    result["schema_version"] = ANALYSIS_SCHEMA_VERSION
 
     _reconcile_account_headings(result, heading_map)
 

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -36,6 +36,9 @@ _SCHEMA_PATH = Path(__file__).with_name("analysis_schema.json")
 _ANALYSIS_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 _ANALYSIS_VALIDATOR = Draft7Validator(_ANALYSIS_SCHEMA)
 
+ANALYSIS_PROMPT_VERSION = 1
+ANALYSIS_SCHEMA_VERSION = 1
+
 try:  # pragma: no cover - fallback when app config is unavailable
     from backend.api.config import ANALYSIS_DEBUG_STORE_RAW
 except Exception:  # pragma: no cover
@@ -412,6 +415,8 @@ def call_ai_analysis(
                     "request_id": request_id,
                     "doc_fingerprint": doc_fingerprint,
                     "bureau": bureau,
+                    "prompt_version": ANALYSIS_PROMPT_VERSION,
+                    "schema_version": ANALYSIS_SCHEMA_VERSION,
                     "tokens_in": tokens_in,
                     "tokens_out": tokens_out,
                     "latency_ms": latency_ms,
@@ -455,5 +460,7 @@ def call_ai_analysis(
 
     if summary_metrics:
         aggregate["summary_metrics"] = summary_metrics
+    aggregate["prompt_version"] = ANALYSIS_PROMPT_VERSION
+    aggregate["schema_version"] = ANALYSIS_SCHEMA_VERSION
 
     return aggregate


### PR DESCRIPTION
## Summary
- add `ANALYSIS_PROMPT_VERSION` and `ANALYSIS_SCHEMA_VERSION` constants
- log and return prompt/schema versions from report analysis
- include analysis version info in document fingerprint

## Testing
- `scripts/run_checks.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cb96e98b88325ac6f988fc5701302