### PR TITLE
chore: type-check report analysis

### DIFF
--- a/backend/core/logic/report_analysis/extract_info.py
+++ b/backend/core/logic/report_analysis/extract_info.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections import Counter
-from typing import Dict, List, Mapping
+from typing import Any, Dict, List, Mapping
 
 import pdfplumber
 
@@ -35,7 +35,7 @@ def extract_bureau_info_column_refined(
     ai_client: AIClient,
     client_info: dict | None = None,
     use_ai: bool = False,
-) -> Mapping[str, Dict[str, str]]:
+) -> Mapping[str, Any]:
     bureaus = BUREAUS
     data = {b: {"name": "", "dob": "", "current_address": ""} for b in bureaus}
     discrepancies = []
@@ -45,7 +45,7 @@ def extract_bureau_info_column_refined(
         words = page.extract_words()
         raw_text = page.extract_text()
 
-    columns = {b: [] for b in bureaus}
+    columns: Dict[str, List[Dict[str, Any]]] = {b: [] for b in bureaus}
     for w in words:
         x0 = float(w["x0"])
         if x0 < 200:

--- a/backend/core/logic/report_analysis/process_accounts.py
+++ b/backend/core/logic/report_analysis/process_accounts.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, cast
 
 from backend.audit.audit import AuditLogger
 from backend.core.logic.compliance.constants import FallbackReason
@@ -105,7 +105,7 @@ def infer_recovery_summary(account: Account) -> str:
 
 def load_analyzed_report(json_path: Path) -> Mapping[str, Any]:
     with open(json_path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        return cast(Mapping[str, Any], json.load(f))
 
 
 # 🎯 Process and categorize by bureau
@@ -123,7 +123,7 @@ def process_analyzed_report(
     """
     data = load_analyzed_report(Path(json_path))
 
-    output = {
+    output: Dict[str, Dict[str, List[Any]]] = {
         bureau: {
             "disputes": [],
             "goodwill": [],
@@ -211,8 +211,8 @@ def process_analyzed_report(
                 )
 
     # 4. Inquiries (exclude matched)
-    def norm(name: str) -> str:
-        return normalize_creditor_name(name or "")
+    def norm(name: str | None) -> str:
+        return cast(str, normalize_creditor_name(name or ""))
 
     matched_names = set()
     for match in data.get("account_inquiry_matches", []):

--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -1,7 +1,7 @@
 """Utilities for parsing credit report PDFs into text and sections."""
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 
 def extract_text_from_pdf(pdf_path: str | Path) -> str:
@@ -23,14 +23,14 @@ def extract_text_from_pdf(pdf_path: str | Path) -> str:
     """
     from backend.core.logic.utils.pdf_ops import extract_pdf_text_safe
 
-    return extract_pdf_text_safe(Path(pdf_path), max_chars=150000)
+    return cast(str, extract_pdf_text_safe(Path(pdf_path), max_chars=150000))
 
 
 from backend.core.models.bureau import BureauAccount  # noqa: E402
 
 
 def bureau_data_from_dict(
-    data: Mapping[str, list[dict[str, Any]]]
+    data: Mapping[str, list[dict[str, Any]]],
 ) -> Mapping[str, list[BureauAccount]]:
     """Convert raw bureau ``data`` to typed ``BureauAccount`` objects.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,11 @@ warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True
 warn_redundant_casts = True
+follow_imports = skip
+files = backend/core/models, backend/core/logic/report_analysis
 
 [mypy-backend.core.models.*]
 disallow_any_generics = True
+follow_imports = normal
+
+[mypy-backend.core.logic.report_analysis.*]

--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ruff check tests/test_architecture.py
 black --check tests/test_architecture.py
-# Run mypy on the typed models package
-mypy backend/core/models
+# Run mypy on the typed packages
+mypy backend/core/models backend/core/logic/report_analysis
 python scripts/scan_public_dict_apis.py
 pytest -q


### PR DESCRIPTION
## Summary
- expand mypy coverage to `backend/core/logic/report_analysis`
- annotate report analysis utilities to satisfy new mypy checks
- run mypy on report analysis in CI script

## Testing
- `mypy backend/core/models backend/core/logic/report_analysis`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd9d1ef508325b3cd0990b13b6f43