### PR TITLE
Improve report segment repair loop

### DIFF
--- a/backend/core/logic/report_analysis/flags.py
+++ b/backend/core/logic/report_analysis/flags.py
@@ -31,7 +31,7 @@ class AnalysisFlags:
     inject_headings: bool = _env_bool("ANALYSIS_INJECT_HEADINGS", True)
     cache_enabled: bool = _env_bool("ANALYSIS_CACHE_ENABLED", True)
     debug_store_raw: bool = _env_bool("ANALYSIS_DEBUG_STORE_RAW", False)
-    max_remediation_passes: int = _env_int("ANALYSIS_MAX_REMEDIATION_PASSES", 2)
+    max_remediation_passes: int = _env_int("ANALYSIS_MAX_REMEDIATION_PASSES", 3)
     max_segment_tokens: int = _env_int("ANALYSIS_MAX_SEGMENT_TOKENS", 8000)
 
 

--- a/tests/report_analysis/test_retry_repair_loop.py
+++ b/tests/report_analysis/test_retry_repair_loop.py
@@ -1,0 +1,51 @@
+import logging
+
+
+def test_retry_repair_loop(monkeypatch, caplog, tmp_path):
+    from backend.core.logic.report_analysis import report_prompting as rp
+
+    # Force single segment and generous token limit
+    monkeypatch.setattr(rp.FLAGS, "chunk_by_bureau", False)
+    monkeypatch.setattr(rp.FLAGS, "max_segment_tokens", 10_000)
+
+    # Simulate headings so missing account issue is detected
+    monkeypatch.setattr(
+        rp,
+        "extract_account_headings",
+        lambda text: [("acme", "Acme Bank")],
+    )
+
+    calls = {"count": 0}
+
+    def fake_analyze_bureau(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # First pass returns a merged account triggering remediation
+            return {"all_accounts": [{"name": "Acme Bank", "bureaus": []}]}, None
+        return {"all_accounts": [{"name": "Acme Bank", "bureaus": ["Full"]}]}, None
+
+    monkeypatch.setattr(rp, "analyze_bureau", fake_analyze_bureau)
+    monkeypatch.setattr(rp, "get_cached_analysis", lambda *a, **k: None)
+    monkeypatch.setattr(rp, "store_cached_analysis", lambda *a, **k: None)
+
+    caplog.set_level(logging.INFO)
+
+    result = rp.call_ai_analysis(
+        text="Acme Bank\nDetails",
+        is_identity_theft=False,
+        output_json_path=tmp_path / "out.json",
+        ai_client=None,
+        strategic_context=None,
+        request_id="req",
+        doc_fingerprint="doc",
+    )
+
+    # Ensure remediation was attempted
+    assert calls["count"] == 2
+    assert any(
+        r.message == "analysis_remediation" and getattr(r, "repair_step", 0) == 1
+        for r in caplog.records
+    )
+
+    # Final result contains the recovered account
+    assert result["all_accounts"][0]["name"] == "Acme Bank"


### PR DESCRIPTION
## Summary
- broaden segment repair hints and error codes for missing or merged accounts
- allow up to three repair passes and log each `repair_step`
- add regression test covering retry loop

## Testing
- `pytest tests/report_analysis/test_retry_repair_loop.py -q`
- `pytest tests/report_analysis -q`
- `pytest tests/test_bureau_failure_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f7effb16c8325bc07ce3233b40996