### PR TITLE
Add post-render sanitizer with per-template allow/deny lists

### DIFF
--- a/backend/core/letters/sanitizer.py
+++ b/backend/core/letters/sanitizer.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+from backend.analytics.analytics_tracker import emit_counter
+from backend.core.letters import validators
+
+
+# Resolve template names indirectly to avoid hard-coded literals.
+_DISPUTE_TEMPLATE = next(
+    k for k in validators.CHECKLIST if k.startswith("dispute_letter_template")
+)
+_GENERAL_TEMPLATE = next(
+    k for k in validators.CHECKLIST if k.startswith("general_letter_template")
+)
+
+# Static per-template deny list. Terms are matched case-insensitively.
+_DENYLISTS: Dict[str, List[str]] = {
+    # Dispute and general letters should not contain settlement style language.
+    _DISPUTE_TEMPLATE: ["promise to pay"],
+    _GENERAL_TEMPLATE: ["promise to pay"],
+}
+
+# Per-template allow lists for exceptional terms
+_ALLOWLISTS: Dict[str, List[str]] = {}
+
+
+def _has_collection_account(ctx: Dict[str, Any]) -> bool:
+    """Return True if any account in context is tagged as a collection."""
+    accounts = ctx.get("accounts") or []
+    for acc in accounts:
+        tag = str(acc.get("action_tag") or acc.get("status") or "").lower()
+        if tag == "collection":
+            return True
+    # Some contexts may directly specify the letter action tag
+    tag = str(ctx.get("action_tag", "")).lower()
+    return tag == "collection"
+
+
+def sanitize_rendered_html(
+    html: str, template_path: str, context: Dict[str, Any]
+) -> Tuple[str, List[str]]:
+    """Remove forbidden phrases from rendered ``html``.
+
+    Parameters
+    ----------
+    html:
+        Rendered HTML content.
+    template_path:
+        The template used to generate the HTML. This selects the deny/allow lists.
+    context:
+        Rendering context. Used for conditional policy checks (e.g. collection letters).
+
+    Returns
+    -------
+    tuple
+        ``(sanitized_html, overrides)`` where ``overrides`` is a list of removed terms.
+    """
+
+    deny_terms = list(_DENYLISTS.get(template_path, []))
+    if _has_collection_account(context):
+        deny_terms.append("goodwill")
+
+    allow_terms = _ALLOWLISTS.get(template_path, [])
+
+    overrides: List[str] = []
+    sanitized = html
+    for term in deny_terms:
+        if term in allow_terms:
+            continue
+        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        sanitized, count = pattern.subn("", sanitized)
+        if count:
+            overrides.append(term)
+
+    if overrides:
+        emit_counter(f"sanitizer.applied.{template_path}")
+        for term in overrides:
+            sanitized_term = term.replace(" ", "_")
+            emit_counter(
+                f"policy_override_reason.{template_path}.{sanitized_term}"
+            )
+
+    return sanitized, overrides
+
+
+__all__ = ["sanitize_rendered_html"]

--- a/backend/core/logic/letters/generate_custom_letters.py
+++ b/backend/core/logic/letters/generate_custom_letters.py
@@ -32,6 +32,7 @@ from backend.core.models.client import ClientInfo
 from backend.core.services.ai_client import AIClient
 from backend.core.letters.router import select_template
 from backend.core.letters import validators
+from backend.core.letters.sanitizer import sanitize_rendered_html
 
 from .utils import StrategyContextMissing, ensure_strategy_context
 
@@ -279,6 +280,7 @@ def generate_custom_letter(
     tmpl = env.get_template(decision.template_path)
     html = tmpl.render(**context)
     emit_counter(f"letter_template_selected.{decision.template_path}")
+    html, _ = sanitize_rendered_html(html, decision.template_path, context)
     safe_recipient = (recipient or "Recipient").replace("/", "_").replace("\\", "_")
     filename = f"Custom Letter - {safe_recipient}.pdf"
     full_path = output_path / filename

--- a/backend/core/logic/letters/goodwill_rendering.py
+++ b/backend/core/logic/letters/goodwill_rendering.py
@@ -25,6 +25,7 @@ from backend.analytics.analytics_tracker import emit_counter
 from backend.api.config import env_bool
 from backend.core.letters.client_context import format_safe_client_context
 from backend.core.letters import validators
+from backend.core.letters.sanitizer import sanitize_rendered_html
 
 
 def load_creditor_address_map() -> Mapping[str, str]:
@@ -123,6 +124,8 @@ def render_goodwill_letter(
         "goodwill",
         ai_client=ai_client,
     )
+
+    html, _ = sanitize_rendered_html(html, template_path, context)
 
     safe_name = safe_filename(creditor)
     pdf_path = output_path / f"Goodwill Request - {safe_name}.pdf"

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -47,6 +47,7 @@ from .utils import (
 from backend.core.letters.router import select_template
 from backend.api.config import env_bool
 from backend.core.letters.client_context import format_safe_client_context
+from backend.core.letters.sanitizer import sanitize_rendered_html
 
 logger = logging.getLogger(__name__)
 
@@ -315,6 +316,11 @@ def generate_all_dispute_letters_with_ai(
             "dispute",
             ai_client=ai_client,
         )
+        html, _ = sanitize_rendered_html(
+            html, decision.template_path, context.to_dict()
+        )
+        if isinstance(artifact, LetterArtifact):
+            artifact.html = html
         filename = f"Dispute Letter - {bureau_name}.pdf"
         filepath = output_path / filename
         if wkhtmltopdf_path:

--- a/tests/test_post_render_sanitizer.py
+++ b/tests/test_post_render_sanitizer.py
@@ -1,0 +1,35 @@
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+from backend.core.letters.sanitizer import sanitize_rendered_html
+
+
+def test_sanitize_blocks_goodwill_for_collections():
+    reset_counters()
+    html = "<p>This is a goodwill adjustment request.</p>"
+    ctx = {"accounts": [{"action_tag": "collection"}]}
+    sanitized, overrides = sanitize_rendered_html(
+        html, "dispute_letter_template.html", ctx
+    )
+    assert "goodwill" not in sanitized.lower()
+    assert overrides == ["goodwill"]
+    counters = get_counters()
+    assert (
+        counters["sanitizer.applied.dispute_letter_template.html"] == 1
+    )
+    assert (
+        counters["policy_override_reason.dispute_letter_template.html.goodwill"]
+        == 1
+    )
+
+
+def test_sanitize_noop_for_clean_html():
+    reset_counters()
+    html = "<p>All good here.</p>"
+    sanitized, overrides = sanitize_rendered_html(
+        html, "dispute_letter_template.html", {}
+    )
+    assert sanitized == html
+    assert overrides == []
+    counters = get_counters()
+    assert (
+        "sanitizer.applied.dispute_letter_template.html" not in counters
+    )


### PR DESCRIPTION
## Summary
- add final HTML sanitizer with per-template deny lists and metrics logging
- invoke sanitizer for dispute, goodwill, and custom letter generation
- test sanitizer removal and no-op behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4b78a14388325a6cabeda7311033e