### PR TITLE
Handle missing bureaus with placeholder sections

### DIFF
--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -761,6 +761,7 @@ def call_ai_analysis(
     }
     summary_metrics: dict = {}
     needs_review = bool(missing_bureaus)
+    bureau_sections: List[dict] = []
 
     for idx, (bureau, seg_text) in enumerate(segments.items()):
         seg_path = (
@@ -1010,6 +1011,15 @@ def call_ai_analysis(
         if error_code or data.get("needs_human_review"):
             needs_review = True
 
+        # capture per-bureau data before merging
+        per_bureau = {
+            **data,
+            "bureau": bureau,
+            "error_code": error_code,
+            "is_missing": False,
+        }
+        bureau_sections.append(per_bureau)
+
         for key in [
             "negative_accounts",
             "open_accounts_with_issues",
@@ -1049,5 +1059,28 @@ def call_ai_analysis(
         aggregate["missing_bureaus"] = missing_bureaus
     else:
         aggregate["missing_bureaus"] = []
+
+    # add placeholder sections for any missing bureaus
+    for bureau in missing_bureaus:
+        bureau_sections.append(
+            {
+                "bureau": bureau,
+                "negative_accounts": [],
+                "open_accounts_with_issues": [],
+                "positive_accounts": [],
+                "high_utilization_accounts": [],
+                "all_accounts": [],
+                "inquiries": [],
+                "personal_info_issues": [],
+                "account_inquiry_matches": [],
+                "strategic_recommendations": [],
+                "confidence": 0.0,
+                "needs_human_review": True,
+                "error_code": "MISSING_BUREAU",
+                "is_missing": True,
+            }
+        )
+
+    aggregate["bureau_sections"] = bureau_sections
 
     return aggregate

--- a/tests/report_analysis/test_missing_bureau_synthesis.py
+++ b/tests/report_analysis/test_missing_bureau_synthesis.py
@@ -1,0 +1,42 @@
+import types
+from pathlib import Path
+
+import backend.core.logic.report_analysis.report_prompting as rp
+from backend.core.logic.utils.names_normalization import BUREAUS
+
+
+def test_missing_bureau_sections(monkeypatch, tmp_path: Path):
+    """Missing bureaus should still emit placeholder sections."""
+    # simplify prompt generation and caching
+    monkeypatch.setattr(rp, "_generate_prompt", lambda *a, **k: ("", "", ""))
+    monkeypatch.setattr(rp, "get_cached_analysis", lambda *a, **k: None)
+    monkeypatch.setattr(rp, "store_cached_analysis", lambda *a, **k: None)
+
+    def fake_analyze_bureau(text, **kwargs):
+        return {"all_accounts": [{"name": "Cap One", "bureaus": ["Experian"]}], "inquiries": []}, None
+
+    monkeypatch.setattr(rp, "analyze_bureau", fake_analyze_bureau)
+
+    text = "Experian report\naccount details"
+
+    result = rp.call_ai_analysis(
+        text=text,
+        is_identity_theft=False,
+        output_json_path=tmp_path / "out.json",
+        ai_client=types.SimpleNamespace(),
+        strategic_context=None,
+        request_id="req",
+        doc_fingerprint="fp",
+    )
+
+    sections = {s["bureau"]: s for s in result["bureau_sections"]}
+    assert set(sections.keys()) == set(BUREAUS)
+    # Experian section comes from analysis and should not be marked missing
+    assert not sections["Experian"]["is_missing"]
+    for bureau in BUREAUS:
+        if bureau == "Experian":
+            continue
+        placeholder = sections[bureau]
+        assert placeholder["is_missing"]
+        assert placeholder["all_accounts"] == []
+        assert placeholder["inquiries"] == []


### PR DESCRIPTION
## Summary
- Add `bureau_sections` to analysis results and insert empty placeholders when bureaus are absent
- Provide metadata (`error_code`, `is_missing`) so downstream consumers can safely iterate over all bureaus
- Cover missing-bureau logic with unit test

## Testing
- `pytest tests/report_analysis/test_missing_bureau_synthesis.py -q`
- `pytest tests/report_analysis -q`


------
https://chatgpt.com/codex/tasks/task_b_689f82974c048325beaf4be7b3d979b9