### PR TITLE
Cache report analysis by schema version with metrics

### DIFF
--- a/backend/core/logic/report_analysis/analysis_cache.py
+++ b/backend/core/logic/report_analysis/analysis_cache.py
@@ -2,35 +2,41 @@ import random
 import time
 from typing import Any, Dict, Tuple
 
+from backend.analytics.analytics_tracker import emit_counter
+
 _MIN_TTL_SEC = 14 * 24 * 60 * 60
 _MAX_TTL_SEC = 30 * 24 * 60 * 60
 
-CacheKey = Tuple[str, str, str, str]
-CacheValue = Tuple[Dict[str, Any], float, int, int]
+CacheKey = Tuple[str, str, str, str, int]
+CacheValue = Tuple[Dict[str, Any], float]
 
 _CACHE: Dict[CacheKey, CacheValue] = {}
 
+
 def _now() -> float:
     return time.time()
+
 
 def get_cached_analysis(
     doc_fingerprint: str,
     bureau: str,
     prompt_hash: str,
     model_version: str,
-    *,
-    prompt_version: int,
     schema_version: int,
 ) -> Dict[str, Any] | None:
-    key = (doc_fingerprint, bureau, prompt_hash, model_version)
+    key = (doc_fingerprint, bureau, prompt_hash, model_version, schema_version)
     item = _CACHE.get(key)
     if not item:
+        emit_counter("analysis.cache_miss")
         return None
-    data, expires, p_version, s_version = item
-    if _now() > expires or p_version != prompt_version or s_version != schema_version:
+    data, expires = item
+    if _now() > expires:
         _CACHE.pop(key, None)
+        emit_counter("analysis.cache_miss")
         return None
+    emit_counter("analysis.cache_hit")
     return data
+
 
 def store_cached_analysis(
     doc_fingerprint: str,
@@ -38,14 +44,14 @@ def store_cached_analysis(
     prompt_hash: str,
     model_version: str,
     result: Dict[str, Any],
-    *,
-    prompt_version: int,
     schema_version: int,
 ) -> None:
     ttl = random.randint(_MIN_TTL_SEC, _MAX_TTL_SEC)
     expires = _now() + ttl
-    key = (doc_fingerprint, bureau, prompt_hash, model_version)
-    _CACHE[key] = (result, expires, prompt_version, schema_version)
+    key = (doc_fingerprint, bureau, prompt_hash, model_version, schema_version)
+    _CACHE[key] = (result, expires)
+    emit_counter("analysis.cache_store")
+
 
 def reset_cache() -> None:
     _CACHE.clear()

--- a/tests/report_analysis/test_analysis_cache.py
+++ b/tests/report_analysis/test_analysis_cache.py
@@ -1,0 +1,86 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure repo root is on path for direct imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.analytics import analytics_tracker
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_analysis_cache_hits_and_invalidates(tmp_path, monkeypatch):
+    """Repeated calls hit cache; prompt or schema changes invalidate."""
+
+    report_prompting = importlib.import_module(
+        "backend.core.logic.report_analysis.report_prompting"
+    )
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
+    analytics_tracker.reset_counters()
+
+    client = FakeAIClient()
+    client.add_chat_response('{"inquiries": [], "all_accounts": []}')
+    out = tmp_path / "result.json"
+
+    # Prime cache
+    report_prompting.call_ai_analysis(
+        "text",
+        False,
+        out,
+        ai_client=client,
+        strategic_context="goal",
+        request_id="req",
+        doc_fingerprint="fp",
+    )
+
+    # Second call with identical inputs should hit cache
+    report_prompting.call_ai_analysis(
+        "text",
+        False,
+        out,
+        ai_client=client,
+        strategic_context="goal",
+        request_id="req",
+        doc_fingerprint="fp",
+    )
+
+    counters = analytics_tracker.get_counters()
+    assert counters.get("analysis.cache_hit") == 1
+    assert len(client.chat_payloads) == 1
+
+    # Changing prompt invalidates cache
+    client.add_chat_response('{"inquiries": [], "all_accounts": []}')
+    report_prompting.call_ai_analysis(
+        "text",
+        False,
+        out,
+        ai_client=client,
+        strategic_context="other",
+        request_id="req",
+        doc_fingerprint="fp",
+    )
+    assert len(client.chat_payloads) == 2
+
+    # Bumping schema invalidates cache
+    monkeypatch.setattr(
+        report_prompting,
+        "ANALYSIS_SCHEMA_VERSION",
+        report_prompting.ANALYSIS_SCHEMA_VERSION + 1,
+    )
+    client.add_chat_response('{"inquiries": [], "all_accounts": []}')
+    report_prompting.call_ai_analysis(
+        "text",
+        False,
+        out,
+        ai_client=client,
+        strategic_context="goal",
+        request_id="req",
+        doc_fingerprint="fp",
+    )
+    assert len(client.chat_payloads) == 3
+
+    # Cache hit metric should still reflect only the first hit
+    counters = analytics_tracker.get_counters()
+    assert counters.get("analysis.cache_hit") == 1


### PR DESCRIPTION
## Summary
- Key analysis cache by document fingerprint, bureau, prompt hash, model version, and schema version
- Track analysis cache metrics and integrate into report prompt flow
- Validate cache hit and invalidation scenarios in tests

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/analysis_cache.py backend/core/logic/report_analysis/report_prompting.py tests/report_analysis/test_analysis_cache.py`
- `pytest tests/report_analysis/test_analysis_cache.py tests/test_report_modules.py`


------
https://chatgpt.com/codex/tasks/task_b_689f84adfa948325ae30364e9e769cbe