### PR TITLE
Pass Stage 2.5 data to strategist and drop rulebook from Stage 4

### DIFF
--- a/backend/core/logic/strategy/strategy_engine.py
+++ b/backend/core/logic/strategy/strategy_engine.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 from typing import Any, Dict, List, Mapping
 
 from backend.api.session_manager import get_session, update_session
-from backend.core.logic.compliance.rules_loader import load_rules
 from backend.core.logic.guardrails.summary_validator import (
     validate_structured_summaries,
 )
@@ -79,9 +78,9 @@ def generate_strategy(
     """Build a comprehensive strategy document for a given session.
 
     The strategy combines sanitized client summaries (``structured_summaries``),
-    the current rulebook, a snapshot of the provided credit report data and
-    recent outcome telemetry. Raw client explanations are intentionally
-    excluded to prevent accidental leakage into any generated letters.
+    a snapshot of the provided credit report data and recent outcome telemetry.
+    Raw client explanations are intentionally excluded to prevent accidental
+    leakage into any generated letters.
     """
 
     session = get_session(session_id) or {}
@@ -91,7 +90,6 @@ def generate_strategy(
 
     strategy: Dict[str, Any] = {
         "generated_at": datetime.now(UTC).isoformat(),
-        "rules": load_rules(),
         "dispute_items": structured,
         "bureau_data": bureau_data,
         "historical_outcomes": get_outcomes(),

--- a/tests/test_strategy_stage_2_5_prompt.py
+++ b/tests/test_strategy_stage_2_5_prompt.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+from backend.core.logic.strategy.generate_strategy_report import StrategyGenerator
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_stage_2_5_data_included_in_prompt_and_saved(tmp_path):
+    fake = FakeAIClient()
+    # minimal valid strategy response
+    fake.add_chat_response(
+        json.dumps(
+            {
+                "overview": "",
+                "accounts": [{"account_id": "1", "name": "Acc"}],
+                "global_recommendations": [],
+            }
+        )
+    )
+    gen = StrategyGenerator(ai_client=fake)
+    stage_2_5 = {
+        "1": {
+            "legal_safe_summary": "Safe summary",
+            "suggested_dispute_frame": "fraud",
+            "rule_hits": ["E_IDENTITY"],
+            "needs_evidence": ["identity_theft_affidavit"],
+            "red_flags": ["admission_of_fault"],
+        }
+    }
+    with mock.patch(
+        "backend.core.logic.strategy.generate_strategy_report.fix_draft_with_guardrails",
+        lambda *a, **k: None,
+    ):
+        report = gen.generate(
+            {"name": "Client", "session_id": "sess"},
+            {"Experian": {}},
+            stage_2_5_data=stage_2_5,
+            audit=None,
+        )
+    prompt = fake.chat_payloads[0]["messages"][0]["content"]
+    assert "legal_safe_summary" in prompt
+    assert "Safe summary" in prompt
+    path = gen.save_report(
+        report,
+        {"name": "Client", "session_id": "sess"},
+        "2024-01-01",
+        base_dir=tmp_path,
+        stage_2_5_data=stage_2_5,
+    )
+    saved = json.loads(Path(path).read_text())
+    assert saved["accounts"][0]["legal_safe_summary"] == "Safe summary"
+    assert saved["accounts"][0]["rule_hits"] == ["E_IDENTITY"]
+    assert saved["accounts"][0]["needs_evidence"] == ["identity_theft_affidavit"]
+    assert saved["accounts"][0]["red_flags"] == ["admission_of_fault"]


### PR DESCRIPTION
## Summary
- plumb Stage 2.5 map through `generate_strategy_plan` into `StrategyGenerator`
- ensure strategist prompt and schema surface Stage 2.5 fields
- remove rulebook loading from strategy engine (Stage 4)
- add test for Stage 2.5 data in strategist prompt and saved report

## Testing
- `pre-commit run --files backend/core/orchestrators.py backend/core/logic/strategy/strategy_engine.py tests/test_strategy_stage_2_5_prompt.py`
- `pytest tests/test_local_workflow.py::test_skip_goodwill_when_identity_theft tests/test_strategy_engine.py tests/test_strategy_stage_2_5_prompt.py tests/strategy/test_stage_2_5_pipeline.py tests/strategy/test_rule_logging.py`


------
https://chatgpt.com/codex/tasks/task_b_689d49a298708325964f500e19530319