### PR TITLE
refactor: centralize letter template routing

### DIFF
--- a/backend/core/letters/__init__.py
+++ b/backend/core/letters/__init__.py
@@ -1,0 +1,3 @@
+from .router import select_template, TemplateDecision
+
+__all__ = ["select_template", "TemplateDecision"]

--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Literal
+
+
+@dataclass
+class TemplateDecision:
+    template_path: str | None
+    required_fields: List[str]
+    router_mode: str
+    reason: str
+
+
+def _enabled() -> bool:
+    return os.getenv("LETTERS_ROUTER_ENABLED", "").lower() in {"1", "true", "yes"}
+
+
+def select_template(
+    action_tag: str,
+    ctx: dict,
+    mode: Literal["render", "skip", "auto_route"] = "auto_route",
+) -> TemplateDecision:
+    """Return the template selection for ``action_tag``.
+
+    When ``LETTERS_ROUTER_ENABLED`` is not set the router simply mirrors the
+    previous hard-coded template choices so behavior remains unchanged.
+    """
+
+    tag = (action_tag or "").lower()
+    routes = {
+        "dispute": ("dispute_letter_template.html", []),
+        "goodwill": ("goodwill_letter_template.html", []),
+        "custom_letter": ("general_letter_template.html", []),
+    }
+
+    if tag == "ignore":
+        return TemplateDecision(
+            template_path=None,
+            required_fields=[],
+            router_mode="skip",
+            reason="ignore action",
+        )
+
+    template_path, required = routes.get(tag, (None, []))
+
+    if not _enabled():
+        return TemplateDecision(
+            template_path=template_path,
+            required_fields=required,
+            router_mode="bypass",
+            reason="router disabled",
+        )
+
+    reason = "route matched" if template_path else "no route"
+    return TemplateDecision(
+        template_path=template_path,
+        required_fields=required,
+        router_mode=mode,
+        reason=reason,
+    )
+
+
+__all__ = ["TemplateDecision", "select_template"]

--- a/backend/core/logic/letters/dispute_preparation.py
+++ b/backend/core/logic/letters/dispute_preparation.py
@@ -8,6 +8,7 @@ from backend.core.logic.strategy.fallback_manager import determine_fallback_acti
 from backend.core.logic.utils.names_normalization import normalize_creditor_name
 from backend.core.models.bureau import BureauPayload
 from backend.core.models.client import ClientInfo
