### PR TITLE
Mask sensitive identifiers in logs and snapshots

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from backend.api import config
+from backend.core.logic.utils.pii import redact_pii
 
 # Cache metrics --------------------------------------------------------------
 
@@ -194,6 +195,6 @@ def save_analytics_snapshot(
         snapshot["strategist_failures"] = strategist_failures
 
     with open(filename, "w", encoding="utf-8") as f:
-        json.dump(snapshot, f, indent=2)
+        f.write(redact_pii(json.dumps(snapshot, indent=2)))
 
     print(f"[📊] Analytics snapshot saved: {filename}")

--- a/backend/audit/audit.py
+++ b/backend/audit/audit.py
@@ -7,6 +7,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from backend.core.logic.utils.pii import redact_pii
+
 
 class AuditLevel(Enum):
     ESSENTIAL = 1
@@ -68,7 +70,8 @@ class AuditLogger:
         folder.mkdir(parents=True, exist_ok=True)
         path = folder / "audit.json"
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.data, f, indent=2)
+            json_data = json.dumps(self.data, indent=2)
+            f.write(redact_pii(json_data))
         return path
 
 
@@ -86,4 +89,4 @@ _logger = logging.getLogger(__name__)
 def emit_event(event: str, payload: Dict[str, Any]) -> None:
     """Emit a structured audit log entry for external monitoring."""
 
-    _logger.info("%s %s", event, json.dumps(payload))
+    _logger.info("%s %s", event, redact_pii(json.dumps(payload)))

--- a/backend/core/logic/compliance/rule_checker.py
+++ b/backend/core/logic/compliance/rule_checker.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Literal, TypedDict
 
 from backend.core.logic.compliance.rules_loader import load_rules, load_state_rules
+from backend.core.logic.utils.pii import redact_pii
 from backend.core.models.letter import LetterContext
 
 
@@ -49,7 +50,7 @@ def check_letter(
                         "message": rule.get("description", ""),
                     }
                 )
-            modified_text = regex.sub("[REDACTED]", modified_text)
+    modified_text = redact_pii(modified_text)
 
     # Apply other systemic rules
     for rule in rules:

--- a/backend/core/logic/utils/pii.py
+++ b/backend/core/logic/utils/pii.py
@@ -1,4 +1,9 @@
-"""Helpers for redacting personally identifiable information from text."""
+"""Helpers for redacting personally identifiable information from text.
+
+This module provides simple pattern based masking for common PII. Emails and
+phone numbers are fully redacted, while SSNs and account numbers keep their
+last four digits for audit/debugging purposes.
+"""
 
 from __future__ import annotations
 
@@ -6,17 +11,18 @@ import re
 
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
 _PHONE_RE = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
-_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_SSN_RE = re.compile(r"\b(?:\d{3}-\d{2}-\d{4}|\d{9})\b")
 _ACCOUNT_RE = re.compile(r"\b\d{12,16}\b")
-
-_PATTERNS = (_EMAIL_RE, _PHONE_RE, _SSN_RE, _ACCOUNT_RE)
 
 
 def redact_pii(text: str) -> str:
-    """Return ``text`` with common PII patterns replaced by ``[REDACTED]``."""
+    """Return ``text`` with common PII patterns masked."""
     if not text:
         return ""
-    redacted = text
-    for pattern in _PATTERNS:
-        redacted = pattern.sub("[REDACTED]", redacted)
+    redacted = _EMAIL_RE.sub("[REDACTED]", text)
+    redacted = _PHONE_RE.sub("[REDACTED]", redacted)
+    redacted = _SSN_RE.sub(
+        lambda m: "***-**-" + re.sub(r"\D", "", m.group())[-4:], redacted
+    )
+    redacted = _ACCOUNT_RE.sub(lambda m: "****" + m.group()[-4:], redacted)
     return redacted

