### PR TITLE
Log strategy rule enforcement metrics and audit

### DIFF
--- a/backend/audit/audit.py
+++ b/backend/audit/audit.py
@@ -23,6 +23,7 @@ class AuditLogger:
         "strategy_generated",
         "strategy_merged",
         "strategy_decision",
+        "strategy_rule_enforcement",
         "pre_strategy_fallback",
         "strategy_fallback",
     }


### PR DESCRIPTION
## Summary
- log rule hit counts, overrides, and suggested frames per account with metrics
- emit `strategy_rule_enforcement` audit events for final recommendations
- record rule enforcement as essential audit step and test metrics logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e620d46c08325a41e7b768e809164