### PR TITLE
Add policy rulebook loader with schema validation

### DIFF
--- a/backend/policy/__init__.py
+++ b/backend/policy/__init__.py
@@ -1,0 +1,1 @@
+"""Policy management utilities."""

--- a/backend/policy/policy_loader.py
+++ b/backend/policy/policy_loader.py
@@ -1,0 +1,50 @@
+"""Utilities for loading and validating the policy rulebook."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from jsonschema import Draft7Validator, ValidationError
+
+_RULEBOOK_PATH = Path(__file__).with_name("rulebook.yaml")
+_SCHEMA_PATH = Path(__file__).with_name("rulebook_schema.yaml")
+
+_RULEBOOK_CACHE: Mapping[str, Any] | None = None
+_RULEBOOK_VERSION: str | None = None
+
+
+def load_rulebook() -> Mapping[str, Any]:
+    """Load and return the policy rulebook.
+
+    The rulebook is validated against ``rulebook_schema.yaml``. A
+    ``ValidationError`` is raised if the rulebook does not conform to the
+    schema.
+    """
+
+    global _RULEBOOK_CACHE
+    if _RULEBOOK_CACHE is not None:
+        return _RULEBOOK_CACHE
+
+    data = yaml.safe_load(_RULEBOOK_PATH.read_text(encoding="utf-8"))
+    schema = yaml.safe_load(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = Draft7Validator(schema)
+    validator.validate(data)  # May raise ValidationError
+    _RULEBOOK_CACHE = data
+    return _RULEBOOK_CACHE
+
+
+def get_rulebook_version() -> str:
+    """Return a stable hash representing the current rulebook version."""
+
+    global _RULEBOOK_VERSION
+    if _RULEBOOK_VERSION is None:
+        _RULEBOOK_VERSION = hashlib.sha256(
+            _RULEBOOK_PATH.read_bytes()
+        ).hexdigest()
+    return _RULEBOOK_VERSION
+
+
+__all__ = ["load_rulebook", "get_rulebook_version", "ValidationError"]

--- a/tests/policy/test_policy_loader.py
+++ b/tests/policy/test_policy_loader.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import hashlib
+
+from backend.policy.policy_loader import get_rulebook_version, load_rulebook
+
+
+def test_load_rulebook_empty_rules():
+    data = load_rulebook()
+    assert data["rules"] == []
+
+
+def test_rulebook_version_matches_file_hash():
+    version = get_rulebook_version()
+    expected = hashlib.sha256(
+        Path("backend/policy/rulebook.yaml").read_bytes()
+    ).hexdigest()
+    assert version == expected


### PR DESCRIPTION
## Summary
- add policy loader that validates rulebook against schema
- compute rulebook version via sha256 hash
- test loading of empty rulebook and version hash

## Testing
- `pytest tests/policy/test_policy_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689d0d8addd48325b4158adf54888e34