### PR TITLE
Add evaluation methodology and helper scripts

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -1,0 +1,54 @@
+# Evaluation Methodology
+
+This document describes a lightweight procedure for validating changes to the
+credit report pipeline. The goal is to run the same sample of reports against
+multiple code revisions and compare high‑level metrics.
+
+## 1. Sample reports
+
+1. Collect **5–10** representative credit reports in JSON format.
+2. Store them in a folder such as `sample_reports/`.
+3. The files should contain the following optional fields used by the scripts:
+   - `accounts` – list of parsed accounts
+   - `inquiries` – list of inquiry records
+   - `duplicates_removed` – list of entries removed as duplicates
+   - `cost` – numeric processing cost for the report
+
+## 2. Collect metrics
+
+Run the evaluation script on the sampled reports and persist the aggregated
+metrics. Execute this once on the current baseline (`pre`) and once after your
+changes (`post`).
+
+```bash
+# Pre‑change metrics
+python scripts/run_eval.py sample_reports/*.json --output pre_metrics.json
+
+# Post‑change metrics
+python scripts/run_eval.py sample_reports/*.json --output post_metrics.json
+```
+
+Each run reports the average of these metrics across all sampled reports:
+
+| Metric | Description |
+| ------ | ----------- |
+| `accounts_found` | Number of accounts extracted |
+| `inquiries_found` | Number of inquiry records |
+| `dup_removed` | Count of duplicates removed |
+| `latency` | Processing time in seconds |
+| `cost` | Dollar cost of processing |
+
+## 3. Compare results
+
+Use the comparison helper to view the delta between the two runs:
+
+```bash
+python scripts/compare_eval.py pre_metrics.json post_metrics.json
+```
+
+Investigate any unexpected changes before finalizing your pull request.
+
+## 4. Reporting
+
+Record the metric outputs and any observations in the pull request description
+or linked issue so reviewers can see the impact of the change.

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def load_metrics(path: Path) -> dict[str, float]:
+    return json.loads(path.read_text())
+
+
+def compare(
+    pre: dict[str, float], post: dict[str, float]
+) -> dict[str, tuple[float, float, float]]:
+    keys = sorted(set(pre) | set(post))
+    diff: dict[str, tuple[float, float, float]] = {}
+    for k in keys:
+        pre_v = float(pre.get(k, 0))
+        post_v = float(post.get(k, 0))
+        diff[k] = (pre_v, post_v, post_v - pre_v)
+    return diff
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("usage: compare_eval.py pre.json post.json")
+        raise SystemExit(1)
+    pre = load_metrics(Path(sys.argv[1]))
+    post = load_metrics(Path(sys.argv[2]))
+    for metric, values in compare(pre, post).items():
+        pre_v, post_v, delta = values
+        print(f"{metric}: pre={pre_v} post={post_v} delta={delta}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+
+def extract_metrics(path: Path) -> dict[str, float]:
+    start = time.perf_counter()
+    data = json.loads(path.read_text())
+    latency = time.perf_counter() - start
+    metrics = {
+        "accounts_found": len(data.get("accounts", [])),
+        "inquiries_found": len(data.get("inquiries", [])),
+        "dup_removed": len(data.get("duplicates_removed", [])),
+        "latency": latency,
+        "cost": float(data.get("cost", 0)),
+    }
+    return metrics
+
+
+def aggregate(results: list[dict[str, float]]) -> dict[str, float]:
+    aggregated: dict[str, float] = {}
+    for key in results[0].keys():
+        aggregated[key] = statistics.fmean(r[key] for r in results)
+    return aggregated
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Collect evaluation metrics for report files"
+    )
+    parser.add_argument(
+        "reports", nargs="+", type=Path, help="Paths to sampled report JSON files"
+    )
+    parser.add_argument(
+        "--output", type=Path, help="Optional path to write aggregated metrics JSON"
+    )
+    args = parser.parse_args()
+    metrics = [extract_metrics(p) for p in args.reports]
+    aggregated = aggregate(metrics)
+    output = json.dumps(aggregated, indent=2)
+    print(output)
+    if args.output:
+        args.output.write_text(output)


### PR DESCRIPTION
## Summary
- document evaluation methodology and metrics
- add scripts for gathering and comparing evaluation metrics

## Testing
- `ruff check scripts/run_eval.py scripts/compare_eval.py`
- `black --check scripts/run_eval.py scripts/compare_eval.py`
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_b_689cd88a41508325a815d425975da41a