### PR TITLE
docs: add stage 3 hardening guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Strategy snapshot now records rulebook version, rule hits, evidence needs, and red flags and emits structured audit events.
 - Document deterministic Stage 2.5 rollout with explicit rule evaluation order, precedence/exclusion rules, metrics, and rulebook update workflow.
 - Optional AI admission detection for Stage 2.5 when regex patterns find no admission.
+- Document Stage 3 hardening flow, versions, metrics, and troubleshooting guidance.
 ### Removed
 - Remove deprecated shims and aliases in audit, letter rendering, goodwill letters, instructions, and report analysis modules.
 - Remove unused `logic.copy_documents` module.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Legacy documentation and sample artifacts retained for historical reference. See
 Python backend powering ingestion, analysis, strategy generation, letter creation, analytics, and auditing. Key subpackages include [api](backend/api/README.md), [core](backend/core/README.md), [analytics](backend/analytics/README.md), [audit](backend/audit/README.md), and [assets](backend/assets/README.md).
 
 ### docs
-Reference materials such as data models and contributing guides. No dedicated README; browse files within [`docs`](docs) for deeper documentation.
+Reference materials such as data models, stage guides, and contributing
+instructions. Includes pipeline docs like [Stage 2.5](docs/STAGE_2_5.md)
+and [Stage 3 Hardening](docs/stage3_hardening.md). No dedicated README;
+browse files within [`docs`](docs) for deeper documentation.
 
 ### frontend
 React client that interacts with the API to upload reports and display results. See [frontend/README.md](frontend/README.md) for build and run instructions.

--- a/docs/stage3_hardening.md
+++ b/docs/stage3_hardening.md
@@ -1,0 +1,54 @@
+# Stage 3 Hardening Guide
+
+Stage 3 consolidates bureau segments into a hardened summary and records
+versioned metadata for reproducibility.
+
+## Flow
+1. Split the raw credit report into bureau‑specific segments.
+2. For each segment, fetch a cached analysis or call the model
+   (`ANALYSIS_MODEL_VERSION`).
+3. Validate the response against `analysis_schema.json` and populate
+   defaults.
+4. Merge bureau data, compute summary metrics, and flag
+   `needs_human_review` for low‑confidence runs.
+5. Emit a `report_segment` event with latency, cost, and token metrics.
+
+## Schema and Prompt Versions
+- **Prompt version:** `ANALYSIS_PROMPT_VERSION = 2`
+- **Schema version:** `ANALYSIS_SCHEMA_VERSION = 1`
+- **Schema path:** `backend/core/logic/report_analysis/analysis_schema.json`
+
+### Summary Metrics Fields
+The `summary_metrics` object includes:
+- `num_collections`
+- `num_late_payments`
+- `high_utilization`
+- `recent_inquiries`
+- `total_inquiries`
+- `num_negative_accounts`
+- `num_accounts_over_90_util`
+- `account_types_in_problem`
+
+## Logged Metrics
+`report_segment` events record:
+- `stage3_tokens_in`
+- `stage3_tokens_out`
+- `latency_ms`
+- `cost_est`
+- `cache_hit`
+- `error_code`
+- `confidence`
+- `needs_human_review`
+- `missing_bureaus`
+- `repair_count`
+- `remediation_applied`
+
+## Troubleshooting
+- **Non‑zero `error_code`:** parsing failure. Inspect bureau headings and
+  raw text.
+- **Low `confidence`:** values below `0.7` set `needs_human_review`.
+- **Missing bureaus:** non‑empty `missing_bureaus` indicates unparsed
+  sections in the report.
+- **Unexpected `repair_count` or `remediation_applied`:** extractors
+  disagreed with model output; verify account numbers, statuses, and
+  dates.


### PR DESCRIPTION
## Summary
- document Stage 3 hardening flow with versions, metrics, and troubleshooting
- reference Stage 3 guide in README
- log Stage 3 doc in changelog

## Testing
- `pre-commit run --files CHANGELOG.md README.md docs/stage3_hardening.md`
- `python tools/import_sanity_check.py`
- `pytest -q`
- `mkdocs build -f /tmp/mkdocs.yml -d /tmp/site`

------
https://chatgpt.com/codex/tasks/task_b_689f8a7e39f48325a2680571aa3084b8