### PR TITLE
Implement phased letter router with validation

### DIFF
--- a/backend/core/letters/validators.py
+++ b/backend/core/letters/validators.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+CHECKLIST: Dict[str, List[str]] = {
+    "dispute_letter_template.html": ["bureau"],
+    "goodwill_letter_template.html": ["creditor"],
+    "general_letter_template.html": ["recipient"],
+}
+
+
+def validate_required_fields(
+    template_path: str | None,
+    ctx: dict,
+    required: List[str],
+    checklist: Dict[str, List[str]],
+) -> List[str]:
+    """Return missing required fields for ``template_path``."""
+
+    expected = required or checklist.get(template_path or "", [])
+    return [field for field in expected if not ctx.get(field)]
+
+
+__all__ = ["validate_required_fields", "CHECKLIST"]
+

--- a/backend/core/logic/letters/dispute_preparation.py
+++ b/backend/core/logic/letters/dispute_preparation.py
@@ -51,7 +51,7 @@ def prepare_disputes_and_inquiries(
     account identifiers to account metadata.
     """
 
-    decision = select_template("dispute", {"bureau": bureau_name})
+    decision = select_template("dispute", {"bureau": bureau_name}, "candidate")
     log_messages.append(
         f"[{bureau_name}] Router selected template '{decision.template_path}'"
     )

--- a/backend/core/logic/letters/generate_custom_letters.py
+++ b/backend/core/logic/letters/generate_custom_letters.py
@@ -264,7 +264,7 @@ def generate_custom_letter(
         "body_paragraph": body_paragraph,
         "supporting_docs": doc_names,
     }
-    decision = select_template("custom_letter", {"recipient": recipient})
+    decision = select_template("custom_letter", {"recipient": recipient}, "final")
     tmpl = env.get_template(decision.template_path or "general_letter_template.html")
     html = tmpl.render(**context)
     safe_recipient = (recipient or "Recipient").replace("/", "_").replace("\\", "_")

--- a/backend/core/logic/letters/generate_goodwill_letters.py
+++ b/backend/core/logic/letters/generate_goodwill_letters.py
@@ -161,7 +161,7 @@ def generate_goodwill_letter_with_ai(
 
     _, doc_names, _ = gather_supporting_docs(session_id or "")
 
-    decision = select_template("goodwill", {"creditor": creditor})
+    decision = select_template("goodwill", {"creditor": creditor}, "final")
     goodwill_rendering.render_goodwill_letter(
         creditor,
         gpt_data,

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -285,7 +285,7 @@ def generate_all_dispute_letters_with_ai(
             closing_paragraph=gpt_data.get("closing_paragraph", ""),
             is_identity_theft=is_identity_theft,
         )
-        decision = select_template("dispute", {"bureau": bureau_name})
+        decision = select_template("dispute", {"bureau": bureau_name}, "final")
         artifact = render_dispute_letter_html(
             context, decision.template_path or "dispute_letter_template.html"
         )

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -60,7 +60,7 @@ def test_dispute_flow_golden(monkeypatch):
     ctx.bureau_name = "Experian"
     ctx.bureau_address = "Address"
     ctx.date = "January 1, 2024"
-    decision = select_template("dispute", {})
+    decision = select_template("dispute", {"bureau": "Experian"}, "final")
     artifact = render_dispute_letter_html(
         ctx, decision.template_path or "dispute_letter_template.html"
     )

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -2,10 +2,27 @@ from backend.core.letters.router import select_template
 
 
 def test_router_basic_mappings(monkeypatch):
-    monkeypatch.setenv("LETTERS_ROUTER_ENABLED", "1")
-    assert select_template("dispute", {}).template_path == "dispute_letter_template.html"
-    assert select_template("goodwill", {}).template_path == "goodwill_letter_template.html"
-    assert select_template("custom_letter", {}).template_path == "general_letter_template.html"
-    decision = select_template("ignore", {})
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    assert (
+        select_template("dispute", {"bureau": "Experian"}, "final").template_path
+        == "dispute_letter_template.html"
+    )
+    assert (
+        select_template("goodwill", {"creditor": "ABC"}, "final").template_path
+        == "goodwill_letter_template.html"
+    )
+    assert (
+        select_template("custom_letter", {"recipient": "Joe"}, "final").template_path
+        == "general_letter_template.html"
+    )
+    decision = select_template("ignore", {}, "final")
     assert decision.template_path is None
     assert decision.router_mode == "skip"
+
+
+def test_missing_fields(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    decision = select_template("goodwill", {}, "candidate")
+    assert decision.missing_fields == ["creditor"]
+    decision = select_template("goodwill", {"creditor": "XYZ"}, "candidate")
+    assert decision.missing_fields == []


### PR DESCRIPTION
## Summary
- extend letter router with candidate/final phases
- add field checklist validator and missing-fields reporting
- emit router metrics and gate by LETTERS_ROUTER_PHASED flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a49405a4788325a86248f4d04ed46b