### PR TITLE
Align instruction pipeline with router and metrics

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -114,10 +114,15 @@ def select_template(
         )
 
     if template_path:
+        # Emit both legacy and tag-specific router metrics for transition
         if phase == "candidate":
-            emit_counter("router.candidate_selected")
+            emit_counter("router.candidate_selected")  # deprecated
+            if tag:
+                emit_counter(f"router.candidate_selected.{tag}")
         elif phase in {"final", "finalize"}:
-            emit_counter("router.finalized")
+            emit_counter("router.finalized")  # deprecated
+            if tag:
+                emit_counter(f"router.finalized.{tag}")
 
     if missing_fields:
         for field in missing_fields:

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -115,29 +115,27 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         )
         monkeypatch.setattr(
             "backend.core.logic.rendering.instruction_data_preparation.generate_account_action",
-            lambda acc, ai_client=None: "Do something",
+            lambda acc, ai_client=None: "Pay the balance",
         )
         monkeypatch.setattr(
             "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
             lambda html, path: None,
         )
-        from backend.core.models import BureauPayload, ClientInfo
+        from backend.core.models import ClientInfo
 
         client = ClientInfo.from_dict({"name": "Client", "session_id": "s2"})
         bureau_data = {
-            "Experian": BureauPayload.from_dict(
-                {
-                    "all_accounts": [
-                        {
-                            "name": "Bank B",
-                            "status": "good",
-                            "action_tag": "positive",
-                        }
-                    ],
-                    "disputes": [],
-                    "inquiries": [],
-                }
-            )
+            "Experian": {
+                "all_accounts": [
+                    {
+                        "name": "Bank B",
+                        "status": "good",
+                        "action_tag": "positive",
+                    }
+                ],
+                "disputes": [],
+                "inquiries": [],
+            }
         }
         generate_instruction_file(
             client, bureau_data, False, tmp_path / "inst", ai_client=FakeAIClient()

--- a/tests/test_instruction_validation.py
+++ b/tests/test_instruction_validation.py
@@ -34,4 +34,20 @@ def test_instruction_validation_missing_actions(monkeypatch, tmp_path):
         ai_client=FakeAIClient(),
     )
     counters = get_counters()
-    assert counters.get("validation.failed.instruction_template.html.per_account_actions")
+    # Validation metrics
+    assert counters.get("validation.failed")
+    assert counters.get("validation.failed.instruction_template.html")
+    assert counters.get(
+        "validation.failed.instruction_template.html.per_account_actions"
+    )
+    # Router metrics still emitted
+    assert counters.get("router.candidate_selected")
+    assert counters.get("router.candidate_selected.instruction")
+    assert counters.get("router.finalized")
+    assert counters.get("router.finalized.instruction")
+    # No render should occur when validation fails
+    assert (
+        counters.get("letter_template_selected.instruction_template.html")
+        is None
+    )
+    assert counters.get("letter.render_ms.instruction_template.html") is None

--- a/tests/test_strategy_workflow.py
+++ b/tests/test_strategy_workflow.py
@@ -118,7 +118,7 @@ def test_full_letter_workflow():
         ),
         mock.patch(
             "backend.core.logic.rendering.instruction_data_preparation.generate_account_action",
-            return_value="Action",
+            return_value="Pay the balance",
         ),
         mock.patch(
             "backend.core.logic.rendering.instructions_generator.run_compliance_pipeline",


### PR DESCRIPTION
## Summary
- Preserve `all_accounts` when routing instruction data
- Emit router metrics with legacy and tag-specific names
- Validate instruction fields and record candidate/final metrics
- Update instruction tests for router flow and validation failures

## Testing
- `pytest tests/test_instruction_metrics.py::test_instruction_metrics_emitted -vv`
- `pytest tests/test_instruction_validation.py::test_instruction_validation_missing_actions -vv`
- `pytest tests/test_compliance_pipeline_usage.py::test_pipeline_invoked_for_documents[instructions] -vv`
- `pytest tests/test_strategy_workflow.py::test_full_letter_workflow -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4b428faa883259d4f781ed27e52cd