### PR TITLE
Mask account identifiers in strategy and audit logs

### DIFF
--- a/backend/audit/audit.py
+++ b/backend/audit/audit.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from backend.core.logic.utils.pii import redact_pii
+from backend.core.logic.utils.pii import mask_account_fields, redact_pii
 
 
 class AuditLevel(Enum):
@@ -46,7 +46,7 @@ class AuditLogger:
             {
                 "stage": stage,
                 "timestamp": datetime.now(UTC).isoformat(),
-                "details": details or {},
+                "details": mask_account_fields(details or {}),
             }
         )
 
@@ -58,7 +58,7 @@ class AuditLogger:
             return
         acc = self.data["accounts"].setdefault(str(account_id), [])
         entry = {"timestamp": datetime.now(UTC).isoformat()}
-        entry.update(info)
+        entry.update(mask_account_fields(info))
         acc.append(entry)
 
     def log_error(self, message: str) -> None:

--- a/backend/core/logic/strategy/generate_strategy_report.py
+++ b/backend/core/logic/strategy/generate_strategy_report.py
@@ -18,6 +18,7 @@ from backend.core.logic.compliance.constants import (
 from backend.core.logic.guardrails import fix_draft_with_guardrails
 from backend.core.logic.policy import get_precedence, precedence_version
 from backend.core.logic.utils.json_utils import parse_json
+from backend.core.logic.utils.pii import mask_account_fields
 from backend.core.services.ai_client import AIClient
 from backend.policy.policy_loader import load_rulebook
 
@@ -540,5 +541,5 @@ Ensure the response is strictly valid JSON: all property names and strings in do
             ) from exc
         path = folder / "strategy.json"
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(report, f, indent=2, ensure_ascii=False)
+            json.dump(mask_account_fields(report), f, indent=2, ensure_ascii=False)
         return path

--- a/backend/core/logic/utils/pii.py
+++ b/backend/core/logic/utils/pii.py
@@ -7,7 +7,9 @@ last four digits for audit/debugging purposes.
 
 from __future__ import annotations
 
+import json
 import re
+from typing import Any, Dict
 
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
 _PHONE_RE = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
@@ -28,3 +30,9 @@ def redact_pii(text: str) -> str:
         lambda m: "****" + re.sub(r"\D", "", m.group())[-4:], redacted
     )
     return redacted
+
+
+def mask_account_fields(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``data`` with account numbers and SSNs masked."""
+
+    return json.loads(redact_pii(json.dumps(data)))

--- a/tests/strategy/test_strategy_redaction.py
+++ b/tests/strategy/test_strategy_redaction.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from backend.audit.audit import create_audit_logger
+from backend.core.logic.strategy.generate_strategy_report import StrategyGenerator
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_strategy_and_audit_mask_account_numbers_and_ssn(tmp_path: Path) -> None:
+    report = {
+        "overview": "",
+        "accounts": [
+            {
+                "account_id": "1",
+                "name": "Bank",
+                "account_number": "0000111122223333",
+                "ssn": "123-45-6789",
+                "recommendation": "Dispute",
+            }
+        ],
+        "global_recommendations": [],
+    }
+    client = {"name": "Jane Doe", "session_id": "sess1"}
+
+    gen = StrategyGenerator(ai_client=FakeAIClient())
+    strategy_path = gen.save_report(
+        report, client, "2024-01-01", base_dir=str(tmp_path)
+    )
+    text = strategy_path.read_text()
+    assert "0000111122223333" not in text
+    assert "123-45-6789" not in text
+    assert "****3333" in text
+    assert "***-**-6789" in text
+
+    audit = create_audit_logger("sess1")
+    audit.log_step("strategy_generated", report)
+    audit_path = audit.save(tmp_path)
+    audit_text = audit_path.read_text()
+    assert "0000111122223333" not in audit_text
+    assert "123-45-6789" not in audit_text
+    assert "****3333" in audit_text
+    assert "***-**-6789" in audit_text


### PR DESCRIPTION
## Summary
- add helper to mask SSNs and account numbers with last-four digits
- apply masking in audit logging and strategy report saving
- test that strategy output and audit logs contain only masked identifiers

## Testing
- `pre-commit run --files backend/core/logic/utils/pii.py backend/audit/audit.py backend/core/logic/strategy/generate_strategy_report.py tests/strategy/test_strategy_redaction.py`
- `pytest tests/test_pii_logging.py tests/test_trace_breakdown_exporter.py tests/strategy/test_strategy_redaction.py`

------
https://chatgpt.com/codex/tasks/task_b_689f4b0fa30c8325a4e1c72830394fd9