### PR TITLE
Add Stage 2.5 metrics and pipeline tests

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -22,6 +22,28 @@ _AI_METRICS: Dict[str, float] = {
     "latency_ms": 0.0,
 }
 
+# Generic counters -----------------------------------------------------------
+
+_COUNTERS: Dict[str, int] = {}
+
+
+def emit_counter(name: str, increment: int = 1) -> None:
+    """Increment a named counter for analytics."""
+
+    _COUNTERS[name] = _COUNTERS.get(name, 0) + increment
+
+
+def get_counters() -> Dict[str, int]:
+    """Return current generic counters (for tests)."""
+
+    return _COUNTERS.copy()
+
+
+def reset_counters() -> None:
+    """Reset generic counters (for tests)."""
+
+    _COUNTERS.clear()
+
 
 def _write_cache_snapshot() -> None:
     """Persist current cache metrics to ``analytics_data`` and reset counters."""

--- a/tests/strategy/test_stage_2_5_pipeline.py
+++ b/tests/strategy/test_stage_2_5_pipeline.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.core.logic.strategy.normalizer_2_5 import normalize_and_tag
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+
+
+class DummyRulebook:
+    def __init__(self, version: str = "2024-01") -> None:
+        self.version = version
+
+
+@pytest.fixture(autouse=True)
+def clear_metrics():
+    reset_counters()
+    yield
+    reset_counters()
+
+
+@pytest.fixture
+def rulebook() -> DummyRulebook:
+    return DummyRulebook()
+
+
+def test_admission_neutralized_with_red_flags(rulebook: DummyRulebook) -> None:
+    account_cls = {"user_statement_raw": "I was late paying this account"}
+    result = normalize_and_tag(account_cls, {}, rulebook)
+    assert result["legal_safe_summary"] == "The consumer was late paying this account"
+    assert result["red_flags"] == ["late_payment"]
+    counters = get_counters()
+    assert counters["stage_2_5.admission_neutralized"] == 1
+    assert counters["stage_2_5.rules_applied"] == 1
+
+
+def test_placeholder_handled(rulebook: DummyRulebook) -> None:
+    result = normalize_and_tag({}, {}, rulebook)
+    assert result["legal_safe_summary"] == "No statement provided"
+    assert result["red_flags"] == []
+    counters = get_counters()
+    assert counters.get("stage_2_5.admission_neutralized", 0) == 0
+    assert counters["stage_2_5.rules_applied"] == 1


### PR DESCRIPTION
## Summary
- add generic counter support to analytics tracker
- count admission neutralizations and rule evaluations in stage 2.5 normalizer
- cover stage 2.5 pipeline with fixture-based tests

## Testing
- `pytest --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_b_689d1fc7b878832591ae200c1b164461