### PR TITLE
feat: include stage 2.5 context in strategy

### DIFF
--- a/backend/core/models/strategy.py
+++ b/backend/core/models/strategy.py
@@ -34,6 +34,11 @@ class StrategyItem:
     name: str
     account_number: Optional[str] = None
     recommendation: Recommendation | None = None
+    legal_safe_summary: Optional[str] = None
+    suggested_dispute_frame: Optional[str] = None
+    rule_hits: List[str] = field(default_factory=list)
+    needs_evidence: List[str] = field(default_factory=list)
+    red_flags: List[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "StrategyItem":
@@ -42,6 +47,11 @@ class StrategyItem:
             name=data.get("name", ""),
             account_number=data.get("account_number"),
             recommendation=Recommendation.from_dict(data) if data else None,
+            legal_safe_summary=data.get("legal_safe_summary"),
+            suggested_dispute_frame=data.get("suggested_dispute_frame"),
+            rule_hits=list(data.get("rule_hits", []) or []),
+            needs_evidence=list(data.get("needs_evidence", []) or []),
+            red_flags=list(data.get("red_flags", []) or []),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/strategy/test_strategy_plan_compat.py
+++ b/tests/strategy/test_strategy_plan_compat.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.core.models.strategy import StrategyPlan
+
+
+def test_parses_legacy_strategy():
+    data = {
+        "accounts": [
+            {
+                "account_id": "1",
+                "name": "Account A",
+                "account_number": "1234",
+                "recommendation": {"recommended_action": "Dispute"},
+            }
+        ]
+    }
+    plan = StrategyPlan.from_dict(data)
+    item = plan.accounts[0]
+    assert item.account_id == "1"
+    assert item.legal_safe_summary is None
+    assert item.rule_hits == []
+
+
+def test_parses_new_fields():
+    data = {
+        "accounts": [
+            {
+                "account_id": "1",
+                "name": "Account A",
+                "account_number": "1234",
+                "legal_safe_summary": "summary",
+                "suggested_dispute_frame": "frame",
+                "rule_hits": ["R1"],
+                "needs_evidence": ["E1"],
+                "red_flags": ["F1"],
+                "recommendation": {"recommended_action": "Dispute"},
+            }
+        ]
+    }
+    plan = StrategyPlan.from_dict(data)
+    item = plan.accounts[0]
+    assert item.legal_safe_summary == "summary"
+    assert item.suggested_dispute_frame == "frame"
+    assert item.rule_hits == ["R1"]
+    assert item.needs_evidence == ["E1"]
+    assert item.red_flags == ["F1"]


### PR DESCRIPTION
## Summary
- include stage 2.5 analysis details in strategy prompts and saved reports
- extend strategy model to store legal summaries and rule evaluation metadata
- add compatibility tests for legacy strategy records

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d16519fb48325b0443261a7356edd