### PR TITLE
test: add end-to-end golden suite for letters

### DIFF
--- a/tests/letters/goldens/cease_and_desist.html
+++ b/tests/letters/goldens/cease_and_desist.html
@@ -1,0 +1,5 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Collector Inc</p>
+<p>Account 1234 (EXPERIAN)</p><p>I request that all further communication regarding this account cease immediately.</p><p>Stop contact immediately.</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/debt_validation.html
+++ b/tests/letters/goldens/debt_validation.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Collector Inc</p>
+<p>Account 1234 (EXPERIAN)</p><p>I request full validation of this debt in accordance with the Fair Debt Collection Practices Act.</p><p>FDCPA 1692g requires validation; please respond within 30 days.</p>
+<p>5</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/duplicate_tradeline.html
+++ b/tests/letters/goldens/duplicate_tradeline.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Dup Co</p>
+<p>Account 1234 (EXPERIAN)</p><p>I dispute the accuracy of this account and request that the furnisher investigate.</p><p>This tradeline appears duplicated.</p>
+<p>3 Dup Rd</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/fraud_with_ftc.html
+++ b/tests/letters/goldens/fraud_with_ftc.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Fraud Corp</p>
+<p>Account 1234 (EXPERIAN)</p><p>I am disputing this account because it does not belong to me.</p><p>FCRA 605B allows me to block or remove this item via FTC report within 30 days.</p>
+<p>True</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/medical.html
+++ b/tests/letters/goldens/medical.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Medical Co</p>
+<p>Account 1234 (EXPERIAN)</p><p>I dispute the accuracy of this account and request that the furnisher investigate.</p><p>Paid medical debt under $500 should be removed.</p>
+<p>1 Med St</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/mov.html
+++ b/tests/letters/goldens/mov.html
@@ -1,0 +1,7 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Bank</p>
+<p>Account 1234 (EXPERIAN)</p><p>I am requesting the method of verification used to validate this account.</p><p>Please reinvestigate this item.</p>
+<p>verified</p>
+<p>45</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/pay_for_delete.html
+++ b/tests/letters/goldens/pay_for_delete.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Collector Inc</p>
+<p>Account 1234 (EXPERIAN)</p><p>I am willing to resolve this account contingent on its deletion from my credit report.</p><p>I will pay if you delete this account.</p>
+<p>Delete account and we pay 60%.</p>
+<p>Jane Doe</p>

--- a/tests/letters/goldens/unauthorized_inquiry.html
+++ b/tests/letters/goldens/unauthorized_inquiry.html
@@ -1,0 +1,6 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Inquiry Co</p>
+<p>Account 1234 (EXPERIAN)</p><p>I dispute the accuracy of this account and request that the furnisher investigate.</p><p>This unauthorized inquiry should be removed.</p>
+<p>2 Inquiry Ave</p>
+<p>Jane Doe</p>

