### PR TITLE
feat: add analysis flags

### DIFF
--- a/backend/core/logic/report_analysis/flags.py
+++ b/backend/core/logic/report_analysis/flags.py
@@ -1,0 +1,37 @@
+"""Runtime flags controlling report analysis behavior.
+
+Each flag can be overridden via an environment variable of the same name.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except ValueError:
+        return default
+
+
+@dataclass
+class AnalysisFlags:
+    """Container for report analysis feature flags."""
+
+    chunk_by_bureau: bool = _env_bool("ANALYSIS_CHUNK_BY_BUREAU", True)
+    inject_headings: bool = _env_bool("ANALYSIS_INJECT_HEADINGS", True)
+    cache_enabled: bool = _env_bool("ANALYSIS_CACHE_ENABLED", True)
+    debug_store_raw: bool = _env_bool("ANALYSIS_DEBUG_STORE_RAW", False)
+    max_remediation_passes: int = _env_int("ANALYSIS_MAX_REMEDIATION_PASSES", 2)
+
+
+FLAGS = AnalysisFlags()

--- a/docs/ANALYSIS_FLAGS.md
+++ b/docs/ANALYSIS_FLAGS.md
@@ -1,0 +1,11 @@
+# Analysis Flags
+
+Environment variables that tweak the credit report analysis flow. Defaults are shown in parentheses.
+
+- `ANALYSIS_CHUNK_BY_BUREAU` (`1`): split report text by bureau before sending to the model. Set to `0` to analyze the full report at once.
+- `ANALYSIS_INJECT_HEADINGS` (`1`): if enabled, detected account headings are prepended to the prompt.
+- `ANALYSIS_CACHE_ENABLED` (`1`): enables caching of analysis results.
+- `ANALYSIS_DEBUG_STORE_RAW` (`0`): when true, store the raw model response and debugging excerpts alongside the JSON output.
+- `ANALYSIS_MAX_REMEDIATION_PASSES` (`2`): number of remediation attempts after schema validation errors.
+
+Flags are defined in `backend/core/logic/report_analysis/flags.py` and can be adjusted via environment variables or by modifying `FLAGS` at runtime.


### PR DESCRIPTION
## Summary
- add AnalysisFlags dataclass for report analysis tuning
- use flags in `call_ai_analysis` and document behavior

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/flags.py backend/core/logic/report_analysis/report_prompting.py docs/ANALYSIS_FLAGS.md tests/test_report_modules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cbbdfd7c88325b34bef77f3efb78e