### PR TITLE
Track strategy usage metrics and cache events

### DIFF
--- a/docs/strategy_stage4.md
+++ b/docs/strategy_stage4.md
@@ -34,3 +34,9 @@ Stage 4 executes the final LLM strategy with policy enforcement and caching.
 - `stage4_cache_hits_total`
 - `stage4_guardrail_violations_total`
 - `stage4_latency_ms`
+- `strategy.cache_hit`
+- `strategy.cache_miss`
+
+## Monitoring
+- Dashboards should track `tokens_in`, `tokens_out`, `cost`, and `latency_ms` from
+  `log_ai_request` to alert on unusual latency or cost spikes.


### PR DESCRIPTION
## Summary
- log tokens, estimated cost, and latency for strategy generation
- add strategy cache hit/miss/store counters for cache operations
- document new metrics and monitoring guidance for Stage 4

## Testing
- `pre-commit run --files backend/core/logic/strategy/generate_strategy_report.py backend/core/cache/strategy_cache.py docs/strategy_stage4.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f4556afd88325b8796d6ef73c008c