### PR TITLE
feat: optional AI admission check for stage 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Analysis prompt now instructs models to respond with valid JSON only, using `null` or empty arrays when data is unknown and avoiding invented fields. Bump `ANALYSIS_PROMPT_VERSION` to 2.
 - Strategy snapshot now records rulebook version, rule hits, evidence needs, and red flags and emits structured audit events.
 - Document deterministic Stage 2.5 rollout with explicit rule evaluation order, precedence/exclusion rules, metrics, and rulebook update workflow.
+- Optional AI admission detection for Stage 2.5 when regex patterns find no admission.
 ### Removed
 - Remove deprecated shims and aliases in audit, letter rendering, goodwill letters, instructions, and report analysis modules.
 - Remove unused `logic.copy_documents` module.

--- a/backend/core/logic/strategy/normalizer_2_5.py
+++ b/backend/core/logic/strategy/normalizer_2_5.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any, Dict, Mapping, Protocol, Tuple
@@ -11,6 +12,8 @@ from jsonschema import Draft7Validator, ValidationError
 from backend.audit.audit import emit_event
 from backend.analytics.analytics_tracker import emit_counter, get_counters, set_metric
 from backend.core.logic.utils.pii import redact_pii
+from backend.core.logic.utils.json_utils import parse_json
+from backend.core.services.ai_client import get_ai_client
 
 
 class Rulebook(Protocol):
