### PR TITLE
Add detailed report analysis metrics and monitoring docs

### DIFF
--- a/docs/report_analysis_metrics.md
+++ b/docs/report_analysis_metrics.md
@@ -1,0 +1,33 @@
+# Report analysis metrics
+
+The `report_segment` audit event records detailed metrics for each bureau
+analysis run. Logged fields include:
+
+- `stage3_tokens_in`
+- `stage3_tokens_out`
+- `latency_ms`
+- `cost_est`
+- `cache_hit`
+- `error_code`
+- `confidence`
+- `needs_human_review`
+- `missing_bureaus`
+- `repair_count`
+- `remediation_applied`
+
+## Grafana / Kibana panels
+
+- **Confidence trend** – average `confidence` by bureau. Trigger an alert when
+  the 5‑minute moving average drops below `0.7`.
+- **Cost anomalies** – sum of `cost_est` per hour. Alert when cost exceeds the
+  95th percentile of the previous day.
+
+## SLO suggestions
+
+- **Low confidence spike** – alert if more than 5 % of segments report
+  `confidence < 0.7` over a 10‑minute window.
+- **Cost regression** – alert when `cost_est` per report doubles relative to
+  the trailing weekly median.
+
+These panels and alerts can be added in Grafana or Kibana by querying the
+`report_segment` logs and aggregating on the fields above.

--- a/tests/report_analysis/test_metrics_emission.py
+++ b/tests/report_analysis/test_metrics_emission.py
@@ -1,0 +1,57 @@
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+
+
+def test_metrics_emission(monkeypatch, tmp_path):
+    from backend.core.logic.report_analysis import report_prompting as rp
+
+    # Single segment without chunking
+    monkeypatch.setattr(rp.FLAGS, "chunk_by_bureau", False)
+    monkeypatch.setattr(rp.FLAGS, "max_segment_tokens", 10_000)
+
+    # Fake analysis response with token usage and confidence
+    def fake_analyze_bureau(*args, **kwargs):
+        return {
+            "summary_metrics": {
+                "stage3_tokens_in": 5,
+                "stage3_tokens_out": 7,
+            },
+            "confidence": 0.8,
+            "needs_human_review": False,
+        }, None
+
+    monkeypatch.setattr(rp, "analyze_bureau", fake_analyze_bureau)
+    from backend.core.logic.report_analysis import analysis_cache
+
+    analysis_cache.reset_cache()
+    monkeypatch.setattr(rp, "store_cached_analysis", lambda *a, **k: None)
+
+    events = []
+    monkeypatch.setattr(rp, "emit_event", lambda e, p: events.append((e, p)))
+
+    reset_counters()
+
+    rp.call_ai_analysis(
+        text="Sample",
+        is_identity_theft=False,
+        output_json_path=tmp_path / "out.json",
+        ai_client=None,
+        strategic_context=None,
+        request_id="req",
+        doc_fingerprint="doc",
+    )
+
+    assert events and events[0][0] == "report_segment"
+    payload = events[0][1]
+
+    assert payload["stage3_tokens_in"] == 5
+    assert payload["stage3_tokens_out"] == 7
+    assert payload["cost_est"] > 0
+    assert payload["cache_hit"] is False
+    assert "confidence" in payload
+    assert "needs_human_review" in payload
+    assert "missing_bureaus" in payload
+    assert payload["repair_count"] == 0
+    assert payload["remediation_applied"] is False
+
+    counters = get_counters()
+    assert counters["analysis.cache_miss"] == 1


### PR DESCRIPTION
## Summary
- log stage3 token, cost, cache, confidence, and remediation details for each report segment
- document report analysis dashboards and SLO alerts
- test metric emission and counter exports

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_prompting.py docs/report_analysis_metrics.md tests/report_analysis/test_metrics_emission.py`
- `pytest tests/report_analysis/test_metrics_emission.py`


------
https://chatgpt.com/codex/tasks/task_b_689f8842d7a08325a512695ecb376fe4