### PR TITLE
Track AI usage and render latency

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -181,6 +181,13 @@ def log_ai_request(
     _AI_METRICS["latency_ms"] += latency_ms
 
 
+def log_ai_stage(stage: str, tokens: int, cost: float) -> None:
+    """Record token and cost usage for a specific pipeline stage."""
+
+    emit_counter(f"ai.tokens.{stage}", tokens)
+    emit_counter(f"ai.cost.{stage}", cost)
+
+
 def get_ai_stats() -> Dict[str, float]:
     """Return current AI usage metrics (for tests)."""
 
@@ -246,6 +253,11 @@ def save_analytics_snapshot(
 
     if strategist_failures:
         snapshot["strategist_failures"] = strategist_failures
+
+    snapshot["metrics"] = {
+        "counters": get_counters(),
+        "ai": get_ai_stats(),
+    }
 
     with open(filename, "w", encoding="utf-8") as f:
         f.write(redact_pii(json.dumps(snapshot, indent=2)))

--- a/backend/core/logic/guardrails/__init__.py
+++ b/backend/core/logic/guardrails/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, List, Tuple
 
 from backend.analytics.analytics_tracker import (
     log_ai_request,
+    log_ai_stage,
     log_guardrail_fix,
     log_letter_without_strategy,
     log_policy_violations_prevented,
@@ -102,6 +103,7 @@ def generate_letter_with_guardrails(
         tokens_out = getattr(usage, "completion_tokens", 0)
         cost = tokens_in * _INPUT_COST_PER_TOKEN + tokens_out * _OUTPUT_COST_PER_TOKEN
         log_ai_request(tokens_in, tokens_out, cost, latency_ms)
+        log_ai_stage("candidate", tokens_in + tokens_out, cost)
         text = response.choices[0].message.content.strip()
         if text.startswith("```"):
             text = text.replace("```", "").strip()
@@ -179,6 +181,7 @@ def fix_draft_with_guardrails(
         tokens_out = getattr(usage, "completion_tokens", 0)
         cost = tokens_in * _INPUT_COST_PER_TOKEN + tokens_out * _OUTPUT_COST_PER_TOKEN
         log_ai_request(tokens_in, tokens_out, cost, latency_ms)
+        log_ai_stage("finalize", tokens_in + tokens_out, cost)
         text = response.choices[0].message.content.strip()
         if text.startswith("```"):
             text = text.replace("```", "").strip()

--- a/backend/core/logic/letters/goodwill_rendering.py
+++ b/backend/core/logic/letters/goodwill_rendering.py
@@ -129,7 +129,7 @@ def render_goodwill_letter(
 
     safe_name = safe_filename(creditor)
     pdf_path = output_path / f"Goodwill Request - {safe_name}.pdf"
-    pdf_fn(html, str(pdf_path))
+    pdf_fn(html, str(pdf_path), template_name=template_path)
 
     with open(output_path / f"{safe_name}_gpt_response.json", "w") as f:
         json.dump(gpt_data, f, indent=2)

--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -325,10 +325,15 @@ def generate_all_dispute_letters_with_ai(
         filepath = output_path / filename
         if wkhtmltopdf_path:
             pdf_renderer.render_html_to_pdf(
-                html, str(filepath), wkhtmltopdf_path=wkhtmltopdf_path
+                html,
+                str(filepath),
+                wkhtmltopdf_path=wkhtmltopdf_path,
+                template_name=decision.template_path,
             )
         else:
-            pdf_renderer.render_html_to_pdf(html, str(filepath))
+            pdf_renderer.render_html_to_pdf(
+                html, str(filepath), template_name=decision.template_path
+            )
 
         with open(output_path / f"{bureau_name}_gpt_response.json", "w") as f:
             json.dump(gpt_data, f, indent=2)

--- a/tests/test_compliance_pipeline_usage.py
+++ b/tests/test_compliance_pipeline_usage.py
@@ -69,7 +69,7 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         )
         monkeypatch.setattr(
             "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-            lambda html, path: None,
+            lambda html, path, **k: None,
         )
         from backend.core.logic.strategy.summary_classifier import ClassificationRecord
         from backend.core.models import BureauPayload, ClientInfo
@@ -119,7 +119,7 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         )
         monkeypatch.setattr(
             "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-            lambda html, path: None,
+            lambda html, path, **k: None,
         )
         from backend.core.models import ClientInfo
 
@@ -165,7 +165,7 @@ def test_pipeline_invoked_for_documents(monkeypatch, tmp_path, doc_type):
         )
         monkeypatch.setattr(
             "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-            lambda html, path: None,
+            lambda html, path, **k: None,
         )
         monkeypatch.setattr(
             "backend.core.logic.letters.generate_goodwill_letters.gather_supporting_docs",

--- a/tests/test_goodwill_integration.py
+++ b/tests/test_goodwill_integration.py
@@ -54,7 +54,7 @@ def test_orchestrator_invokes_compliance(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         generate_goodwill_letters.goodwill_rendering,

--- a/tests/test_goodwill_rendering.py
+++ b/tests/test_goodwill_rendering.py
@@ -5,7 +5,7 @@ from tests.helpers.fake_ai_client import FakeAIClient
 def test_rendering_calls_compliance_and_pdf(tmp_path):
     html_called = {}
 
-    def fake_pdf(html, path):
+    def fake_pdf(html, path, **kwargs):
         html_called["pdf"] = (html, path)
 
     def fake_compliance(html, state, session_id, doc_type, ai_client=None):

--- a/tests/test_instruction_metrics.py
+++ b/tests/test_instruction_metrics.py
@@ -1,7 +1,8 @@
-from backend.analytics.analytics_tracker import reset_counters, get_counters
+from backend.analytics.analytics_tracker import reset_counters, get_counters, set_metric
 from backend.core.models import ClientInfo
 from tests.helpers.fake_ai_client import FakeAIClient
 import backend.core.logic.rendering.instructions_generator as generator
+from backend.core.logic.rendering import pdf_renderer
 
 
 def test_instruction_metrics_emitted(monkeypatch, tmp_path):
@@ -21,9 +22,15 @@ def test_instruction_metrics_emitted(monkeypatch, tmp_path):
         )
 
     monkeypatch.setattr(generator, "prepare_instruction_data", fake_prepare)
-    monkeypatch.setattr(generator, "render_pdf_from_html", lambda *a, **k: None)
     monkeypatch.setattr(generator, "save_json_output", lambda *a, **k: None)
     monkeypatch.setattr(generator, "run_compliance_pipeline", lambda *a, **k: None)
+
+    def fake_render(html, path, **kwargs):
+        template = kwargs.get("template_name")
+        if template:
+            set_metric(f"letter.render_ms.{template}", 0)
+
+    monkeypatch.setattr(pdf_renderer, "render_html_to_pdf", fake_render)
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
 
     generator.generate_instruction_file(

--- a/tests/test_letter_fallback.py
+++ b/tests/test_letter_fallback.py
@@ -47,7 +47,7 @@ def test_unrecognized_action_fallback(monkeypatch, tmp_path, capsys):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",

--- a/tests/test_letters_ignore_intake.py
+++ b/tests/test_letters_ignore_intake.py
@@ -73,7 +73,7 @@ def test_letters_do_not_access_raw_intake(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",

--- a/tests/test_logging_edge_cases.py
+++ b/tests/test_logging_edge_cases.py
@@ -10,7 +10,7 @@ from tests.helpers.fake_ai_client import FakeAIClient
 def _setup(monkeypatch):
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",

--- a/tests/test_pipeline_metrics.py
+++ b/tests/test_pipeline_metrics.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import types
+
+from backend.analytics.analytics_tracker import reset_counters, get_counters
+from backend.core.logic.guardrails import (
+    generate_letter_with_guardrails,
+    fix_draft_with_guardrails,
+)
+from backend.core.logic.rendering import pdf_renderer
+from tests.helpers.fake_ai_client import FakeAIClient
+
+
+def test_pipeline_metrics(monkeypatch, tmp_path):
+    reset_counters()
+
+    def fake_config(**kwargs):
+        return types.SimpleNamespace()
+
+    def fake_from_string(html, path, configuration=None, options=None):
+        Path(path).write_bytes(b"PDF")
+
+    monkeypatch.setattr(pdf_renderer.pdfkit, "configuration", fake_config)
+    monkeypatch.setattr(pdf_renderer.pdfkit, "from_string", fake_from_string)
+
+    ai = FakeAIClient()
+    text, _viol, _ = generate_letter_with_guardrails(
+        "hello", None, {"debt_type": "cc", "dispute_reason": "err"}, "", "custom", ai_client=ai
+    )
+    text += " 12345 "
+    fix_draft_with_guardrails(text, None, {}, "", "custom", ai_client=ai)
+
+    out = tmp_path / "out.pdf"
+    pdf_renderer.render_html_to_pdf(
+        "<p>hi</p>", str(out), template_name="test_template.html"
+    )
+
+    counters = get_counters()
+    assert counters.get("ai.tokens.candidate") is not None
+    assert counters.get("ai.tokens.finalize") is not None
+    assert counters.get("ai.tokens.render") is not None
+    assert counters.get("ai.cost.candidate") is not None
+    assert counters.get("ai.cost.finalize") is not None
+    assert counters.get("ai.cost.render") is not None
+    assert (
+        counters.get("letter.render_ms.test_template.html") is not None
+        and counters["letter.render_ms.test_template.html"] >= 0
+    )

--- a/tests/test_sensitive_language_filtered.py
+++ b/tests/test_sensitive_language_filtered.py
@@ -79,7 +79,7 @@ def test_dispute_letter_ignores_emotional_text(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",
@@ -163,7 +163,7 @@ def test_goodwill_letter_ignores_emotional_text(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",

--- a/tests/test_strategy_parse_failure_letters.py
+++ b/tests/test_strategy_parse_failure_letters.py
@@ -96,7 +96,7 @@ def test_letters_generate_when_strategy_llm_returns_junk(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",

--- a/tests/test_strategy_workflow.py
+++ b/tests/test_strategy_workflow.py
@@ -114,7 +114,7 @@ def test_full_letter_workflow():
         mock.patch("backend.core.logic.rendering.pdf_renderer.render_html_to_pdf"),
         mock.patch(
             "backend.core.logic.rendering.instructions_generator.render_pdf_from_html",
-            side_effect=lambda html, p: instructions_capture.setdefault("html", html),
+            side_effect=lambda html, p, template_path, **k: instructions_capture.setdefault("html", html),
         ),
         mock.patch(
             "backend.core.logic.rendering.instruction_data_preparation.generate_account_action",

--- a/tests/test_summary_validator.py
+++ b/tests/test_summary_validator.py
@@ -60,7 +60,7 @@ def test_validator_replaces_flagged_paragraph(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "backend.core.logic.rendering.pdf_renderer.render_html_to_pdf",
-        lambda html, path: None,
+        lambda html, path, **k: None,
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.run_compliance_pipeline",


### PR DESCRIPTION
## Summary
- capture per-stage AI token and cost metrics
- measure PDF render time per template and log zero-cost render stage
- persist analytics counters in snapshots and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4b9e64318832584993254af9317eb