--- a/tests/strategy/test_stage_2_5_pipeline.py
+++ b/tests/strategy/test_stage_2_5_pipeline.py
@@ -82,8 +82,8 @@ def test_admission_emits_event(rulebook: DummyRulebook, monkeypatch) -> None:
     assert events
     event, payload = events[0]
     assert event == "admission_neutralized"
-    assert payload["account_id"] == "[REDACTED]"
-    assert payload["raw_statement"] == "I owe on account [REDACTED]"
+    assert payload["account_id"] == "****9012"
+    assert payload["raw_statement"] == "I owe on account ****9012"
     assert (
         payload["summary"]
         == "Creditor reports a debt; consumer requests verification."
@@ -140,4 +140,4 @@ def test_ai_assist_emits_event(rulebook: DummyRulebook, monkeypatch) -> None:
     ai_events = [e for e in events if e[0] == "admission_ai_checked"]
     assert ai_events
     _, payload = ai_events[0]
-    assert payload["account_id"] == "[REDACTED]"
+    assert payload["account_id"] == "****9012"

--- a/tests/test_pii_logging.py
+++ b/tests/test_pii_logging.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from backend.audit.audit import AuditLevel, create_audit_logger
+from backend.analytics.analytics_tracker import save_analytics_snapshot
+
+
+def test_audit_save_masks_pii(tmp_path: Path):
+    audit = create_audit_logger("sess1", level=AuditLevel.VERBOSE)
+    audit.log_step(
+        "strategist_invocation",
+        {"ssn": "123-45-6789", "acct": "0000111122223333"},
+    )
+    path = audit.save(tmp_path)
+    data = path.read_text()
+    assert "123-45-6789" not in data
+    assert "0000111122223333" not in data
+    assert "***-**-6789" in data
+    assert "****3333" in data
+
+
+def test_snapshot_masks_pii(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    client_info = {"name": "Test 123-45-6789"}
+    report_summary = {"strategic_recommendations": ["Call 0000111122223333"]}
+    save_analytics_snapshot(client_info, report_summary)
+    file = next(Path("analytics_data").glob("*.json"))
+    text = file.read_text()
+    assert "123-45-6789" not in text
+    assert "0000111122223333" not in text
+    assert "***-**-6789" in text
+    assert "****3333" in text

--- a/tests/test_rule_checker.py
+++ b/tests/test_rule_checker.py
@@ -22,10 +22,12 @@ def test_admissions_replaced_and_ca_disclosure():
 
 
 def test_pii_masked_and_violation_recorded():
-    text = "My SSN is 123-45-6789"
+    text = "My SSN is 123-45-6789 and account 0000111122223333"
     cleaned, violations = check_letter(text, state=None, context={})
     assert "123-45-6789" not in cleaned
-    assert "[REDACTED]" in cleaned
+    assert "0000111122223333" not in cleaned
+    assert "***-**-6789" in cleaned
+    assert "****3333" in cleaned
     assert any(
         v["rule_id"] == "RULE_PII_LIMIT" and v["severity"] == "critical"
         for v in violations

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -28,7 +28,9 @@ def test_utils_smoke(tmp_path: Path):
     filtered = filter_sections_by_bureau(sections, "Experian")
     assert filtered["disputes"]
 
-    red = redact_pii("email test@example.com phone 555-111-2222 ssn 123-45-6789")
-    assert "test@example.com" not in red
-    assert "555-111-2222" not in red
-    assert "123-45-6789" not in red
+    red = redact_pii(
+        "email test@example.com phone 555-111-2222 ssn 123-45-6789 account 999999999999"
+    )
+    assert red.count("[REDACTED]") == 2
+    assert "***-**-6789" in red
+    assert "****9999" in red


### PR DESCRIPTION
## Summary
- mask SSNs to last four and account numbers to `****1234`
- sanitize audit events and analytics snapshots before persisting
- add regression tests to ensure logs and snapshots contain only masked data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e6931f06083259ce0ef47961cc019