### PR TITLE
Add versioned analysis caching for report analysis

### DIFF
--- a/backend/core/logic/report_analysis/analysis_cache.py
+++ b/backend/core/logic/report_analysis/analysis_cache.py
@@ -1,0 +1,51 @@
+import random
+import time
+from typing import Any, Dict, Tuple
+
+_MIN_TTL_SEC = 14 * 24 * 60 * 60
+_MAX_TTL_SEC = 30 * 24 * 60 * 60
+
+CacheKey = Tuple[str, str, str, str]
+CacheValue = Tuple[Dict[str, Any], float, int, int]
+
+_CACHE: Dict[CacheKey, CacheValue] = {}
+
+def _now() -> float:
+    return time.time()
+
+def get_cached_analysis(
+    doc_fingerprint: str,
+    bureau: str,
+    prompt_hash: str,
+    model_version: str,
+    *,
+    prompt_version: int,
+    schema_version: int,
+) -> Dict[str, Any] | None:
+    key = (doc_fingerprint, bureau, prompt_hash, model_version)
+    item = _CACHE.get(key)
+    if not item:
+        return None
+    data, expires, p_version, s_version = item
+    if _now() > expires or p_version != prompt_version or s_version != schema_version:
+        _CACHE.pop(key, None)
+        return None
+    return data
+
+def store_cached_analysis(
+    doc_fingerprint: str,
+    bureau: str,
+    prompt_hash: str,
+    model_version: str,
+    result: Dict[str, Any],
+    *,
+    prompt_version: int,
+    schema_version: int,
+) -> None:
+    ttl = random.randint(_MIN_TTL_SEC, _MAX_TTL_SEC)
+    expires = _now() + ttl
+    key = (doc_fingerprint, bureau, prompt_hash, model_version)
+    _CACHE[key] = (result, expires, prompt_version, schema_version)
+
+def reset_cache() -> None:
+    _CACHE.clear()

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -61,6 +61,9 @@ def test_call_ai_analysis_parses_json(tmp_path, monkeypatch):
     report_prompting = importlib.import_module(
         "backend.core.logic.report_analysis.report_prompting"
     )
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
     ra_flags.FLAGS.debug_store_raw = True
 
     assert ra_flags.FLAGS.debug_store_raw
@@ -74,7 +77,7 @@ def test_call_ai_analysis_parses_json(tmp_path, monkeypatch):
         ai_client=client,
         strategic_context="goal",
         request_id="req",
-        doc_fingerprint="fp",
+        doc_fingerprint="fp1",
     )
     assert data["inquiries"] == []
     assert data["prompt_version"] == report_prompting.ANALYSIS_PROMPT_VERSION
@@ -97,6 +100,9 @@ def test_call_ai_analysis_populates_defaults_and_logs(tmp_path, caplog):
     report_prompting = importlib.import_module(
         "backend.core.logic.report_analysis.report_prompting"
     )
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
 
     client = FakeAIClient()
     client.add_chat_response("{}")
@@ -109,7 +115,7 @@ def test_call_ai_analysis_populates_defaults_and_logs(tmp_path, caplog):
             ai_client=client,
             strategic_context="goal",
             request_id="req",
-            doc_fingerprint="fp",
+            doc_fingerprint="fp2",
         )
     assert data["negative_accounts"] == []
     assert data["summary_metrics"]["total_inquiries"] == 0
@@ -137,6 +143,9 @@ def test_call_ai_analysis_rejects_non_json(tmp_path, caplog):
     report_prompting = importlib.import_module(
         "backend.core.logic.report_analysis.report_prompting"
     )
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
 
     client = FakeAIClient()
     client.add_chat_response("not json")
@@ -148,7 +157,7 @@ def test_call_ai_analysis_rejects_non_json(tmp_path, caplog):
             out,
             ai_client=client,
             request_id="req",
-            doc_fingerprint="fp",
+            doc_fingerprint="fp3",
         )
     assert data["negative_accounts"] == []
     assert any(r.__dict__.get("validation_errors") for r in caplog.records)
@@ -169,6 +178,9 @@ def test_call_ai_analysis_merges_segments(tmp_path):
     report_prompting = importlib.import_module(
         "backend.core.logic.report_analysis.report_prompting"
     )
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
 
     client = FakeAIClient()
     client.add_chat_response(
@@ -185,7 +197,7 @@ def test_call_ai_analysis_merges_segments(tmp_path):
         out,
         ai_client=client,
         request_id="req",
-        doc_fingerprint="fp",
+        doc_fingerprint="fp4",
     )
     assert len(data["inquiries"]) == 2
     assert sorted(data["all_accounts"][0]["bureaus"]) == [
@@ -276,6 +288,9 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
     client.add_chat_response(response)
     client.add_chat_response(response)
 
+    from backend.core.logic.report_analysis import analysis_cache
+    analysis_cache.reset_cache()
+
     # Parsing stage
     monkeypatch.setattr(report_parsing, "extract_text_from_pdf", lambda p: "text")
     monkeypatch.setattr(analyze_report, "extract_inquiries", lambda text: [])
@@ -320,7 +335,7 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
         ai_client=client,
         strategic_context=default_goal,
         request_id="req",
-        doc_fingerprint="fp",
+        doc_fingerprint="fp5",
     )
 
     result = analyze_report.analyze_credit_report(


### PR DESCRIPTION
## Summary
- add in-memory cache for AI analysis results with 14–30 day TTL
- compute prompt hash and model version to reuse previous segment analysis
- ensure tests reset cache for isolation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cc3c5b7948325b78db3a4a70ba1d5