### PR TITLE
Add Stage 2.5 placeholder configuration files

### DIFF
--- a/backend/core/logic/strategy/stage_2_5_schema.json
+++ b/backend/core/logic/strategy/stage_2_5_schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "required": [
+    "legal_safe_summary",
+    "suggested_dispute_frame",
+    "rule_hits",
+    "needs_evidence",
+    "red_flags",
+    "prohibited_admission_detected",
+    "rulebook_version"
+  ],
+  "properties": {
+    "legal_safe_summary": { "type": "string" },
+    "suggested_dispute_frame": { "type": "string" },
+    "rule_hits": { "type": "array", "items": { "type": "string" } },
+    "needs_evidence": { "type": "array", "items": { "type": "string" } },
+    "red_flags": { "type": "array", "items": { "type": "string" } },
+    "prohibited_admission_detected": { "type": "boolean" },
+    "rulebook_version": { "type": "string" }
+  }
+}

--- a/backend/policy/admission_patterns.yaml
+++ b/backend/policy/admission_patterns.yaml
@@ -1,0 +1,9 @@
+- id: late_payment_en
+  pattern: '(?i)\bi was late\b'
+  replacement: 'Creditor reports lateness; client requests validation.'
+- id: my_fault_en
+  pattern: '(?i)\bmy fault\b'
+  replacement: 'Client disputes the accuracy and requests verification.'
+- id: mi_culpa_es
+  pattern: '(?i)\bmi culpa\b'
+  replacement: 'El cliente disputa la precisión y solicita verificación.'

--- a/backend/policy/legal_safe_templates.yaml
+++ b/backend/policy/legal_safe_templates.yaml
@@ -1,0 +1,2 @@
+fraud_flow: "Client reports identity theft and requests verification."
+no_goodwill_on_collections: "Client requests verification; goodwill adjustment is not applicable."


### PR DESCRIPTION
## Summary
- add admission detection patterns with English and Spanish placeholders
- define Stage 2.5 JSON schema for strategy output
- stub legal-safe templates for rule summaries

## Testing
- `pre-commit run --files backend/policy/admission_patterns.yaml backend/core/logic/strategy/stage_2_5_schema.json backend/policy/legal_safe_templates.yaml`


------
https://chatgpt.com/codex/tasks/task_b_689d3097a10c8325a96dea9ad701eb0d