--- a/tests/letters/test_letter_pipeline_golden.py
+++ b/tests/letters/test_letter_pipeline_golden.py
@@ -1,0 +1,197 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+from backend.core.letters import validators
+from backend.core.letters.client_context import format_safe_client_context
+from backend.core.letters.router import select_template
+from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
+
+BASE_CTX = {
+    "client": {"full_name": "Jane Doe", "address_line": "123 Main St"},
+    "today": "January 1, 2024",
+    "account_number_masked": "1234",
+    "bureau": "Experian",
+}
+
+SCENARIOS = [
+    {
+        "name": "fraud_with_ftc",
+        "action_tag": "fraud_dispute",
+        "initial_ctx": {
+            "creditor_name": "Fraud Corp",
+            "legal_safe_summary": "FCRA 605B allows me to block or remove this item via FTC report within 30 days.",
+            "is_identity_theft": True,
+        },
+        "expect_html": True,
+        "template": "fraud_dispute_letter_template.html",
+        "golden": Path("tests/letters/goldens/fraud_with_ftc.html"),
+    },
+    {
+        "name": "fraud_without_ftc",
+        "action_tag": "fraud_dispute",
+        "initial_ctx": {
+            "creditor_name": "Fraud Corp",
+            "legal_safe_summary": "FCRA 605B allows me to remove this item within 30 days.",
+            "is_identity_theft": True,
+        },
+        "expect_html": False,
+        "expect_validation_failure": True,
+        "template": "fraud_dispute_letter_template.html",
+    },
+    {
+        "name": "debt_validation",
+        "action_tag": "debt_validation",
+        "initial_ctx": {
+            "legal_safe_summary": "FDCPA 1692g requires validation; please respond within 30 days.",
+            "days_since_first_contact": "5",
+        },
+        "strategy_ctx": {"collector_name": "Collector Inc"},
+        "expect_html": True,
+        "template": "debt_validation_letter_template.html",
+        "golden": Path("tests/letters/goldens/debt_validation.html"),
+    },
+    {
+        "name": "mov",
+        "action_tag": "mov",
+        "initial_ctx": {
+            "creditor_name": "Bank",
+            "legal_safe_summary": "Please reinvestigate this item.",
+            "cra_last_result": "verified",
+            "days_since_cra_result": "45",
+        },
+        "expect_html": True,
+        "template": "mov_letter_template.html",
+        "golden": Path("tests/letters/goldens/mov.html"),
+    },
+    {
+        "name": "pay_for_delete",
+        "action_tag": "pay_for_delete",
+        "initial_ctx": {
+            "collector_name": "Collector Inc",
+            "legal_safe_summary": "I will pay if you delete this account.",
+            "offer_terms": "Delete account and we pay 60%.",
+        },
+        "expect_html": True,
+        "template": "pay_for_delete_letter_template.html",
+        "golden": Path("tests/letters/goldens/pay_for_delete.html"),
+    },
+    {
+        "name": "cease_and_desist",
+        "action_tag": "cease_and_desist",
+        "initial_ctx": {
+            "collector_name": "Collector Inc",
+            "legal_safe_summary": "Stop contact immediately.",
+        },
+        "expect_html": True,
+        "template": "cease_and_desist_letter_template.html",
+        "golden": Path("tests/letters/goldens/cease_and_desist.html"),
+    },
+    {
+        "name": "medical",
+        "action_tag": "direct_dispute",
+        "initial_ctx": {
+            "creditor_name": "Medical Co",
+            "legal_safe_summary": "Paid medical debt under $500 should be removed.",
+            "furnisher_address": "1 Med St",
+        },
+        "expect_html": True,
+        "template": "direct_dispute_letter_template.html",
+        "golden": Path("tests/letters/goldens/medical.html"),
+    },
+    {
+        "name": "unauthorized_inquiry",
+        "action_tag": "direct_dispute",
+        "initial_ctx": {
+            "creditor_name": "Inquiry Co",
+            "legal_safe_summary": "This unauthorized inquiry should be removed.",
+            "furnisher_address": "2 Inquiry Ave",
+        },
+        "expect_html": True,
+        "template": "direct_dispute_letter_template.html",
+        "golden": Path("tests/letters/goldens/unauthorized_inquiry.html"),
+    },
+    {
+        "name": "duplicate_tradeline",
+        "action_tag": "direct_dispute",
+        "initial_ctx": {
+            "creditor_name": "Dup Co",
+            "legal_safe_summary": "This tradeline appears duplicated.",
+            "furnisher_address": "3 Dup Rd",
+        },
+        "expect_html": True,
+        "template": "direct_dispute_letter_template.html",
+        "golden": Path("tests/letters/goldens/duplicate_tradeline.html"),
+    },
+    {
+        "name": "ignore",
+        "action_tag": "ignore",
+        "initial_ctx": {},
+        "expect_html": False,
+        "template": None,
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s["name"] for s in SCENARIOS])
+def test_letter_pipeline_golden(scenario):
+    os.environ["LETTERS_ROUTER_PHASED"] = "1"
+    reset_counters()
+    ctx = BASE_CTX.copy()
+    ctx.update(scenario.get("initial_ctx", {}))
+
+    select_template(scenario["action_tag"], ctx, phase="candidate")
+
+    if scenario.get("strategy_ctx"):
+        ctx.update(scenario["strategy_ctx"])
+
+    ctx["client_context_sentence"] = format_safe_client_context(
+        scenario["action_tag"], "", {}, []
+    )
+
+    final_decision = select_template(scenario["action_tag"], ctx, phase="finalize")
+    template = final_decision.template_path
+
+    if template:
+        missing = validators.validate_required_fields(
+            template, ctx, final_decision.required_fields, validators.CHECKLIST
+        )
+    else:
+        missing = []
+
+    if scenario["expect_html"]:
+        assert template == scenario["template"]
+        assert not missing
+        artifact = render_dispute_letter_html(ctx, template)
+        html = artifact.html.strip()
+        expected = scenario["golden"].read_text().strip()
+        assert html == expected
+    else:
+        if scenario.get("expect_validation_failure"):
+            assert template == scenario["template"]
+            assert not missing
+            with pytest.raises(ValueError):
+                render_dispute_letter_html(ctx, template)
+        else:
+            assert template is None
+
+    counters = get_counters()
+    if template:
+        assert counters.get("router.candidate_selected") == 1
+        assert counters.get("router.finalized") == 1
+    else:
+        assert "router.candidate_selected" not in counters
+        assert "router.finalized" not in counters
+
+    if scenario["expect_html"]:
+        assert counters.get(f"letter_template_selected.{template}") == 1
+        assert not any(k.startswith("validation.failed") for k in counters)
+    else:
+        if scenario.get("expect_validation_failure"):
+            assert any(k.startswith("validation.failed") for k in counters)
+            assert counters.get(f"letter_template_selected.{template}") is None
+        else:
+            assert not any(k.startswith("validation.failed") for k in counters)
+            assert all(not k.startswith("letter_template_selected.") for k in counters)


### PR DESCRIPTION
## Summary
- add comprehensive end-to-end tests for letter pipeline across multiple scenarios
- snapshot golden HTML outputs for successful letter renders

## Testing
- `pytest tests/letters/test_letter_pipeline_golden.py -q`
- `pytest -q` *(fails: test_pipeline_invoked_for_documents[instructions], test_instruction_metrics_emitted, test_full_letter_workflow)*

------
https://chatgpt.com/codex/tasks/task_b_68a4ad28a52c8325ba4af201ab8af640