### PR TITLE
feat: enforce json-only analysis responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Analysis prompt now instructs models to respond with valid JSON only, using `null` or empty arrays when data is unknown and avoiding invented fields. Bump `ANALYSIS_PROMPT_VERSION` to 2.
 ### Removed
 - Remove deprecated shims and aliases in audit, letter rendering, goodwill letters, instructions, and report analysis modules.
 - Remove unused `logic.copy_documents` module.

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -35,8 +35,10 @@ _OUTPUT_COST_PER_TOKEN = 0.03 / 1000
 _SCHEMA_PATH = Path(__file__).with_name("analysis_schema.json")
 _ANALYSIS_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 _ANALYSIS_VALIDATOR = Draft7Validator(_ANALYSIS_SCHEMA)
-
-ANALYSIS_PROMPT_VERSION = 1
+# ANALYSIS_PROMPT_VERSION history:
+# 2: Add explicit JSON directive (Task 8)
+# 1: Initial version
+ANALYSIS_PROMPT_VERSION = 2
 ANALYSIS_SCHEMA_VERSION = 1
 
 
@@ -153,6 +155,8 @@ def _run_segment(
     )
 
     prompt = f"""{heading_summary}
+
+Respond with **valid JSON only**; use `null` or empty arrays when data is unknown; do **not** invent fields.
 
 You are a senior credit repair expert with deep knowledge of credit reports, FCRA regulations, dispute strategies, and client psychology.
 

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -118,6 +118,42 @@ def test_call_ai_analysis_populates_defaults_and_logs(tmp_path, caplog):
     assert any(r.__dict__.get("validation_errors") for r in caplog.records)
 
 
+def test_call_ai_analysis_rejects_non_json(tmp_path, caplog):
+    utils_pkg = types.ModuleType("backend.core.logic.utils")
+    utils_pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[1]
+            / "backend"
+            / "core"
+            / "logic"
+            / "utils"
+        )
+    ]
+    sys.modules["backend.core.logic.utils"] = utils_pkg
+
+    fake_pdf_ops = types.ModuleType("backend.core.logic.utils.pdf_ops")
+    fake_pdf_ops.extract_pdf_text_safe = lambda *a, **k: ""
+    sys.modules.setdefault("backend.core.logic.utils.pdf_ops", fake_pdf_ops)
+    report_prompting = importlib.import_module(
+        "backend.core.logic.report_analysis.report_prompting"
+    )
+
+    client = FakeAIClient()
+    client.add_chat_response("not json")
+    out = tmp_path / "result.json"
+    with caplog.at_level(logging.WARNING):
+        data = report_prompting.call_ai_analysis(
+            "text",
+            False,
+            out,
+            ai_client=client,
+            request_id="req",
+            doc_fingerprint="fp",
+        )
+    assert data["negative_accounts"] == []
+    assert any(r.__dict__.get("validation_errors") for r in caplog.records)
+
+
 def test_call_ai_analysis_merges_segments(tmp_path):
     utils_pkg = types.ModuleType("backend.core.logic.utils")
     utils_pkg.__path__ = [


### PR DESCRIPTION
## Summary
- require valid JSON responses for report analysis segments
- bump analysis prompt version and log change
- test schema validation rejects non-JSON output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cc01c4c0883258db2472a7c8f9f3b