### PR TITLE
refactor: enforce router-driven template rendering

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -23,7 +23,7 @@ def _enabled() -> bool:
 def select_template(
     action_tag: str,
     ctx: dict,
-    phase: Literal["candidate", "final"],
+    phase: Literal["candidate", "final", "finalize"],
 ) -> TemplateDecision:
     """Return the template selection for ``action_tag``.
 
@@ -65,7 +65,7 @@ def select_template(
     if template_path:
         if phase == "candidate":
             emit_counter("router.candidate_selected")
-        elif phase == "final":
+        elif phase in {"final", "finalize"}:
             emit_counter("router.finalized")
 
     if missing_fields:

--- a/backend/core/logic/letters/dispute_preparation.py
+++ b/backend/core/logic/letters/dispute_preparation.py
@@ -51,7 +51,7 @@ def prepare_disputes_and_inquiries(
     account identifiers to account metadata.
     """
 
-    decision = select_template("dispute", {"bureau": bureau_name}, "candidate")
+    decision = select_template("dispute", {"bureau": bureau_name}, phase="candidate")
     log_messages.append(
         f"[{bureau_name}] Router selected template '{decision.template_path}'"
     )

--- a/backend/core/logic/letters/generate_custom_letters.py
+++ b/backend/core/logic/letters/generate_custom_letters.py
@@ -264,8 +264,12 @@ def generate_custom_letter(
         "body_paragraph": body_paragraph,
         "supporting_docs": doc_names,
     }
-    decision = select_template("custom_letter", {"recipient": recipient}, "final")
-    tmpl = env.get_template(decision.template_path or "general_letter_template.html")
+    decision = select_template(
+        "custom_letter", {"recipient": recipient}, phase="finalize"
+    )
+    if not decision.template_path:
+        raise ValueError("router did not supply template_path")
+    tmpl = env.get_template(decision.template_path)
     html = tmpl.render(**context)
     safe_recipient = (recipient or "Recipient").replace("/", "_").replace("\\", "_")
     filename = f"Custom Letter - {safe_recipient}.pdf"

