### PR TITLE
Add confidence metrics and review flags to report analysis

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -100,6 +100,8 @@ def analyze_credit_report(
             "high_utilization_accounts": [],
             "all_accounts": [],
             "inquiries": [],
+            "needs_human_review": False,
+            "missing_bureaus": [],
         }
 
     result["prompt_version"] = ANALYSIS_PROMPT_VERSION


### PR DESCRIPTION
## Summary
- compute confidence from heading matches and JSON validity in `_run_segment`
- aggregate `needs_human_review` and `missing_bureaus` in `call_ai_analysis` and merge per-item confidence
- propagate review flags when skipping AI analysis

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ccd33f7d48325ab8d785ec5076942