### PR TITLE
Add tests for stage4 letter policy enforcement

### DIFF
--- a/tests/letters/test_custom_letter_policy_conflict.py
+++ b/tests/letters/test_custom_letter_policy_conflict.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from backend.core.logic.letters.generate_custom_letters import generate_custom_letter
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_custom_prompt_policy_conflict(monkeypatch, tmp_path: Path):
+    events = []
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.gather_supporting_docs",
+        lambda session_id: ("", [], None),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.pdfkit.from_string",
+        lambda html, path, configuration=None, options=None: None,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.get_session",
+        lambda sid: {"structured_summaries": {"1": {"account_id": "1", "debt_type": "credit"}}},
+    )
+
+    fake = FakeAIClient()
+    fake.add_chat_response(
+        "Please accept this goodwill payment and delete the debt."
+    )
+    fake.add_chat_response("This is a dispute letter without policy issues.")
+
+    account = {"name": "Bank", "account_number": "1", "action_tag": "dispute", "account_id": "1"}
+    client = {"legal_name": "Tester", "session_id": "s1"}
+
+    classification_map = {
+        "1": ClassificationRecord(
+            summary={}, classification={"category": "error", "action_tag": "dispute"}, summary_hash=""
+        )
+    }
+
+    generate_custom_letter(
+        account,
+        client,
+        tmp_path,
+        audit=None,
+        ai_client=fake,
+        classification_map=classification_map,
+    )
+
+    text = (tmp_path / "Bank_custom_gpt_response.txt").read_text()
+    assert "goodwill" not in text.lower()
+    assert events[0][1]["action_tag_after"] == "dispute"

--- a/tests/letters/test_no_goodwill_on_collections_custom.py
+++ b/tests/letters/test_no_goodwill_on_collections_custom.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from backend.core.logic.letters.generate_custom_letters import generate_custom_letter
+from backend.core.logic.strategy.summary_classifier import ClassificationRecord
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_block_goodwill_on_collection(monkeypatch, tmp_path: Path):
+    events = []
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.call_gpt_for_custom_letter",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not call GPT")),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.gather_supporting_docs",
+        lambda session_id: ("", [], None),
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.pdfkit.from_string",
+        lambda html, path, configuration=None, options=None: None,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.get_session",
+        lambda sid: {},
+    )
+
+    account = {
+        "name": "Collector",
+        "account_number": "1",
+        "action_tag": "goodwill",
+        "account_id": "1",
+    }
+    classification_map = {
+        "1": ClassificationRecord(
+            summary={}, classification={"category": "collection", "action_tag": "goodwill"}, summary_hash=""
+        )
+    }
+    client = {"name": "Tester", "session_id": "s1"}
+
+    fake = FakeAIClient()
+    generate_custom_letter(
+        account,
+        client,
+        tmp_path,
+        audit=None,
+        ai_client=fake,
+        classification_map=classification_map,
+    )
+
+    assert events[-1][1]["policy_override_reason"] == "collection_no_goodwill"
+    assert not any(tmp_path.iterdir())

--- a/tests/letters/test_strategy_context_required.py
+++ b/tests/letters/test_strategy_context_required.py
@@ -1,0 +1,68 @@
+import pytest
+
+from backend.core.logic.letters.generate_custom_letters import generate_custom_letter
+from backend.core.logic.letters.generate_goodwill_letters import (
+    generate_goodwill_letters,
+)
+from backend.core.logic.letters.letter_generator import (
+    generate_all_dispute_letters_with_ai,
+)
+from backend.core.logic.letters.utils import StrategyContextMissing
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+@pytest.fixture(autouse=True)
+def _set_enforcement(monkeypatch):
+    monkeypatch.setenv("STAGE4_POLICY_ENFORCEMENT", "1")
+    monkeypatch.setattr("backend.api.config.STAGE4_POLICY_ENFORCEMENT", True)
+    monkeypatch.setattr(
+        "backend.core.logic.letters.letter_generator.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_goodwill_letters.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.generate_custom_letters.api_config.STAGE4_POLICY_ENFORCEMENT",
+        True,
+    )
+
+
+def test_dispute_requires_action_tag(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "backend.core.logic.letters.letter_generator.generate_strategy",
+        lambda session_id, bureau_data: {
+            "accounts": [{"account_id": "1"}],
+            "dispute_items": {},
+        },
+    )
+    fake = FakeAIClient()
+    client = {"name": "Test", "session_id": "s1"}
+    bureau_map = {"Experian": {"disputes": [], "inquiries": []}}
+    with pytest.raises(StrategyContextMissing):
+        generate_all_dispute_letters_with_ai(
+            client, bureau_map, tmp_path, False, None, ai_client=fake
+        )
+
+
+def test_goodwill_requires_action_tag(tmp_path):
+    client = {"legal_name": "John Doe", "session_id": "s1"}
+    bureau_map = {
+        "Experian": {
+            "disputes": [{"name": "Bank", "account_number": "1", "account_id": "1"}]
+        }
+    }
+    fake = FakeAIClient()
+    with pytest.raises(StrategyContextMissing):
+        generate_goodwill_letters(
+            client, bureau_map, tmp_path, audit=None, ai_client=fake
+        )
+
+
+def test_custom_requires_action_tag(tmp_path):
+    account = {"name": "Bank", "account_number": "1", "account_id": "1"}
+    client = {"name": "Tester", "session_id": "s1"}
+    fake = FakeAIClient()
+    with pytest.raises(StrategyContextMissing):
+        generate_custom_letter(account, client, tmp_path, audit=None, ai_client=fake)


### PR DESCRIPTION
## Summary
- add regression tests requiring strategy context for dispute, goodwill, and custom letter generators
- add failing tests for blocking custom goodwill letters on collection accounts
- add failing tests for custom-letter prompts that conflict with stage-4 strategy

## Testing
- `pytest tests/letters/test_strategy_context_required.py::test_dispute_requires_action_tag -q`
- `pytest tests/letters/test_strategy_context_required.py::test_goodwill_requires_action_tag -q`
- `pytest tests/letters/test_strategy_context_required.py::test_custom_requires_action_tag -q`
- `pytest tests/letters/test_no_goodwill_on_collections_custom.py::test_block_goodwill_on_collection -q` *(fails: should not call GPT)*
- `pytest tests/letters/test_custom_letter_policy_conflict.py::test_custom_prompt_policy_conflict -q` *(fails: 'goodwill' still in text)*

------
https://chatgpt.com/codex/tasks/task_b_689f64f97dc88325a524dd5296f3b426