### PR TITLE
Add client context sentence support

### DIFF
--- a/backend/assets/phrases/phrases.yaml
+++ b/backend/assets/phrases/phrases.yaml
@@ -1,35 +1,24 @@
 fraud_dispute:
   neutral_client_sentence: "I am disputing this account because it does not belong to me."
-
 bureau_dispute:
   neutral_client_sentence: "I am requesting that the bureau verify this account as required by law."
-
 inquiry_dispute:
   neutral_client_sentence: "I did not authorize this inquiry and request its removal from my report."
-
 debt_validation:
   neutral_client_sentence: "I request full validation of this debt in accordance with the Fair Debt Collection Practices Act."
-
 obsolescence:
   neutral_client_sentence: "This account should no longer appear on my report because it is older than the allowable reporting period."
-
 mov:
   neutral_client_sentence: "I am requesting the method of verification used to validate this account."
-
 medical_dispute:
   neutral_client_sentence: "I dispute this medical-related account and request verification without disclosure of medical details."
-
 direct_dispute:
   neutral_client_sentence: "I dispute the accuracy of this account and request that the furnisher investigate."
-
 goodwill:
   neutral_client_sentence: "I respectfully request goodwill adjustment based on my positive account history."
-
 pay_for_delete:
   neutral_client_sentence: "I am willing to resolve this account contingent on its deletion from my credit report."
-
 cease_and_desist:
   neutral_client_sentence: "I request that all further communication regarding this account cease immediately."
-
 custom_letter:
   neutral_client_sentence: "This letter is submitted to formally dispute or clarify the information listed above."

--- a/backend/assets/templates/bureau_dispute_letter_template.html
+++ b/backend/assets/templates/bureau_dispute_letter_template.html
@@ -2,6 +2,6 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 {% endblock %}

--- a/backend/assets/templates/cease_and_desist_letter_template.html
+++ b/backend/assets/templates/cease_and_desist_letter_template.html
@@ -2,6 +2,6 @@
 {% block body %}
 <p>{{ collector_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 {% endblock %}

--- a/backend/assets/templates/custom_letter_template.html
+++ b/backend/assets/templates/custom_letter_template.html
@@ -2,6 +2,6 @@
 {% block body %}
 <p>{{ recipient_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 {% endblock %}

--- a/backend/assets/templates/debt_validation_letter_template.html
+++ b/backend/assets/templates/debt_validation_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ collector_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ days_since_first_contact }}</p>
 {% endblock %}

--- a/backend/assets/templates/direct_dispute_letter_template.html
+++ b/backend/assets/templates/direct_dispute_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ furnisher_address }}</p>
 {% endblock %}

--- a/backend/assets/templates/dispute_letter_template.html
+++ b/backend/assets/templates/dispute_letter_template.html
@@ -71,6 +71,7 @@
 <div class="section">
     <p>To whom it may concern,</p>
     <p>{{ opening_paragraph }}</p>
+    {% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 </div>
 
 {% if accounts %}

--- a/backend/assets/templates/fraud_dispute_letter_template.html
+++ b/backend/assets/templates/fraud_dispute_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ is_identity_theft }}</p>
 {% endblock %}

--- a/backend/assets/templates/general_letter_template.html
+++ b/backend/assets/templates/general_letter_template.html
@@ -33,6 +33,7 @@
     <div class="section">
         <p>{{ greeting_line }}</p>
         <p>{{ body_paragraph }}</p>
+        {% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
     </div>
 
     {% if supporting_docs %}

--- a/backend/assets/templates/goodwill_letter_template.html
+++ b/backend/assets/templates/goodwill_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ months_since_last_late }}</p>
 <p>{{ account_history_good }}</p>

--- a/backend/assets/templates/inquiry_dispute_letter_template.html
+++ b/backend/assets/templates/inquiry_dispute_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ inquiry_creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ inquiry_date }}</p>
 {% endblock %}

--- a/backend/assets/templates/medical_dispute_letter_template.html
+++ b/backend/assets/templates/medical_dispute_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ amount }}</p>
 <p>{{ medical_status }}</p>

--- a/backend/assets/templates/mov_letter_template.html
+++ b/backend/assets/templates/mov_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ cra_last_result }}</p>
 <p>{{ days_since_cra_result }}</p>

--- a/backend/assets/templates/obsolescence_letter_template.html
+++ b/backend/assets/templates/obsolescence_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ creditor_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ years_since_dofd }}</p>
 <p>{{ years_since_bankruptcy }}</p>