--- a/backend/core/logic/letters/generate_goodwill_letters.py
+++ b/backend/core/logic/letters/generate_goodwill_letters.py
@@ -161,7 +161,11 @@ def generate_goodwill_letter_with_ai(
 
     _, doc_names, _ = gather_supporting_docs(session_id or "")
 
-    decision = select_template("goodwill", {"creditor": creditor}, "final")
+    decision = select_template(
+        "goodwill", {"creditor": creditor}, phase="finalize"
+    )
+    if not decision.template_path:
+        raise ValueError("router did not supply template_path")
     goodwill_rendering.render_goodwill_letter(
         creditor,
         gpt_data,
@@ -173,7 +177,7 @@ def generate_goodwill_letter_with_ai(
         audit=audit,
         compliance_fn=run_compliance_pipeline,
         pdf_fn=pdf_renderer.render_html_to_pdf,
-        template_path=decision.template_path or "goodwill_letter_template.html",
+        template_path=decision.template_path,
     )
 
 

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -285,9 +285,13 @@ def generate_all_dispute_letters_with_ai(
             closing_paragraph=gpt_data.get("closing_paragraph", ""),
             is_identity_theft=is_identity_theft,
         )
-        decision = select_template("dispute", {"bureau": bureau_name}, "final")
+        decision = select_template(
+            "dispute", {"bureau": bureau_name}, phase="finalize"
+        )
+        if not decision.template_path:
+            raise ValueError("router did not supply template_path")
         artifact = render_dispute_letter_html(
-            context, decision.template_path or "dispute_letter_template.html"
+            context, decision.template_path
         )
         html = artifact.html if isinstance(artifact, LetterArtifact) else artifact
         run_compliance_pipeline(
@@ -327,7 +331,7 @@ def generate_all_dispute_letters_with_ai(
                 f"[Alert] Issues detected generating letter for {bureau_name}",
                 stacklevel=2,
             )
-        tmpl = decision.template_path or "dispute_letter_template.html"
+        tmpl = decision.template_path
         print(
             f"[LetterSummary] letter_id={filename}, bureau={bureau_name}, action=dispute, "
             f"template={tmpl}, fallback_used={fallback_used}, "

--- a/backend/core/logic/rendering/instruction_renderer.py
+++ b/backend/core/logic/rendering/instruction_renderer.py
@@ -14,16 +14,24 @@ from typing import Any
 from backend.assets.paths import templates_path
 from backend.core.logic.rendering import pdf_renderer
 from backend.core.models.letter import LetterContext
+from backend.analytics.analytics_tracker import emit_counter
 
 
-def render_instruction_html(context: LetterContext | dict[str, Any]) -> str:
+def render_instruction_html(
+    context: LetterContext | dict[str, Any], template_path: str
+) -> str:
     """Render the Jinja2 template with the provided context."""
+    if not template_path:
+        emit_counter("rendering.missing_template_path")
+        raise ValueError("template_path is required")
     env = pdf_renderer.ensure_template_env(templates_path(""))
-    template = env.get_template("instruction_template.html")
+    template = env.get_template(template_path)
     return template.render(**context)
 
 
-def build_instruction_html(context: LetterContext | dict[str, Any]) -> str:
+def build_instruction_html(
+    context: LetterContext | dict[str, Any], template_path: str
+) -> str:
     """Build the full instruction HTML string from prepared data."""
     sections = context.get("sections", {})
 
@@ -228,7 +236,8 @@ def build_instruction_html(context: LetterContext | dict[str, Any]) -> str:
             + closing_block,
             "is_identity_theft": context.get("is_identity_theft"),
             "logo_base64": context.get("logo_base64"),
-        }
+        },
+        template_path,
     )
 
     return final_html

--- a/backend/core/logic/rendering/instructions_generator.py
+++ b/backend/core/logic/rendering/instructions_generator.py
@@ -73,7 +73,7 @@ def generate_instruction_file(
         ai_client=ai_client,
         strategy=strategy,
     )
-    html = build_instruction_html(context)
+    html = build_instruction_html(context, "instruction_template.html")
     run_compliance_pipeline(
         html,
         client_info.get("state"),

--- a/backend/core/logic/rendering/letter_rendering.py
+++ b/backend/core/logic/rendering/letter_rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from backend.assets.paths import templates_path
 from backend.core.logic.rendering import pdf_renderer
 from backend.core.models.letter import LetterArtifact, LetterContext
+from backend.analytics.analytics_tracker import emit_counter
 
 
 def render_dispute_letter_html(
@@ -12,8 +13,12 @@ def render_dispute_letter_html(
 ) -> LetterArtifact:
     """Render the dispute letter HTML using the Jinja template."""
 
+    if not template_path:
+        emit_counter("rendering.missing_template_path")
+        raise ValueError("template_path is required")
+
     env = pdf_renderer.ensure_template_env(templates_path(""))
-    template = env.get_template(template_path or "dispute_letter_template.html")
+    template = env.get_template(template_path)
     html = template.render(**context.to_dict())
     return LetterArtifact(html=html)
 

--- a/tests/test_all_render_calls_use_router.py
+++ b/tests/test_all_render_calls_use_router.py
@@ -1,0 +1,47 @@
+import pytest
+
+from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
+from backend.core.logic.letters.goodwill_rendering import render_goodwill_letter
+from backend.core.logic.rendering.instruction_renderer import render_instruction_html
+from backend.core.models.letter import LetterContext
+from tests.helpers.fake_ai_client import FakeAIClient
+import backend.analytics.analytics_tracker as tracker
+
+
+def test_all_render_calls_use_router(monkeypatch, tmp_path):
+    metrics = []
+
+    def fake_counter(name, increment=1):
+        metrics.append(name)
+
+    monkeypatch.setattr(
+        tracker, "emit_counter", fake_counter
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.rendering.letter_rendering.emit_counter", fake_counter
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.letters.goodwill_rendering.emit_counter", fake_counter
+    )
+    monkeypatch.setattr(
+        "backend.core.logic.rendering.instruction_renderer.emit_counter", fake_counter
+    )
+
+    ctx = LetterContext()
+    with pytest.raises(ValueError):
+        render_dispute_letter_html(ctx, "")
+
+    with pytest.raises(ValueError):
+        render_instruction_html({}, template_path="")
+
+    with pytest.raises(ValueError):
+        render_goodwill_letter(
+            "Creditor",
+            {},
+            {"legal_name": "A", "session_id": "s", "state": "CA"},
+            tmp_path,
+            ai_client=FakeAIClient(),
+            template_path="",
+        )
+
+    assert metrics.count("rendering.missing_template_path") >= 3

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -60,9 +60,11 @@ def test_dispute_flow_golden(monkeypatch):
     ctx.bureau_name = "Experian"
     ctx.bureau_address = "Address"
     ctx.date = "January 1, 2024"
-    decision = select_template("dispute", {"bureau": "Experian"}, "final")
+    decision = select_template(
+        "dispute", {"bureau": "Experian"}, phase="finalize"
+    )
     artifact = render_dispute_letter_html(
-        ctx, decision.template_path or "dispute_letter_template.html"
+        ctx, decision.template_path
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.fix_draft_with_guardrails",

--- a/tests/test_instruction_evidence.py
+++ b/tests/test_instruction_evidence.py
@@ -34,6 +34,6 @@ def test_instruction_includes_evidence():
         ai_client=fake,
         strategy=strategy,
     )
-    html = build_instruction_html(context)
+    html = build_instruction_html(context, "instruction_template.html")
     assert "identity_theft_affidavit" in html
     assert accounts[0]["needs_evidence"] == ["identity_theft_affidavit"]

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -4,25 +4,25 @@ from backend.core.letters.router import select_template
 def test_router_basic_mappings(monkeypatch):
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
     assert (
-        select_template("dispute", {"bureau": "Experian"}, "final").template_path
+        select_template("dispute", {"bureau": "Experian"}, phase="finalize").template_path
         == "dispute_letter_template.html"
     )
     assert (
-        select_template("goodwill", {"creditor": "ABC"}, "final").template_path
+        select_template("goodwill", {"creditor": "ABC"}, phase="finalize").template_path
         == "goodwill_letter_template.html"
     )
     assert (
-        select_template("custom_letter", {"recipient": "Joe"}, "final").template_path
+        select_template("custom_letter", {"recipient": "Joe"}, phase="finalize").template_path
         == "general_letter_template.html"
     )
-    decision = select_template("ignore", {}, "final")
+    decision = select_template("ignore", {}, phase="finalize")
     assert decision.template_path is None
     assert decision.router_mode == "skip"
 
 
 def test_missing_fields(monkeypatch):
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
-    decision = select_template("goodwill", {}, "candidate")
+    decision = select_template("goodwill", {}, phase="candidate")
     assert decision.missing_fields == ["creditor"]
-    decision = select_template("goodwill", {"creditor": "XYZ"}, "candidate")
+    decision = select_template("goodwill", {"creditor": "XYZ"}, phase="candidate")
     assert decision.missing_fields == []

--- a/tests/test_local_workflow.py
+++ b/tests/test_local_workflow.py
@@ -200,7 +200,9 @@ def test_minimal_workflow():
             ai_client=fake,
             strategy=None,
         )
-        html_content = instructions_generator.build_instruction_html(context)
+        html_content = instructions_generator.build_instruction_html(
+            context, "instruction_template.html"
+        )
         instructions_generator.run_compliance_pipeline(
             html_content,
             client_info.get("state"),

--- a/tests/test_logic_fixes.py
+++ b/tests/test_logic_fixes.py
@@ -92,7 +92,9 @@ def test_dedup_without_numbers():
             ai_client=fake,
             strategy=None,
         )
-        html = instructions_generator.build_instruction_html(context)
+        html = instructions_generator.build_instruction_html(
+            context, "instruction_template.html"
+        )
         instructions_generator.run_compliance_pipeline(
             html,
             None,

--- a/tests/test_no_raw_template_paths.py
+++ b/tests/test_no_raw_template_paths.py
@@ -1,0 +1,22 @@
+import ast
+import re
+from pathlib import Path
+
+
+def test_no_raw_template_paths():
+    root = Path(__file__).resolve().parents[1]
+    pattern = re.compile(r"_letter_template\.html$")
+    allowed = {
+        root / "backend" / "core" / "letters" / "router.py",
+        root / "backend" / "core" / "letters" / "validators.py",
+    }
+    for path in root.rglob("*.py"):
+        if path.is_relative_to(root / "tests"):
+            continue
+        if path in allowed:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if pattern.search(node.value):
+                    raise AssertionError(f"Found template literal {node.value!r} in {path}")


### PR DESCRIPTION
## Summary
- require router-supplied templates for dispute, goodwill, and custom letters
- hard fail in rendering helpers when template_path is missing and emit metrics
- add tests guarding router use and absence of hard-coded template paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4985bdb0c8325bb860002736c382c