### PR TITLE
Improve bureau section chunking heuristics

### DIFF
--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -47,6 +47,17 @@ ANALYSIS_PROMPT_VERSION = 2
 ANALYSIS_SCHEMA_VERSION = 1
 
 
+# Allow for odd spacing, lowercase headers, and page-break markers when
+# locating bureau sections in raw report text.
+_BUREAU_REGEXES = {
+    bureau: re.compile(
+        r"(?:^|\n|\f)\s*" + r"[\s-]*".join(re.escape(ch) for ch in bureau) + r"\b",
+        re.IGNORECASE,
+    )
+    for bureau in BUREAUS
+}
+
+
 def _apply_defaults(data: dict, schema: dict) -> None:
     """Recursively populate defaults based on ``schema``."""
     for key, subschema in schema.get("properties", {}).items():
@@ -84,8 +95,8 @@ def _validate_analysis_schema(data: dict) -> dict:
 def _split_text_by_bureau(text: str) -> Dict[str, str]:
     """Return mapping of bureau name to its text segment."""
     positions: Dict[str, int] = {}
-    for bureau in BUREAUS:
-        match = re.search(bureau, text, re.I)
+    for bureau, pattern in _BUREAU_REGEXES.items():
+        match = pattern.search(text)
         if match:
             positions[bureau] = match.start()
     if not positions:

--- a/tests/report_analysis/test_bureau_chunking_variants.py
+++ b/tests/report_analysis/test_bureau_chunking_variants.py
@@ -1,0 +1,35 @@
+from backend.core.logic.report_analysis.report_prompting import _split_text_by_bureau
+from backend.core.logic.utils.names_normalization import BUREAUS
+
+
+def _compute(text: str):
+    segments = _split_text_by_bureau(text)
+    missing = [b for b in BUREAUS if b not in segments]
+    return segments, missing
+
+
+def test_odd_spacing_headings():
+    text = (
+        "EX PERIAN REPORT\n" "data\n" "\fEQUI FAX REPORT\n" "more\n" "\fTRANS UNION REPORT\n" "end"
+    )
+    segments, missing = _compute(text)
+    assert set(segments) == set(BUREAUS)
+    assert missing == []
+
+
+def test_lowercase_headings():
+    text = (
+        "experian report\n" "a\n" "\fequifax report\n" "b\n" "\ftransunion report\n" "c"
+    )
+    segments, missing = _compute(text)
+    assert set(segments) == set(BUREAUS)
+    assert missing == []
+
+
+def test_merged_sections_missing_bureau():
+    text = (
+        "Experian report\n" "foo\n" "Equifax report\n" "bar\n"
+    )
+    segments, missing = _compute(text)
+    assert set(segments) == {"Experian", "Equifax"}
+    assert missing == ["TransUnion"]


### PR DESCRIPTION
## Summary
- handle bureau headings with regex allowing odd spacing, case-insensitivity, and page-break anchors
- add tests for bureau chunking covering odd spacing, lowercase headings, and merged sections

## Testing
- `pytest tests/report_analysis/test_bureau_chunking_variants.py`


------
https://chatgpt.com/codex/tasks/task_b_689f72cee2808325aba94215aa02a674