### PR TITLE
Add Stage 2.5 metrics and audit logging

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -24,23 +24,30 @@ _AI_METRICS: Dict[str, float] = {
 
 # Generic counters -----------------------------------------------------------
 
-_COUNTERS: Dict[str, int] = {}
+# Metrics are stored as floats to support both counters and timers.
+_COUNTERS: Dict[str, float] = {}
 
 
-def emit_counter(name: str, increment: int = 1) -> None:
-    """Increment a named counter for analytics."""
+def emit_counter(name: str, increment: float = 1) -> None:
+    """Increment a named metric for analytics."""
 
     _COUNTERS[name] = _COUNTERS.get(name, 0) + increment
 
 
-def get_counters() -> Dict[str, int]:
-    """Return current generic counters (for tests)."""
+def set_metric(name: str, value: float) -> None:
+    """Set a named metric to an explicit value."""
+
+    _COUNTERS[name] = value
+
+
+def get_counters() -> Dict[str, float]:
+    """Return current generic metrics (for tests)."""
 
     return _COUNTERS.copy()
 
 
 def reset_counters() -> None:
-    """Reset generic counters (for tests)."""
+    """Reset generic metrics (for tests)."""
 
     _COUNTERS.clear()
 


### PR DESCRIPTION
## Summary
- track Stage 2.5 activity with new counters, latency timer, and rule hit ratio
- record admissions and rule evaluation events with PII-masked account identifiers
- update Stage 2.5 pipeline tests for new metrics and auditing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d4d8872ec8325971a2b556c0f4c4a