### PR TITLE
Add strategy normalizer v2.5 with default statement handling

### DIFF
--- a/backend/core/logic/strategy/normalizer_2_5.py
+++ b/backend/core/logic/strategy/normalizer_2_5.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Protocol
+
+
+class Rulebook(Protocol):
+    """Protocol representing a rulebook with a version attribute."""
+
+    version: str
+
+
+def neutralize_admissions(statement: str) -> str:
+    """Return a legally safe version of ``statement``.
+
+    This is currently a stub that returns the statement unchanged.
+    """
+
+    return statement
+
+
+def evaluate_rules(
+    normalized_statement: str, account_facts: Dict[str, Any], rulebook: Rulebook
+) -> Dict[str, list]:
+    """Evaluate ``normalized_statement`` against the ``rulebook``.
+
+    This stub returns empty results.
+    """
+
+    return {"rule_hits": [], "needs_evidence": [], "red_flags": []}
+
+
+def normalize_and_tag(
+    account_cls: Dict[str, Any], account_facts: Dict[str, Any], rulebook: Rulebook
+) -> Dict[str, Any]:
+    """Normalize user statements and tag accounts with rulebook metadata."""
+
+    user_statement_raw = (
+        account_cls.get("user_statement_raw")
+        or account_facts.get("user_statement_raw")
+        or "No statement provided"
+    )
+    legal_safe_summary = neutralize_admissions(user_statement_raw)
+    evaluation = evaluate_rules(legal_safe_summary, account_facts, rulebook)
+    rulebook_version = getattr(rulebook, "version", "")
+    if not rulebook_version and isinstance(rulebook, Mapping):
+        rulebook_version = str(rulebook.get("version", ""))
+
+    return {
+        "legal_safe_summary": legal_safe_summary,
+        "suggested_dispute_frame": "",
+        "rule_hits": evaluation.get("rule_hits", []),
+        "needs_evidence": evaluation.get("needs_evidence", []),
+        "red_flags": evaluation.get("red_flags", []),
+        "rulebook_version": rulebook_version,
+    }
+
+
+__all__ = [
+    "normalize_and_tag",
+    "neutralize_admissions",
+    "evaluate_rules",
+    "Rulebook",
+]

--- a/tests/strategy/test_normalizer_2_5.py
+++ b/tests/strategy/test_normalizer_2_5.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.core.logic.strategy.normalizer_2_5 import normalize_and_tag
+
+
+class DummyRulebook:
+    def __init__(self, version: str = "v1") -> None:
+        self.version = version
+
+
+@pytest.fixture
+def rulebook() -> DummyRulebook:
+    return DummyRulebook("2024-01")
+
+
+def test_missing_user_statement(rulebook: DummyRulebook) -> None:
+    result = normalize_and_tag({}, {}, rulebook)
+    assert result["legal_safe_summary"] == "No statement provided"
+    assert result["suggested_dispute_frame"] == ""
+    assert result["rule_hits"] == []
+    assert result["needs_evidence"] == []
+    assert result["red_flags"] == []
+    assert result["rulebook_version"] == "2024-01"
+
+
+def test_statement_passthrough(rulebook: DummyRulebook) -> None:
+    account_cls = {"user_statement_raw": "I paid on time"}
+    result = normalize_and_tag(account_cls, {}, rulebook)
+    assert result["legal_safe_summary"] == "I paid on time"


### PR DESCRIPTION
## Summary
- introduce `normalize_and_tag` for normalizer v2.5
- provide default message when user statement missing
- stub out rule evaluation and add unit tests

## Testing
- `pytest tests/strategy/test_normalizer_2_5.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d121dd5f8832598ee2b0811dd774e