### PR TITLE
docs: document stage4 strategy and flow

### DIFF
--- a/docs/diagrams/stage4_flow.mmd
+++ b/docs/diagrams/stage4_flow.mmd
@@ -1,0 +1,2 @@
+flowchart LR
+    prompt --> LLM --> enforcement --> guardrails --> cache --> output

--- a/docs/strategy_stage4.md
+++ b/docs/strategy_stage4.md
@@ -1,0 +1,36 @@
+# Strategy Stage 4
+
+Stage 4 executes the final LLM strategy with policy enforcement and caching.
+
+## Inputs
+- **Prompt** – consolidated instructions passed to the LLM.
+- **Stage 3 output** – structured context from earlier stages.
+- **Rulebook & guardrails** – policy definitions for enforcement.
+
+## Enforcement Steps
+1. Submit the prompt to the LLM and parse the JSON reply.
+2. Validate required fields and coerce types.
+3. Run rulebook checks and apply deterministic fixes.
+4. Record any violations and surface errors.
+
+## Guardrails
+- Normalizes entity names and numbers.
+- Caps token and character length.
+- Filters unsafe admissions and PII.
+- Prevents forbidden dispute frames.
+
+## Cache
+- Deterministic key derived from prompt and rulebook version.
+- Stores both raw LLM reply and sanitized payload.
+- Hits skip re-generation; misses are inserted asynchronously.
+
+## Outputs
+- Policy-compliant strategy fragment.
+- Audit log entries for each correction.
+- Cache metadata indicating hit or miss.
+
+## Metrics
+- `stage4_requests_total`
+- `stage4_cache_hits_total`
+- `stage4_guardrail_violations_total`
+- `stage4_latency_ms`


### PR DESCRIPTION
## Summary
- document Stage 4 strategy inputs, enforcement, guardrails, cache, outputs, and metrics
- add Mermaid diagram for Stage 4 flow from prompt to output

## Testing
- `npx --yes @mermaid-js/mermaid-cli -p /tmp/puppeteer-config.json -i docs/diagrams/stage4_flow.mmd -o /tmp/stage4_flow.svg`
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_b_689f3f7952d8832582964c0ed62030a7