### PR TITLE
Require Stage‑4 strategy context for letters

### DIFF
--- a/backend/core/logic/letters/utils.py
+++ b/backend/core/logic/letters/utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from backend.core.models.account import Account
+
+
+class StrategyContextMissing(RuntimeError):
+    """Raised when an account lacks required strategy context."""
+
+    def __init__(self, account_id: str | None):
+        self.account_id = account_id
+        super().__init__(f"Strategy context missing for account {account_id}")
+
+
+def _get_fields(acc: Account | Mapping[str, Any]) -> tuple[str | None, str | None]:
+    if isinstance(acc, Account):
+        return acc.action_tag, acc.account_id
+    if isinstance(acc, Mapping):
+        return acc.get("action_tag"), acc.get("account_id")
+    return getattr(acc, "action_tag", None), getattr(acc, "account_id", None)
+
+
+def ensure_strategy_context(
+    accounts: Iterable[Account | Mapping[str, Any]],
+    enforcement_enabled: bool,
+) -> None:
+    """Ensure each account has an action tag when enforcement is enabled."""
+
+    if not enforcement_enabled:
+        return
+
+    for acc in accounts:
+        action_tag, account_id = _get_fields(acc)
+        if action_tag:
+            continue
+        raise StrategyContextMissing(account_id)

--- a/tests/test_strategy_context_enforcement.py
+++ b/tests/test_strategy_context_enforcement.py
@@ -1,0 +1,102 @@
+import pytest
+
+from backend.core.logic.letters.generate_custom_letters import generate_custom_letter
+from backend.core.logic.letters.generate_goodwill_letters import (
+    generate_goodwill_letters,
+)
+from backend.core.logic.letters.letter_generator import (
+    generate_all_dispute_letters_with_ai,
+)
+from backend.core.logic.letters.utils import StrategyContextMissing
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+@pytest.fixture(autouse=True)
+def _set_enforcement(monkeypatch):
+    monkeypatch.setenv("STAGE4_POLICY_ENFORCEMENT", "1")
+    monkeypatch.setattr("backend.api.config.STAGE4_POLICY_ENFORCEMENT", True)
+    monkeypatch.setattr(
+        "backend.core.logic.letters.letter_generator.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "backend.audit.audit.emit_event", lambda e, p: events.append((e, p))
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.letter_generator.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    return events
+
+
+def test_dispute_letter_requires_strategy(tmp_path, monkeypatch, _set_enforcement):
+    events = _set_enforcement
+    monkeypatch.setattr(
+        "backend.core.logic.letters.letter_generator.generate_strategy",
+        lambda session_id, bureau_data: {
+            "accounts": [{"account_id": "1"}],
+            "dispute_items": {},
+        },
+    )
+    fake = FakeAIClient()
+    client = {"name": "Test", "session_id": "s1"}
+    bureau_map = {"Experian": {"disputes": [], "inquiries": []}}
+    with pytest.raises(StrategyContextMissing):
+        generate_all_dispute_letters_with_ai(
+            client, bureau_map, tmp_path, False, None, ai_client=fake
+        )
+    assert events == [
+        ("strategy_context_missing", {"account_id": "1", "letter_type": "dispute"})
+    ]
+    assert not any(tmp_path.iterdir())
+
+
+def test_goodwill_letter_requires_strategy(tmp_path, _set_enforcement):
+    events = _set_enforcement
+    client = {"legal_name": "John Doe", "session_id": "s1"}
+    bureau_map = {
+        "Experian": {
+            "disputes": [{"name": "Bank", "account_number": "1", "account_id": "1"}]
+        }
+    }
+    fake = FakeAIClient()
+    with pytest.raises(StrategyContextMissing):
+        generate_goodwill_letters(
+            client, bureau_map, tmp_path, audit=None, ai_client=fake
+        )
+    assert events[-1] == (
+        "strategy_context_missing",
+        {"account_id": "1", "letter_type": "goodwill"},
+    )
+    assert not any(tmp_path.iterdir())
+
+
+def test_custom_letter_requires_strategy(tmp_path, _set_enforcement):
+    events = _set_enforcement
+    account = {"name": "Bank", "account_number": "1", "account_id": "1"}
+    client = {"name": "Tester", "session_id": "s1"}
+    fake = FakeAIClient()
+    with pytest.raises(StrategyContextMissing):
+        generate_custom_letter(account, client, tmp_path, audit=None, ai_client=fake)
+    assert events[-1] == (
+        "strategy_context_missing",
+        {"account_id": "1", "letter_type": "custom"},
+    )
+    assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- add `ensure_strategy_context` helper and `StrategyContextMissing` exception
- enforce strategy context before generating dispute, goodwill and custom letters
- log `strategy_context_missing` audit event when letters lack context
- add tests for Stage‑4 enforcement during letter drafting

## Testing
- `pre-commit run --files backend/core/logic/letters/utils.py backend/core/logic/letters/letter_generator.py backend/core/logic/letters/generate_goodwill_letters.py backend/core/logic/letters/generate_custom_letters.py tests/test_strategy_context_enforcement.py`
- `python -m pytest tests/test_strategy_context_enforcement.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689f56576cd48325a45d4e440e0069d5