### PR TITLE
Block goodwill letters for collections

### DIFF
--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -181,6 +181,15 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
             {"name": "Client", "session_id": "s3"},
             output,
             ai_client=FakeAIClient(),
+            strategy={
+                "accounts": [
+                    {
+                        "name": "Creditor",
+                        "account_number": "1",
+                        "action_tag": "goodwill",
+                    }
+                ]
+            },
         )
 
     assert doc_type in calls

--- a/tests/test_goodwill_collection_policy.py
+++ b/tests/test_goodwill_collection_policy.py
@@ -1,0 +1,55 @@
+from backend.core.logic.letters.generate_goodwill_letters import (
+    generate_goodwill_letter_with_ai,
+)
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_block_goodwill_for_collection(monkeypatch, tmp_path):
+    events = []
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.goodwill_prompting.generate_goodwill_letter_draft",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not call GPT")),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.gather_supporting_docs",
+        lambda session_id: ("", [], None),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
+        lambda html, path: None,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",
+        lambda html, state, session_id, doc_type, ai_client=None: html,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.get_session",
+        lambda sid: {},
+    )
+
+    accounts = [
+        {
+            "name": "Collector",
+            "account_number": "1",
+            "action_tag": "collection",
+            "account_id": "1",
+        }
+    ]
+    strategy = {"accounts": accounts}
+    client = {"name": "Tester", "session_id": "s1"}
+
+    generate_goodwill_letter_with_ai(
+        "Collector",
+        accounts,
+        client,
+        tmp_path,
+        ai_client=FakeAIClient(),
+        strategy=strategy,
+    )
+
+    assert events[-1][1]["policy_override_reason"] == "collection_no_goodwill"
+    assert not any(tmp_path.iterdir())

--- a/tests/test_goodwill_integration.py
+++ b/tests/test_goodwill_integration.py
@@ -71,6 +71,11 @@ def test_orchestrator_invokes_compliance(monkeypatch, tmp_path):
     client_info = {"legal_name": "John Doe", "session_id": "s1", "state": "CA"}
     bureau_data = {}
     generate_goodwill_letters.generate_goodwill_letters(
-        client_info, bureau_data, tmp_path, audit=None, ai_client=ai
+        client_info,
+        bureau_data,
+        tmp_path,
+        audit=None,
+        ai_client=ai,
+        strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
     )
     assert calls  # compliance pipeline was invoked

--- a/tests/test_logic_fixes.py
+++ b/tests/test_logic_fixes.py
@@ -168,6 +168,7 @@ def test_goodwill_generation():
             out_dir,
             None,
             ai_client=fake,
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
     assert "Card Co" in sent
     print("goodwill ok")
@@ -210,7 +211,12 @@ def test_goodwill_on_closed_account():
         mock_g.side_effect = _cb
         fake = FakeAIClient()
         generate_goodwill_letters(
-            {"name": "T"}, bureau_data, out_dir, None, ai_client=fake
+            {"name": "T"},
+            bureau_data,
+            out_dir,
+            None,
+            ai_client=fake,
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
     assert "Old Card" in called
     print("goodwill closed ok")
@@ -242,7 +248,12 @@ def test_skip_goodwill_when_no_late_payments():
         out_dir = Path("output/tmp3")
         out_dir.mkdir(parents=True, exist_ok=True)
         generate_goodwill_letters(
-            {"name": "T"}, bureau_data, out_dir, None, ai_client=FakeAIClient()
+            {"name": "T"},
+            bureau_data,
+            out_dir,
+            None,
+            ai_client=FakeAIClient(),
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
     assert not mock_g.called
     print("goodwill skip ok")
@@ -274,7 +285,12 @@ def test_skip_goodwill_on_collections():
         out_dir = Path("output/tmp4")
         out_dir.mkdir(parents=True, exist_ok=True)
         generate_goodwill_letters(
-            {"name": "T"}, bureau_data, out_dir, None, ai_client=FakeAIClient()
+            {"name": "T"},
+            bureau_data,
+            out_dir,
+            None,
+            ai_client=FakeAIClient(),
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
     assert not mock_g.called
     print("goodwill collection skip ok")
@@ -306,7 +322,12 @@ def test_skip_goodwill_edge_statuses():
         out_dir = Path("output/tmp4a")
         out_dir.mkdir(parents=True, exist_ok=True)
         generate_goodwill_letters(
-            {"name": "T"}, bureau_data, out_dir, None, ai_client=FakeAIClient()
+            {"name": "T"},
+            bureau_data,
+            out_dir,
+            None,
+            ai_client=FakeAIClient(),
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
     assert not mock_g.called
     print("goodwill edge skip ok")
@@ -576,7 +597,12 @@ def test_skip_goodwill_for_disputed_account():
         out_dir = Path("output/tmp_dupe_skip")
         out_dir.mkdir(parents=True, exist_ok=True)
         generate_goodwill_letters(
-            {"name": "T"}, bureau_data, out_dir, None, ai_client=FakeAIClient()
+            {"name": "T"},
+            bureau_data,
+            out_dir,
+            None,
+            ai_client=FakeAIClient(),
+            strategy={"accounts": [{"account_id": "1", "action_tag": "goodwill"}]},
         )
 
     assert not mock_g.called

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -179,7 +179,13 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
     accounts = [{"name": "Creditor", "account_number": "1", "action_tag": "goodwill"}]
 
     generate_goodwill_letter_with_ai(
-        "Creditor", accounts, client_info, tmp_path, None, ai_client=fake2
+        "Creditor",
+        accounts,
+        client_info,
+        tmp_path,
+        None,
+        ai_client=fake2,
+        strategy={"accounts": accounts},
     )
     with open(tmp_path / "Creditor_gpt_response.json") as f:
         data = json.load(f)


### PR DESCRIPTION
## Summary
- require strategy input when generating goodwill letters
- block goodwill letters for collection accounts and log policy override
- add regression test for collection goodwill attempt

## Testing
- `pre-commit run --files backend/core/logic/letters/generate_goodwill_letters.py tests/test_sensitive_language_filtered.py tests/test_goodwill_integration.py tests/test_compliance_pipeline_usage.py tests/test_local_workflow.py tests/test_logic_fixes.py tests/test_goodwill_collection_policy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f5d99770083258b2e159387f4622c