--- a/backend/assets/templates/pay_for_delete_letter_template.html
+++ b/backend/assets/templates/pay_for_delete_letter_template.html
@@ -2,7 +2,7 @@
 {% block body %}
 <p>{{ collector_name }}</p>
 {% include "partials/account_ref.html" %}
-{% if safe_client_sentence %}<p>{{ safe_client_sentence }}</p>{% endif %}
+{% if client_context_sentence %}<p>{{ client_context_sentence }}</p>{% endif %}
 <p>{{ legal_safe_summary }}</p>
 <p>{{ offer_terms }}</p>
 {% endblock %}

--- a/backend/core/ai/paraphrase.py
+++ b/backend/core/ai/paraphrase.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def paraphrase(text: str, banned_terms: Iterable[str] | None = None) -> Optional[str]:
+    """Return a paraphrased version of ``text``.
+
+    This is a lightweight stub used for tests. In production this would call
+    an AI service with low temperature and enforce a similarity check. If any
+    banned term appears in ``text`` the paraphrase is considered failed and
+    ``None`` is returned.
+    """
+
+    banned = {t.lower() for t in (banned_terms or [])}
+    lowered = text.lower()
+    if any(term in lowered for term in banned):
+        return None
+    return text
+
+
+__all__ = ["paraphrase"]

--- a/backend/core/letters/client_context.py
+++ b/backend/core/letters/client_context.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import yaml
+
+from backend.analytics.analytics_tracker import emit_counter
+from backend.assets.paths import ASSETS_ROOT
+from backend.core.ai.paraphrase import paraphrase
+from backend.core.logic.utils.pii import redact_pii
+from backend.api.config import env_bool
+
+_PHRASE_CACHE: Dict[str, Dict[str, str]] | None = None
+_DENYLIST = ["promise to pay", "personal medical"]
+
+
+def _load_phrases() -> Dict[str, Dict[str, str]]:
+    global _PHRASE_CACHE
+    if _PHRASE_CACHE is None:
+        path = ASSETS_ROOT / "phrases" / "phrases.yaml"
+        try:
+            with open(path, encoding="utf-8") as f:
+                _PHRASE_CACHE = yaml.safe_load(f) or {}
+        except FileNotFoundError:  # pragma: no cover - missing asset
+            _PHRASE_CACHE = {}
+    return _PHRASE_CACHE
+
+
+def choose_phrase_template(action_tag: str, policy_flags: Dict, rule_hits: List[str]) -> Dict[str, str]:
+    phrases = _load_phrases()
+    entry = phrases.get(action_tag, {})
+    phrase = entry.get("neutral_client_sentence")
+    if phrase:
+        return {"key": "neutral", "template": phrase}
+    return {}
+
+
+def render_phrase(phrase: str, variables: Dict[str, str]) -> str:
+    try:
+        rendered = phrase.format(**{k: str(v) for k, v in variables.items()})
+    except Exception:
+        rendered = phrase
+    return redact_pii(rendered)
+
+
+def format_safe_client_context(
+    action_tag: str,
+    cleaned_client_summary: str,
+    policy_findings: Dict,
+    rule_hits: List[str],
+) -> Optional[str]:
+    if policy_findings.get("prohibited_admission_detected"):
+        emit_counter(f"client_context_used.{action_tag}.neutral.policy_blocked")
+        return None
+
+    choice = choose_phrase_template(action_tag, policy_findings, rule_hits)
+    phrase = choice.get("template")
+    if not phrase:
+        emit_counter(f"client_context_used.{action_tag}.neutral.policy_blocked")
+        return None
+
+    rendered = render_phrase(phrase, {})
+    rendered = rendered.strip()
+    if not rendered:
+        emit_counter(f"client_context_used.{action_tag}.neutral.masked_out")
+        return None
+    if len(rendered) > 150:
+        emit_counter(f"client_context_used.{action_tag}.neutral.too_long")
+        return None
+    lowered = rendered.lower()
+    if any(tok in lowered for tok in _DENYLIST):
+        emit_counter(f"client_context_used.{action_tag}.neutral.policy_blocked")
+        return None
+
+    if env_bool("ENABLE_CONTEXT_PARAPHRASE", False):
+        paraphrased = paraphrase(rendered, banned_terms=_DENYLIST)
+        if paraphrased:
+            rendered = redact_pii(paraphrased)
+
+    emit_counter(f"client_context_used.{action_tag}.neutral.ok")
+    return rendered
+
+
+__all__ = [
+    "choose_phrase_template",
+    "render_phrase",
+    "format_safe_client_context",
+]

