### PR TITLE
Add strategy schema with enforcement metadata validation

### DIFF
--- a/backend/core/logic/strategy/strategy_schema.json
+++ b/backend/core/logic/strategy/strategy_schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "puraifi://schemas/strategy_schema.json",
+  "title": "Strategy Report",
+  "description": "Strategy report with Stage 2, Stage 2.5, and enforcement metadata for each account.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["overview", "accounts", "global_recommendations"],
+  "properties": {
+    "overview": {"type": "string", "default": ""},
+    "accounts": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "account_id",
+          "name",
+          "account_number",
+          "status",
+          "analysis",
+          "recommendation",
+          "alternative_options",
+          "flags",
+          "legal_safe_summary",
+          "suggested_dispute_frame",
+          "rule_hits",
+          "needs_evidence",
+          "red_flags",
+          "prohibited_admission_detected",
+          "rulebook_version",
+          "action_tag",
+          "priority",
+          "legal_notes",
+          "enforced_rules",
+          "policy_override_reason"
+        ],
+        "properties": {
+          "account_id": {"type": "string"},
+          "name": {"type": "string"},
+          "account_number": {"type": "string", "default": ""},
+          "status": {"type": "string", "default": ""},
+          "analysis": {"type": "string", "default": ""},
+          "recommendation": {"type": "string", "default": ""},
+          "alternative_options": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": []
+          },
+          "flags": {"type": "array", "items": {"type": "string"}, "default": []},
+          "legal_safe_summary": {"type": "string", "default": ""},
+          "suggested_dispute_frame": {"type": "string", "default": ""},
+          "rule_hits": {"type": "array", "items": {"type": "string"}, "default": []},
+          "needs_evidence": {"type": "array", "items": {"type": "string"}, "default": []},
+          "red_flags": {"type": "array", "items": {"type": "string"}, "default": []},
+          "prohibited_admission_detected": {"type": "boolean", "default": false},
+          "rulebook_version": {"type": "string", "default": ""},
+          "action_tag": {
+            "type": "string",
+            "enum": ["", "dispute", "goodwill", "custom_letter", "ignore"],
+            "default": ""
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["", "High", "Medium", "Low"],
+            "default": ""
+          },
+          "legal_notes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": []
+          },
+          "enforced_rules": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": []
+          },
+          "policy_override_reason": {"type": "string", "default": ""}
+        }
+      }
+    },
+    "global_recommendations": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    }
+  }
+}

--- a/tests/test_strategy_schema_validation.py
+++ b/tests/test_strategy_schema_validation.py
@@ -1,0 +1,18 @@
+import pytest
+
+from backend.core.logic.strategy.generate_strategy_report import StrategyGenerator
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_save_report_fails_without_required_fields(tmp_path):
+    fake = FakeAIClient()
+    gen = StrategyGenerator(ai_client=fake)
+    report = {"overview": "", "accounts": [{"account_id": "1"}], "global_recommendations": []}
+    with pytest.raises(ValueError):
+        gen.save_report(
+            report,
+            {"name": "Client", "session_id": "sess"},
+            "2024-01-01",
+            base_dir=tmp_path,
+            stage_2_5_data={"1": {}}
+        )

--- a/tests/test_strategy_stage_2_5_prompt.py
+++ b/tests/test_strategy_stage_2_5_prompt.py
@@ -49,7 +49,13 @@ def test_stage_2_5_data_included_in_prompt_and_saved(tmp_path):
         stage_2_5_data=stage_2_5,
     )
     saved = json.loads(Path(path).read_text())
-    assert saved["accounts"][0]["legal_safe_summary"] == "Safe summary"
-    assert saved["accounts"][0]["rule_hits"] == ["E_IDENTITY"]
-    assert saved["accounts"][0]["needs_evidence"] == ["identity_theft_affidavit"]
-    assert saved["accounts"][0]["red_flags"] == ["admission_of_fault"]
+    acc = saved["accounts"][0]
+    assert acc["legal_safe_summary"] == "Safe summary"
+    assert acc["rule_hits"] == ["E_IDENTITY"]
+    assert acc["needs_evidence"] == ["identity_theft_affidavit"]
+    assert acc["red_flags"] == ["admission_of_fault"]
+    assert acc["action_tag"] == ""
+    assert acc["priority"] == ""
+    assert acc["legal_notes"] == []
+    assert acc["enforced_rules"] == []
+    assert acc["policy_override_reason"] == ""


### PR DESCRIPTION
## Summary
- add `strategy_schema.json` covering Stage 2, Stage 2.5 and enforcement fields
- serialize required fields in `StrategyGenerator.save_report` and validate against schema
- extend tests and add schema validation test

## Testing
- `pytest tests/test_strategy_stage_2_5_prompt.py tests/test_strategy_policy_overrides.py tests/test_strategy_schema_validation.py`

------
https://chatgpt.com/codex/tasks/task_b_689e5f179740832584ed0e0777cfa4a8