### PR TITLE
Author letters pipeline docs & release runbooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check documentation links
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --no-progress --exclude-mail docs
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/docs/letters_router.md
+++ b/docs/letters_router.md
@@ -1,0 +1,64 @@
+# Letters Router
+
+The letters router coordinates generation and delivery of dispute letters.
+This doc explains how data moves through the pipeline and how to extend it.
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    A[Raw input] --> B[Normalize & tag]
+    B --> C[Candidate]
+    C --> D[Merge strategy results]
+    D --> E[Finalize]
+```
+
+- **Candidate** – letters produced after normalization and tagging.
+- **Finalize** – the set after strategy results are merged and validation passes.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `LETTER_ROUTER_VALIDATE` | `1` | Run schema validation on candidates before merging results. |
+| `LETTER_ROUTER_STRICT` | `0` | When `1`, abort processing on the first validation error. |
+| `LETTER_ROUTER_DEBUG` | `0` | Save intermediate artifacts for troubleshooting. |
+
+Flags are read from the environment. A value of `0` disables the behavior.
+
+## Required Fields
+
+Every candidate must include the following fields:
+
+- `account_id`
+- `normalized_text`
+- `strategy_key`
+
+Finalized records add:
+
+- `resolved_text`
+- `delivery_channel`
+
+## Optional Fields
+
+These fields enrich the payload but are not mandatory:
+
+- `attachments`
+- `notes`
+- `debug`
+
+## Example
+
+```json
+{
+  "account_id": "A-123",
+  "normalized_text": "Dispute for account A-123",
+  "strategy_key": "fcra-basic",
+  "resolved_text": "Please remove account A-123",
+  "delivery_channel": "mail",
+  "attachments": ["id.pdf"]
+}
+```
+
+Extending the router generally involves adding a new strategy module
+and mapping it in `services/letters/router.py`.

--- a/docs/phrases_bank.md
+++ b/docs/phrases_bank.md
@@ -1,0 +1,35 @@
+# Phrases Bank
+
+Reusable phrases for letters are stored in YAML.
+This guide covers the schema, adding new variants, and masking rules.
+
+## YAML Schema
+
+Each entry looks like this:
+
+```yaml
+- id: dispute-account
+  text: "I dispute the accuracy of {account}"
+  variants:
+    - "I contest the report for {account}"
+    - "The information for {account} is false"
+  mask:
+    - account
+```
+
+- `id` – unique identifier for the phrase.
+- `text` – base phrase with placeholders.
+- `variants` – optional list of alternate phrasings.
+- `mask` – placeholders that must be masked before model prompts or logging.
+
+## Adding Variants Safely
+
+1. Copy the structure above.
+2. Preserve placeholders; each variant must contain the same `{}` tokens as `text`.
+3. Run unit tests and link checks before committing.
+4. Avoid slang or unreviewed legal language.
+
+## Masking Rules
+
+Values listed in `mask` are replaced with `***` when serializing.
+Mask every field that could contain PII or customer-specific data.

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -1,0 +1,39 @@
+# Author Letters Pipeline Release Runbook
+
+This runbook describes how to ship a safe change to the author letters pipeline.
+
+## Overview
+
+```mermaid
+flowchart LR
+    C[Commit] --> S[Staging batch]
+    S --> K[Canary]
+    K --> P[Full production]
+    P --> R{SLO met?}
+    R -- no --> B[Rollback]
+```
+
+## Staging Batch
+
+1. Merge the change to `main`.
+2. Build and push the container.
+3. Run a batch on staging data.
+4. Verify logs and sample outputs.
+
+## Canary Steps
+
+1. Deploy to 5% of traffic.
+2. Monitor error rates and latency for 30 minutes.
+3. If healthy, expand to 50%, then 100%.
+
+## SLO Thresholds
+
+- Success rate ≥ 99%.
+- P95 latency ≤ 2s for routing.
+- No more than 0.1% invalid letters.
+
+## Rollback
+
+1. Revert to the previous container tag.
+2. Disable new features behind flags if available.
+3. Post-mortem within 24 hours.


### PR DESCRIPTION
## Summary
- Document letters router flow with candidate/finalize states, flags, required fields, and examples
- Add phrases bank guidelines and release runbook with staging, canary, SLO, and rollback steps
- Run documentation link checks in CI

## Testing
- `pre-commit run --files docs/letters_router.md docs/phrases_bank.md docs/release_runbook.md .github/workflows/ci.yml`
- `linkchecker docs/letters_router.md`
- `linkchecker docs/phrases_bank.md`
- `linkchecker docs/release_runbook.md`
- `DISABLE_PDF_RENDER=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a4c13be0188325b1cb20cdd11f5310