+from backend.core.letters.router import select_template
 
 
 def dedupe_disputes(
@@ -50,6 +51,10 @@ def prepare_disputes_and_inquiries(
     account identifiers to account metadata.
     """
 
+    decision = select_template("dispute", {"bureau": bureau_name})
+    log_messages.append(
+        f"[{bureau_name}] Router selected template '{decision.template_path}'"
+    )
     disputes: List[dict] = []
     for d in payload.get("disputes", []):
         action = str(d.get("action_tag") or d.get("recommended_action") or "").lower()

--- a/backend/core/logic/letters/generate_custom_letters.py
+++ b/backend/core/logic/letters/generate_custom_letters.py
@@ -29,11 +29,11 @@ from backend.core.models.account import Account
 from backend.core.models.bureau import BureauPayload
 from backend.core.models.client import ClientInfo
 from backend.core.services.ai_client import AIClient
+from backend.core.letters.router import select_template
 
 from .utils import StrategyContextMissing, ensure_strategy_context
 
 env = Environment(loader=FileSystemLoader(templates_path("")))
-template = env.get_template("general_letter_template.html")
 
 
 def _pdf_config(wkhtmltopdf_path: str | None):
@@ -264,8 +264,9 @@ def generate_custom_letter(
         "body_paragraph": body_paragraph,
         "supporting_docs": doc_names,
     }
-
-    html = template.render(**context)
+    decision = select_template("custom_letter", {"recipient": recipient})
+    tmpl = env.get_template(decision.template_path or "general_letter_template.html")
+    html = tmpl.render(**context)
     safe_recipient = (recipient or "Recipient").replace("/", "_").replace("\\", "_")
     filename = f"Custom Letter - {safe_recipient}.pdf"
     full_path = output_path / filename

--- a/backend/core/logic/letters/generate_goodwill_letters.py
+++ b/backend/core/logic/letters/generate_goodwill_letters.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 import backend.core.logic.letters.goodwill_preparation as goodwill_preparation
 import backend.core.logic.letters.goodwill_prompting as goodwill_prompting
 import backend.core.logic.letters.goodwill_rendering as goodwill_rendering
+from backend.core.letters.router import select_template
 from backend.api import config as api_config
 from backend.api.session_manager import get_session
 from backend.audit.audit import AuditLogger, emit_event
@@ -160,6 +161,7 @@ def generate_goodwill_letter_with_ai(
 
     _, doc_names, _ = gather_supporting_docs(session_id or "")
 
+    decision = select_template("goodwill", {"creditor": creditor})
     goodwill_rendering.render_goodwill_letter(
         creditor,
         gpt_data,
@@ -171,6 +173,7 @@ def generate_goodwill_letter_with_ai(
         audit=audit,
         compliance_fn=run_compliance_pipeline,
         pdf_fn=pdf_renderer.render_html_to_pdf,
+        template_path=decision.template_path or "goodwill_letter_template.html",
     )
 
 

--- a/backend/core/logic/rendering/letter_rendering.py
+++ b/backend/core/logic/rendering/letter_rendering.py
@@ -7,11 +7,13 @@ from backend.core.logic.rendering import pdf_renderer
 from backend.core.models.letter import LetterArtifact, LetterContext
 
 
-def render_dispute_letter_html(context: LetterContext) -> LetterArtifact:
+def render_dispute_letter_html(
+    context: LetterContext, template_path: str
+) -> LetterArtifact:
     """Render the dispute letter HTML using the Jinja template."""
 
     env = pdf_renderer.ensure_template_env(templates_path(""))
-    template = env.get_template("dispute_letter_template.html")
+    template = env.get_template(template_path or "dispute_letter_template.html")
     html = template.render(**context.to_dict())
     return LetterArtifact(html=html)
 

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
+from backend.core.letters.router import select_template
 from backend.core.models.account import Account, Inquiry
 
 
@@ -59,7 +60,10 @@ def test_dispute_flow_golden(monkeypatch):
     ctx.bureau_name = "Experian"
     ctx.bureau_address = "Address"
     ctx.date = "January 1, 2024"
-    artifact = render_dispute_letter_html(ctx)
+    decision = select_template("dispute", {})
+    artifact = render_dispute_letter_html(
+        ctx, decision.template_path or "dispute_letter_template.html"
+    )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.fix_draft_with_guardrails",
         lambda *a, **k: None,

--- a/tests/test_goodwill_rendering.py
+++ b/tests/test_goodwill_rendering.py
@@ -31,6 +31,7 @@ def test_rendering_calls_compliance_and_pdf(tmp_path):
         ai_client=FakeAIClient(),
         compliance_fn=fake_compliance,
         pdf_fn=fake_pdf,
+        template_path="goodwill_letter_template.html",
     )
     assert "compliance" in html_called
     assert "Doc1.pdf" in html_called["compliance"]
@@ -54,6 +55,7 @@ def test_rendering_calls_compliance_and_pdf(tmp_path):
         tmp_path,
         doc_names=["Doc1.pdf"],
         ai_client=FakeAIClient(),
+        template_path="goodwill_letter_template.html",
     )
     assert "compliance" in html_called
     assert "Doc1.pdf" in html_called["compliance"]

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -1,0 +1,11 @@
+from backend.core.letters.router import select_template
+
+
+def test_router_basic_mappings(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_ENABLED", "1")
+    assert select_template("dispute", {}).template_path == "dispute_letter_template.html"
+    assert select_template("goodwill", {}).template_path == "goodwill_letter_template.html"
+    assert select_template("custom_letter", {}).template_path == "general_letter_template.html"
+    decision = select_template("ignore", {})
+    assert decision.template_path is None
+    assert decision.router_mode == "skip"

--- a/tests/test_strategy_parse_failure_letters.py
+++ b/tests/test_strategy_parse_failure_letters.py
@@ -111,7 +111,7 @@ def test_letters_generate_when_strategy_llm_returns_junk(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "backend.core.logic.letters.letter_generator.render_dispute_letter_html",
-        lambda context: "html",
+        lambda context, template_path: "html",
     )
 
     monkeypatch.setattr(pdfkit, "configuration", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- add letters.router with select_template and TemplateDecision to centralize template selection
- refactor dispute, goodwill, and custom letter generation to consult router for templates
- expose router flag via LETTERS_ROUTER_ENABLED and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a485e0cb4083258d06153728003b46