### PR TITLE
Fix mypy target and document Stage 3 fields

### DIFF
--- a/backend/core/logic/report_analysis/README.md
+++ b/backend/core/logic/report_analysis/README.md
@@ -34,3 +34,14 @@ Ingests the uploaded PDF and produces bureau‑specific sections (`disputes`, `g
 ## Guardrails / constraints
 - Sanitization helpers ensure PII is normalized and late-payment data is validated.
 - Summaries should remain factual and neutral.
+
+## Output fields
+The JSON produced by this stage may include informational fields that are not
+yet consumed by downstream modules:
+
+- `confidence`: heuristic confidence score for AI parsing.
+- `needs_human_review`: flag indicating analysis uncertainty.
+- `missing_bureaus`: list of bureaus absent from the source report.
+
+These fields are optional and safely ignored by letter generation and
+instructions pipelines.

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,5 +5,5 @@ warn_unused_configs = True
 ignore_missing_imports = True
 warn_redundant_casts = True
 
-[mypy-models.*]
+[mypy-backend.core.models.*]
 disallow_any_generics = True

--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ruff check tests/test_architecture.py
 black --check tests/test_architecture.py
-mypy models
+# Run mypy on the typed models package
+mypy backend/core/models
 python scripts/scan_public_dict_apis.py
 pytest -q


### PR DESCRIPTION
## Summary
- run mypy on actual typed models package so `scripts/run_checks.sh` no longer fails
- document Stage 3 analysis fields and note they are informational only

## Testing
- `./scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_b_689cd6d5ca1c832592549bb7c19e7737