--- a/backend/core/letters/validators.py
+++ b/backend/core/letters/validators.py
@@ -29,6 +29,15 @@ def validate_required_fields(
     expected = required or checklist.get(template_path or "", [])
     missing = [field for field in expected if not ctx.get(field)]
 
+    sentence = ctx.get("client_context_sentence")
+    if sentence:
+        if len(sentence) > 150:
+            missing.append("client_context_sentence.length")
+        if sentence != redact_pii(sentence):
+            missing.append("client_context_sentence.pii")
+        if re.search(r"promise to pay", sentence, re.IGNORECASE):
+            missing.append("client_context_sentence.banned")
+
     if template_path == "instruction_template.html":
         actions = ctx.get("per_account_actions") or []
         if not actions:
@@ -50,12 +59,6 @@ def validate_required_fields(
                     missing.append("per_account_actions.action_verb")
                     break
 
-        sentence = ctx.get("client_context_sentence")
-        if sentence:
-            if len(sentence) > 150:
-                missing.append("client_context_sentence.length")
-            if sentence != redact_pii(sentence):
-                missing.append("client_context_sentence.pii")
 
     return missing
 

--- a/backend/core/logic/letters/goodwill_rendering.py
+++ b/backend/core/logic/letters/goodwill_rendering.py
@@ -22,6 +22,8 @@ from backend.core.logic.utils.note_handling import get_client_address_lines
 from backend.core.models.client import ClientInfo
 from backend.core.services.ai_client import AIClient
 from backend.analytics.analytics_tracker import emit_counter
+from backend.api.config import env_bool
+from backend.core.letters.client_context import format_safe_client_context
 
 
 def load_creditor_address_map() -> Mapping[str, str]:
@@ -97,6 +99,10 @@ def render_goodwill_letter(
         "closing_paragraph": gpt_data.get("closing_paragraph", ""),
         "supporting_docs": doc_names or [],
     }
+    if env_bool("SAFE_CLIENT_SENTENCE_ENABLED", False):
+        sentence = format_safe_client_context("goodwill", "", {}, [])
+        if sentence:
+            context["client_context_sentence"] = sentence
 
     env = ensure_template_env()
     template = env.get_template(template_path)

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -41,6 +41,8 @@ from .dispute_preparation import prepare_disputes_and_inquiries
 from .gpt_prompting import call_gpt_dispute_letter as _call_gpt_dispute_letter
 from .utils import StrategyContextMissing, ensure_strategy_context
 from backend.core.letters.router import select_template
+from backend.api.config import env_bool
+from backend.core.letters.client_context import format_safe_client_context
 
 logger = logging.getLogger(__name__)
 
@@ -285,6 +287,10 @@ def generate_all_dispute_letters_with_ai(
             closing_paragraph=gpt_data.get("closing_paragraph", ""),
             is_identity_theft=is_identity_theft,
         )
+        if env_bool("SAFE_CLIENT_SENTENCE_ENABLED", False):
+            sentence = format_safe_client_context("bureau_dispute", "", {}, [])
+            if sentence:
+                context.client_context_sentence = sentence
         decision = select_template(
             "dispute", {"bureau": bureau_name}, phase="finalize"
         )

--- a/backend/core/models/letter.py
+++ b/backend/core/models/letter.py
@@ -42,6 +42,7 @@ class LetterContext:
     bureau_address: str = ""
     date: str = ""
     opening_paragraph: str = ""
+    client_context_sentence: str = ""
     accounts: List[LetterAccount] = field(default_factory=list)
     inquiries: List[Inquiry] = field(default_factory=list)
     closing_paragraph: str = ""
@@ -56,6 +57,7 @@ class LetterContext:
             bureau_address=data.get("bureau_address", ""),
             date=data.get("date", ""),
             opening_paragraph=data.get("opening_paragraph", ""),
+            client_context_sentence=data.get("client_context_sentence", ""),
             accounts=[LetterAccount.from_dict(a) for a in data.get("accounts", [])],
             inquiries=[Inquiry.from_dict(i) for i in data.get("inquiries", [])],
             closing_paragraph=data.get("closing_paragraph", ""),

--- a/tests/test_client_context.py
+++ b/tests/test_client_context.py
@@ -1,0 +1,133 @@
+import os
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+from backend.assets.paths import templates_path
+from backend.core.letters.client_context import (
+    choose_phrase_template,
+    format_safe_client_context,
+    render_phrase,
+)
+
+
+def test_choose_phrase_template_neutral():
+    tpl = choose_phrase_template("fraud_dispute", {}, [])
+    assert tpl["template"].startswith("I am disputing")
+
+
+def test_render_phrase_masks_pii():
+    result = render_phrase("Account {account_ref}", {"account_ref": "123-45-6789"})
+    assert "***-**-6789" in result
+
+
+def test_format_safe_client_context_blocks_policy():
+    reset_counters()
+    sentence = format_safe_client_context(
+        "goodwill", "", {"prohibited_admission_detected": True}, []
+    )
+    assert sentence is None
+    counters = get_counters()
+    assert counters["client_context_used.goodwill.neutral.policy_blocked"] == 1
+
+
+def test_format_safe_client_context_ok():
+    reset_counters()
+    sentence = format_safe_client_context("debt_validation", "", {}, [])
+    assert sentence
+    assert len(sentence) <= 150
+    counters = get_counters()
+    assert counters["client_context_used.debt_validation.neutral.ok"] == 1
+
+
+def test_format_safe_client_context_too_long(monkeypatch):
+    import backend.core.letters.client_context as cc
+
+    reset_counters()
+    monkeypatch.setattr(
+        cc,
+        "choose_phrase_template",
+        lambda *a, **k: {"key": "neutral", "template": "a" * 200},
+    )
+    sentence = cc.format_safe_client_context("pay_for_delete", "", {}, [])
+    assert sentence is None
+    counters = get_counters()
+    assert counters["client_context_used.pay_for_delete.neutral.too_long"] == 1
+
+
+def test_format_safe_client_context_banned(monkeypatch):
+    import backend.core.letters.client_context as cc
+
+    reset_counters()
+    monkeypatch.setattr(
+        cc,
+        "choose_phrase_template",
+        lambda *a, **k: {"key": "neutral", "template": "I promise to pay"},
+    )
+    sentence = cc.format_safe_client_context("debt_validation", "", {}, [])
+    assert sentence is None
+    counters = get_counters()
+    assert counters["client_context_used.debt_validation.neutral.policy_blocked"] == 1
+
+
+def _render_template(template_name: str, context: dict) -> str:
+    env = Environment(loader=FileSystemLoader(templates_path("")))
+    template = env.get_template(template_name)
+    return template.render(**context)
+
+
+@pytest.mark.parametrize(
+    "tag, template, ctx",
+    [
+        (
+            "debt_validation",
+            "debt_validation_letter_template.html",
+            {
+                "collector_name": "Collector",
+                "account_number_masked": "****1234",
+                "bureau": "Experian",
+                "legal_safe_summary": "Summary",
+                "days_since_first_contact": "10",
+            },
+        ),
+        (
+            "fraud_dispute",
+            "fraud_dispute_letter_template.html",
+            {
+                "creditor_name": "Creditor",
+                "account_number_masked": "****1234",
+                "bureau": "Experian",
+                "legal_safe_summary": "Summary",
+                "is_identity_theft": "Yes",
+            },
+        ),
+        (
+            "goodwill",
+            "goodwill_letter_template.html",
+            {
+                "creditor_name": "Creditor",
+                "account_number_masked": "****1234",
+                "legal_safe_summary": "Summary",
+                "months_since_last_late": "5",
+                "account_history_good": "History",
+            },
+        ),
+        (
+            "pay_for_delete",
+            "pay_for_delete_letter_template.html",
+            {
+                "collector_name": "Collector",
+                "account_number_masked": "****1234",
+                "legal_safe_summary": "Summary",
+                "offer_terms": "Offer",
+            },
+        ),
+    ],
+)
+def test_templates_include_sentence(tag, template, ctx):
+    sentence = format_safe_client_context(tag, "", {}, [])
+    ctx["client_context_sentence"] = sentence
+    ctx.update({"client": type("C", (), {"full_name": "John Doe", "address_line": "123"})(), "today": "Jan 1, 2024"})
+    html = _render_template(template, ctx)
+    assert sentence in html


### PR DESCRIPTION
## Summary
- add phrase bank for neutral client context sentences
- inject sanitized client context sentence into letter templates and models
- validate and track metrics for client context sentence usage

## Testing
- `python -m pytest tests/test_client_context.py`
- `python -m pytest tests/test_letter_template_router.py tests/test_dispute_flow_golden.py`


------
https://chatgpt.com/codex/tasks/task_b_68a4a178b1e883258bd362c97ae5b231