### PR TITLE
Add versioned strategy cache and constants

### DIFF
--- a/backend/core/cache/strategy_cache.py
+++ b/backend/core/cache/strategy_cache.py
@@ -1,0 +1,70 @@
+import hashlib
+import json
+import random
+import time
+from typing import Any, Dict
+
+_MIN_TTL_SEC = 14 * 24 * 60 * 60
+_MAX_TTL_SEC = 30 * 24 * 60 * 60
+
+_CACHE: Dict[str, tuple[Dict[str, Any], float]] = {}
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _hash_payload(
+    stage2: Dict[str, Any],
+    stage2_5: Dict[str, Any],
+    stage3: Dict[str, Any],
+    model_version: str,
+    prompt_version: int,
+    schema_version: int,
+) -> str:
+    payload = json.dumps(
+        [stage2, stage2_5, stage3, model_version, prompt_version, schema_version],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def get_cached_strategy(
+    stage2: Dict[str, Any],
+    stage2_5: Dict[str, Any],
+    stage3: Dict[str, Any],
+    model_version: str,
+    *,
+    prompt_version: int,
+    schema_version: int,
+) -> Dict[str, Any] | None:
+    key = _hash_payload(stage2, stage2_5, stage3, model_version, prompt_version, schema_version)
+    item = _CACHE.get(key)
+    if not item:
+        return None
+    data, expires = item
+    if _now() > expires:
+        _CACHE.pop(key, None)
+        return None
+    return data
+
+
+def store_cached_strategy(
+    stage2: Dict[str, Any],
+    stage2_5: Dict[str, Any],
+    stage3: Dict[str, Any],
+    model_version: str,
+    result: Dict[str, Any],
+    *,
+    prompt_version: int,
+    schema_version: int,
+) -> None:
+    ttl = random.randint(_MIN_TTL_SEC, _MAX_TTL_SEC)
+    expires = _now() + ttl
+    key = _hash_payload(stage2, stage2_5, stage3, model_version, prompt_version, schema_version)
+    _CACHE[key] = (result, expires)
+
+
+def reset_cache() -> None:
+    _CACHE.clear()

--- a/tests/test_strategy_cache.py
+++ b/tests/test_strategy_cache.py
@@ -1,0 +1,37 @@
+import json
+
+from backend.core.logic.strategy.generate_strategy_report import (
+    StrategyGenerator,
+    STRATEGY_PROMPT_VERSION,
+)
+from backend.core.cache import strategy_cache
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_strategy_cache_hit_and_version_bump(monkeypatch):
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.generate_strategy_report.fix_draft_with_guardrails",
+        lambda *a, **k: None,
+    )
+    strategy_cache.reset_cache()
+    fake = FakeAIClient()
+    fake.add_chat_response(json.dumps({"overview": "", "accounts": [], "global_recommendations": []}))
+    gen = StrategyGenerator(fake)
+    bureau_data = {"Experian": {"disputes": []}}
+    stage_2_5 = {}
+    classification_map = {}
+
+    res1 = gen.generate({}, bureau_data, classification_map=classification_map, stage_2_5_data=stage_2_5)
+    assert res1["accounts"] == []
+    res2 = gen.generate({}, bureau_data, classification_map=classification_map, stage_2_5_data=stage_2_5)
+    assert res1 == res2
+    assert len(fake.chat_payloads) == 1
+
+    monkeypatch.setattr(
+        "backend.core.logic.strategy.generate_strategy_report.STRATEGY_PROMPT_VERSION",
+        STRATEGY_PROMPT_VERSION + 1,
+    )
+    fake.add_chat_response(json.dumps({"overview": "y", "accounts": [], "global_recommendations": []}))
+    res3 = gen.generate({}, bureau_data, classification_map=classification_map, stage_2_5_data=stage_2_5)
+    assert len(fake.chat_payloads) == 2
+    assert res3["overview"] == "y"


### PR DESCRIPTION
## Summary
- define `STRATEGY_PROMPT_VERSION` and `STRATEGY_SCHEMA_VERSION` for strategist
- cache strategy generation using Stage 2/2.5/3 data, versions and model
- include versions in output and validate cache behavior

## Testing
- `pytest tests/test_strategy_cache.py tests/test_strategy_policy_overrides.py tests/test_strategy_generator_audit.py tests/test_strategy_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689e825a9ef08325ab92d0a1a2b75990