### PR TITLE
Ensure strategy guardrails preserve business fields

### DIFF
--- a/backend/core/logic/strategy/generate_strategy_report.py
+++ b/backend/core/logic/strategy/generate_strategy_report.py
@@ -257,13 +257,20 @@ Ensure the response is strictly valid JSON: all property names and strings in do
                     },
                 )
 
-        fix_draft_with_guardrails(
+        guardrails_result = fix_draft_with_guardrails(
             json.dumps(report, indent=2),
             client_info.get("state"),
             {},
             client_info.get("session_id", ""),
             "strategy",
+            ai_client=self.ai_client,
         )
+        if guardrails_result:
+            fixed_text, _, _ = guardrails_result
+            try:
+                report = json.loads(fixed_text)
+            except Exception:
+                pass
         return report
 
     def save_report(

--- a/tests/test_strategy_guardrails.py
+++ b/tests/test_strategy_guardrails.py
@@ -1,0 +1,36 @@
+import json
+from backend.core.logic.strategy.generate_strategy_report import StrategyGenerator
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_harsh_recommendation_softened_and_action_tag_preserved(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "backend.api.session_manager.SESSION_FILE", tmp_path / "sessions.json"
+    )
+    fake = FakeAIClient()
+    initial = {
+        "overview": "",
+        "accounts": [
+            {
+                "account_id": "1",
+                "name": "Acc",
+                "account_number": "",
+                "status": "",
+                "analysis": "",
+                "recommendation": "These crooks must fix this",
+                "alternative_options": [],
+                "flags": ["f1"],
+                "action_tag": "dispute",
+                "priority": "high",
+            }
+        ],
+        "global_recommendations": [],
+    }
+    fake.add_chat_response(json.dumps(initial))
+    gen = StrategyGenerator(ai_client=fake)
+    report = gen.generate({"session_id": "sess", "state": "CA"}, {})
+    acc = report["accounts"][0]
+    assert "crooks" not in acc["recommendation"].lower()
+    assert acc["action_tag"] == initial["accounts"][0]["action_tag"]
+    assert acc["priority"] == initial["accounts"][0]["priority"]
+    assert acc["flags"] == initial["accounts"][0]["flags"]


### PR DESCRIPTION
## Summary
- Pass existing AI client into strategy guardrails and load fixed text back into the report
- Guardrail fixer now preserves action_tag, priority and flags when repairing JSON drafts
- Test that harsh recommendation text is softened while business fields remain unchanged

## Testing
- `pytest tests/test_strategy_guardrails.py -q`
- `pytest tests/test_letter_generator_guardrails.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e64ed573c8325bad9f2f22e9f1681