### PR TITLE
Expand PII redaction patterns

### DIFF
--- a/backend/core/logic/utils/pii.py
+++ b/backend/core/logic/utils/pii.py
@@ -14,7 +14,10 @@ from typing import Any, Dict
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
 _PHONE_RE = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
 _SSN_RE = re.compile(r"\b(?:\d{3}[- ]\d{2}[- ]\d{4}|\d{9})\b")
-_ACCOUNT_RE = re.compile(r"\b(?:\d[ -]?){11,15}\d\b")
+# Match common "last-4" SSN patterns such as "ssn 1234" or "ssn:1234"
+_SSN_LAST4_RE = re.compile(r"(?i)(ssn[\s:#-]*)(\d{4})")
+# Allow account numbers with spaces or hyphens between groups of digits
+_ACCOUNT_RE = re.compile(r"\b(?:\d{4}[ -]?){2,4}\d{4}\b")
 
 
 def redact_pii(text: str) -> str:
@@ -25,6 +28,9 @@ def redact_pii(text: str) -> str:
     redacted = _PHONE_RE.sub("[REDACTED]", redacted)
     redacted = _SSN_RE.sub(
         lambda m: "***-**-" + re.sub(r"\D", "", m.group())[-4:], redacted
+    )
+    redacted = _SSN_LAST4_RE.sub(
+        lambda m: m.group(1) + "***-**-" + m.group(2), redacted
     )
     redacted = _ACCOUNT_RE.sub(
         lambda m: "****" + re.sub(r"\D", "", m.group())[-4:], redacted

--- a/tests/test_pii_logging.py
+++ b/tests/test_pii_logging.py
@@ -8,24 +8,34 @@ def test_audit_save_masks_pii(tmp_path: Path):
     audit = create_audit_logger("sess1", level=AuditLevel.VERBOSE)
     audit.log_step(
         "strategist_invocation",
-        {"ssn": "123-45-6789", "acct": "0000111122223333"},
+        {
+            "ssn": "123-45-6789",
+            "ssn_last4": "ssn 9876",
+            "acct": "0000-1111-2222-3333",
+            "acct_spaced": "0000 1111 2222 3333",
+        },
     )
     path = audit.save(tmp_path)
     data = path.read_text()
     assert "123-45-6789" not in data
-    assert "0000111122223333" not in data
+    assert "ssn 9876" not in data
+    assert "0000-1111-2222-3333" not in data
+    assert "0000 1111 2222 3333" not in data
     assert "***-**-6789" in data
+    assert "ssn ***-**-9876" in data
     assert "****3333" in data
 
 
 def test_snapshot_masks_pii(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    client_info = {"name": "Test 123-45-6789"}
-    report_summary = {"strategic_recommendations": ["Call 0000111122223333"]}
+    client_info = {"name": "Test 123-45-6789 ssn 9876"}
+    report_summary = {"strategic_recommendations": ["Call 0000 1111 2222 3333"]}
     save_analytics_snapshot(client_info, report_summary)
     file = next(Path("analytics_data").glob("*.json"))
     text = file.read_text()
     assert "123-45-6789" not in text
-    assert "0000111122223333" not in text
+    assert "ssn 9876" not in text
+    assert "0000 1111 2222 3333" not in text
     assert "***-**-6789" in text
+    assert "ssn ***-**-9876" in text
     assert "****3333" in text


### PR DESCRIPTION
## Summary
- handle SSN last-four patterns and account numbers with spaces or hyphens
- extend PII logging tests to cover new formats

## Testing
- `pytest tests/test_pii_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f86a74a5c83258beebbda502c0230