@@ -41,6 +44,121 @@ ADMISSION_PATTERNS: Tuple[Tuple[re.Pattern[str], str, str], ...] = (
 _SCHEMA_PATH = Path(__file__).with_name("stage_2_5_schema.json")
 _SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 _VALIDATOR = Draft7Validator(_SCHEMA)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def _ai_cfg() -> Dict[str, Any]:
+    return {
+        "enabled": _env_bool("S2_5_ENABLE_AI_ADMISSION", False),
+        "model": os.getenv("S2_5_AI_MODEL", "gpt-4o-mini"),
+        "timeout_ms": _env_int("S2_5_AI_TIMEOUT_MS", 1200),
+        "max_tokens": _env_int("S2_5_AI_MAX_TOKENS", 200),
+        "min_chars": _env_int("S2_5_AI_MIN_CHARS", 12),
+    }
+
+
+AI_ALLOWED_CATEGORIES = [
+    "late",
+    "fault",
+    "owe",
+    "ownership",
+    "authorization",
+    "promise",
+    "settlement",
+    "other",
+    "none",
+]
+
+_AI_CATEGORY_TO_FLAG = {
+    "late": "admission_of_fault",
+    "fault": "admission_of_fault",
+    "owe": "admission_of_debt",
+    "ownership": "admission_of_ownership",
+    "authorization": "admission_of_authorization",
+    "promise": "promise_to_pay",
+    "settlement": "settlement_commitment",
+    "other": "admission_generic",
+}
+
+
+def ai_admission_check(statement_masked: str, cfg: Mapping[str, Any]) -> Dict[str, Any] | None:
+    start = time.perf_counter()
+    emit_counter("s2_5_ai_admission_checks_total")
+    try:
+        ai_client = get_ai_client()
+        system_prompt = (
+            "You are a compliance assistant. Output JSON only. Do not fabricate facts or legal conclusions. "
+            "Return exactly these keys: admission (boolean), category (string), neutral_summary (string). "
+            "Categories: late, fault, owe, ownership, authorization, promise, settlement, other, none. "
+            "If no admission is present, admission=false, category=\"none\", neutral_summary=\"\". "
+            "Keep neutral_summary short and verification-oriented. No admissions, no promises."
+        )
+        user_prompt = (
+            f"STATEMENT:\n{statement_masked}\n\n"
+            "TASK:\n1) Does the statement include an admission of lateness, fault, owing debt, ownership,\n"
+            "   authorization, promise to pay, or settlement? If yes, set admission=true and choose the best category.\n"
+            "2) Provide a short neutral_summary that removes admissions and asks for verification.\n"
+            "3) Output JSON only as specified.\n\n"
+            "RETURN FORMAT:\n{\"admission\": <bool>, \"category\": \"<enum>\", \"neutral_summary\": \"<string>\"}"
+        )
+        resp = ai_client.chat_completion(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            model=cfg.get("model"),
+            max_tokens=cfg.get("max_tokens"),
+            timeout=cfg.get("timeout_ms", 0) / 1000,
+            response_format={"type": "json_object"},
+        )
+        latency_ms = (time.perf_counter() - start) * 1000
+        emit_counter("s2_5_ai_latency_ms", latency_ms)
+        content = getattr(resp.choices[0].message, "content", "")
+        data, _ = parse_json(content)
+    except Exception:
+        emit_counter("s2_5_ai_error_total")
+        latency_ms = (time.perf_counter() - start) * 1000
+        emit_counter("s2_5_ai_latency_ms", latency_ms)
+        return None
+
+    if not isinstance(data, dict):
+        emit_counter("s2_5_ai_error_total")
+        return None
+
+    admission = data.get("admission")
+    category = data.get("category")
+    neutral_summary = data.get("neutral_summary")
+    if (
+        not isinstance(admission, bool)
+        or not isinstance(category, str)
+        or category not in AI_ALLOWED_CATEGORIES
+        or not isinstance(neutral_summary, str)
+    ):
+        emit_counter("s2_5_ai_error_total")
+        return None
+
+    if admission:
+        emit_counter("s2_5_ai_admissions_detected_total")
+
+    return {
+        "admission": admission,
+        "category": category,
+        "neutral_summary": neutral_summary,
+    }
 
 
 def _fill_defaults(data: Dict[str, Any]) -> None:
@@ -210,14 +328,40 @@ def normalize_and_tag(
     start = time.perf_counter()
     emit_counter("s2_5_accounts_total")
 
-    user_statement_raw = (
-        account_cls.get("user_statement_raw")
-        or account_facts.get("user_statement_raw")
-        or "No statement provided"
+    raw_statement = account_cls.get("user_statement_raw") or account_facts.get(
+        "user_statement_raw"
     )
+    user_statement_raw = raw_statement or "No statement provided"
     legal_safe_summary, admission_flags, admission_detected = neutralize_admissions(
         user_statement_raw, account_id
     )
+
+    cfg = _ai_cfg()
+    if (
+        not admission_detected
+        and cfg.get("enabled")
+        and raw_statement
+        and len(str(raw_statement)) >= cfg.get("min_chars", 0)
+    ):
+        statement_masked = redact_pii(str(raw_statement))
+        ai_res = ai_admission_check(statement_masked, cfg)
+        emit_event(
+            "admission_ai_checked",
+            {
+                "account_id": redact_pii(str(account_id)) if account_id else "",
+                "admission": bool(ai_res and ai_res.get("admission")),
+                "category": ai_res.get("category", "none") if ai_res else "none",
+            },
+        )
+        if ai_res and ai_res.get("admission"):
+            admission_detected = True
+            flag = _AI_CATEGORY_TO_FLAG.get(ai_res.get("category", ""))
+            if flag:
+                admission_flags.append(flag)
+            summary = ai_res.get("neutral_summary", "")
+            if summary:
+                legal_safe_summary = summary
+
     evaluation = evaluate_rules(legal_safe_summary, account_facts, rulebook)
     rulebook_version = getattr(rulebook, "version", "")
     if not rulebook_version and isinstance(rulebook, Mapping):

--- a/tests/strategy/test_stage_2_5_pipeline.py
+++ b/tests/strategy/test_stage_2_5_pipeline.py
@@ -7,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.core.logic.strategy.normalizer_2_5 import normalize_and_tag
 from backend.analytics.analytics_tracker import get_counters, reset_counters
+from tests.helpers.fake_ai_client import FakeAIClient
 
 
 class DummyRulebook:
@@ -87,3 +88,56 @@ def test_admission_emits_event(rulebook: DummyRulebook, monkeypatch) -> None:
         payload["summary"]
         == "Creditor reports a debt; consumer requests verification."
     )
+
+
+def test_ai_assist_detects_admission(rulebook: DummyRulebook, monkeypatch) -> None:
+    fake_client = FakeAIClient()
+    fake_client.add_chat_response(
+        '{"admission": true, "category": "owe", "neutral_summary": "Client disputes the debt and requests verification."}'
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.normalizer_2_5.get_ai_client", lambda: fake_client
+    )
+    monkeypatch.setenv("S2_5_ENABLE_AI_ADMISSION", "1")
+    account_cls = {
+        "user_statement_raw": "They think the balance belongs to me, I suppose."
+    }
+    result = normalize_and_tag(account_cls, {}, rulebook, account_id="acct-5")
+    assert result["prohibited_admission_detected"] is True
+    assert result["red_flags"] == ["admission_of_debt"]
+    assert (
+        result["legal_safe_summary"]
+        == "Client disputes the debt and requests verification."
+    )
+    counters = get_counters()
+    assert counters["s2_5_ai_admission_checks_total"] == 1
+    assert counters["s2_5_ai_admissions_detected_total"] == 1
+    assert counters["s2_5_ai_latency_ms"] > 0
+
+
+def test_ai_assist_emits_event(rulebook: DummyRulebook, monkeypatch) -> None:
+    fake_client = FakeAIClient()
+    fake_client.add_chat_response(
+        '{"admission": false, "category": "none", "neutral_summary": ""}'
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.normalizer_2_5.get_ai_client", lambda: fake_client
+    )
+    monkeypatch.setenv("S2_5_ENABLE_AI_ADMISSION", "1")
+    events = []
+
+    def fake_emit(event, payload):
+        events.append((event, payload))
+
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.normalizer_2_5.emit_event", fake_emit
+    )
+    account_cls = {
+        "user_statement_raw": "This statement is long enough for AI check."
+    }
+    normalize_and_tag(account_cls, {}, rulebook, account_id="123456789012")
+    assert events
+    ai_events = [e for e in events if e[0] == "admission_ai_checked"]
+    assert ai_events
+    _, payload = ai_events[0]
+    assert payload["account_id"] == "[REDACTED]"


### PR DESCRIPTION
## Summary
- add feature-flagged AI admission check fallback for Stage 2.5
- map AI admission categories to red flags and optional summary override
- document Stage 2.5 AI admission assist in changelog

## Testing
- `pytest tests/strategy/test_stage_2_5_pipeline.py tests/strategy/test_normalizer_2_5.py tests/strategy/test_rule_logging.py tests/strategy/test_stage_2_5_rules.py`

------
https://chatgpt.com/codex/tasks/task_b_689def63361c832597b9e01a320bf45f