### PR TITLE
Add cross-validation for bureau analysis using regex extractors

### DIFF
--- a/backend/core/logic/report_analysis/extractors.py
+++ b/backend/core/logic/report_analysis/extractors.py
@@ -1,0 +1,77 @@
+import re
+from backend.core.logic.utils.names_normalization import normalize_creditor_name
+
+
+def _parse_account_sections(text: str) -> dict:
+    """Split ``text`` into account-like sections and extract fields.
+
+    Returns a mapping of normalized account names to dictionaries containing
+    ``account_number``, ``status`` and ``dofd`` when present. Sections that do
+    not contain any of these fields are ignored.
+    """
+    sections = re.split(r"\n{2,}", text)
+    results: dict[str, dict] = {}
+    for sec in sections:
+        lines = [line.strip() for line in sec.splitlines() if line.strip()]
+        if not lines:
+            continue
+        name_norm = normalize_creditor_name(lines[0])
+        account_number = status = dofd = None
+        for line in lines[1:]:
+            lower = line.lower()
+            if lower.startswith("account number") or lower.startswith("acct #"):
+                account_number = line.split(":", 1)[1].strip()
+            elif lower.startswith("status"):
+                status = line.split(":", 1)[1].strip()
+            elif "date of first delinquency" in lower or lower.startswith("dofd"):
+                dofd = line.split(":", 1)[1].strip()
+        if account_number or status or dofd:
+            results[name_norm] = {
+                "account_number": account_number,
+                "status": status,
+                "dofd": dofd,
+            }
+    return results
+
+
+def extract_account_number_masks(text: str) -> dict[str, str]:
+    """Return mapping of account names to account number masks."""
+    parsed = _parse_account_sections(text)
+    return {
+        name: vals["account_number"]
+        for name, vals in parsed.items()
+        if vals.get("account_number")
+    }
+
+
+def extract_account_statuses(text: str) -> dict[str, str]:
+    """Return mapping of account names to statuses."""
+    parsed = _parse_account_sections(text)
+    return {
+        name: vals["status"]
+        for name, vals in parsed.items()
+        if vals.get("status")
+    }
+
+
+def extract_dofd(text: str) -> dict[str, str]:
+    """Return mapping of account names to Date of First Delinquency."""
+    parsed = _parse_account_sections(text)
+    return {
+        name: vals["dofd"]
+        for name, vals in parsed.items()
+        if vals.get("dofd")
+    }
+
+
+def extract_inquiry_dates(text: str) -> dict[str, str]:
+    """Return mapping of inquiry creditor names to dates."""
+    pattern = re.compile(
+        r"(?P<name>[^\n]+)\nInquiry Date:\s*(?P<date>\d{1,2}/\d{1,2}/\d{4})",
+        re.IGNORECASE,
+    )
+    results: dict[str, str] = {}
+    for match in pattern.finditer(text):
+        name = normalize_creditor_name(match.group("name").strip())
+        results[name] = match.group("date").strip()
+    return results

--- a/tests/report_analysis/test_extractor_cross_validation.py
+++ b/tests/report_analysis/test_extractor_cross_validation.py
@@ -1,0 +1,65 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+from backend.core.logic.report_analysis.report_prompting import analyze_bureau
+
+
+class DummyAIClient:
+    def __init__(self, content: str):
+        self._content = content
+
+    def chat_completion(self, **kwargs):
+        message = SimpleNamespace(content=self._content)
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice], usage=None)
+
+
+def test_cross_validation_corrects_fields(tmp_path: Path):
+    text = (
+        "Test Bank\n"
+        "Account Number: ****1234\n"
+        "Status: Open\n"
+        "DOFD: 01/2020\n\n"
+        "Sample Lender\n"
+        "Inquiry Date: 03/15/2023\n"
+    )
+
+    ai_output = json.dumps(
+        {
+            "all_accounts": [
+                {
+                    "name": "Test Bank",
+                    "account_number": "****9999",
+                    "status": "Closed",
+                    "dofd": "02/2020",
+                }
+            ],
+            "inquiries": [
+                {"creditor_name": "Sample Lender", "date": "02/01/2023"}
+            ],
+        }
+    )
+    ai_client = DummyAIClient(ai_output)
+
+    data, err = analyze_bureau(
+        text=text,
+        is_identity_theft=False,
+        output_json_path=tmp_path / "out.json",
+        ai_client=ai_client,
+        strategic_context=None,
+        prompt="",
+        late_summary_text="",
+        inquiry_summary="",
+    )
+
+    assert err is None
+    account = data["all_accounts"][0]
+    assert account["account_number"] == "****1234"
+    assert account["status"] == "Open"
+    assert account["dofd"] == "01/2020"
+    assert account["remediation_applied"] is True
+
+    inquiry = data["inquiries"][0]
+    assert inquiry["date"] == "03/15/2023"
+    assert inquiry["remediation_applied"] is True


### PR DESCRIPTION
## Summary
- Implement regex-based extractors for account numbers, statuses, DOFD, and inquiry dates
- Cross-check AI bureau analysis with extracted values and flag corrections
- Add tests for extractor cross-validation using contradictory data

## Testing
- `pytest tests/report_analysis -q`


------
https://chatgpt.com/codex/tasks/task_b_689f794507788325a48fb86331f1c356