### PR TITLE
feat: capture rule evaluations in strategy snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - Analysis prompt now instructs models to respond with valid JSON only, using `null` or empty arrays when data is unknown and avoiding invented fields. Bump `ANALYSIS_PROMPT_VERSION` to 2.
+- Strategy snapshot now records rulebook version, rule hits, evidence needs, and red flags and emits structured audit events.
 ### Removed
 - Remove deprecated shims and aliases in audit, letter rendering, goodwill letters, instructions, and report analysis modules.
 - Remove unused `logic.copy_documents` module.

--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -5,6 +5,7 @@ from .bureau import BureauAccount, BureauPayload, BureauSection
 from .client import ClientInfo, ProofDocuments
 from .letter import LetterAccount, LetterArtifact, LetterContext
 from .strategy import Recommendation, StrategyItem, StrategyPlan
+from .strategy_snapshot import StrategySnapshot
 
 __all__ = [
     "Account",
@@ -17,6 +18,7 @@ __all__ = [
     "BureauPayload",
     "StrategyPlan",
     "StrategyItem",
+    "StrategySnapshot",
     "Recommendation",
     "LetterContext",
     "LetterAccount",

--- a/backend/core/models/strategy_snapshot.py
+++ b/backend/core/models/strategy_snapshot.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, List
+
+
+@dataclass
+class StrategySnapshot:
+    """Per-account snapshot of rulebook evaluation results."""
+
+    legal_safe_summary: str = ""
+    suggested_dispute_frame: str = ""
+    rulebook_version: str = ""
+    rule_hits: List[str] = field(default_factory=list)
+    needs_evidence: List[str] = field(default_factory=list)
+    red_flags: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StrategySnapshot":
+        return cls(
+            legal_safe_summary=data.get("legal_safe_summary", ""),
+            suggested_dispute_frame=data.get("suggested_dispute_frame", ""),
+            rulebook_version=data.get("rulebook_version", ""),
+            rule_hits=list(data.get("rule_hits", []) or []),
+            needs_evidence=list(data.get("needs_evidence", []) or []),
+            red_flags=list(data.get("red_flags", []) or []),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -614,7 +614,7 @@ def run_credit_repair_process(
                 else {}
             )
             stage_2_5[acc_id] = normalize_and_tag(
-                account_cls, facts_map.get(acc_id, {}), rulebook
+                account_cls, facts_map.get(acc_id, {}), rulebook, account_id=acc_id
             )
         if session_id:
             update_session(session_id, stage_2_5=stage_2_5)

--- a/tests/strategy/test_rule_logging.py
+++ b/tests/strategy/test_rule_logging.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.core.logic.strategy.normalizer_2_5 import normalize_and_tag
+
+
+class DummyRulebook:
+    def __init__(self, version: str = "2024-01") -> None:
+        self.version = version
+
+
+def test_emits_rule_event(monkeypatch):
+    events = []
+
+    def fake_emit(event, payload):
+        events.append((event, payload))
+
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.normalizer_2_5.emit_event", fake_emit
+    )
+    normalize_and_tag({}, {}, DummyRulebook(), account_id="123")
+    assert events
+    assert events[0][1] == {
+        "account_id": "123",
+        "rule_hits": [],
+        "rulebook_version": "2024-01",
+    }


### PR DESCRIPTION
## Summary
- add StrategySnapshot model capturing rulebook evaluation details
- emit `rule_evaluated` events when tagging accounts
- cover rule evaluation logging with tests

## Testing
- `pytest tests/strategy/test_normalizer_2_5.py tests/strategy/test_rule_logging.py`


------
https://chatgpt.com/codex/tasks/task_b_689d1c26e7f483258cfec21cdc0a13fb