### PR TITLE
Ensure letter generators hit router candidate phase early

### DIFF
--- a/tests/letters/test_letter_pipeline_golden.py
+++ b/tests/letters/test_letter_pipeline_golden.py
@@ -178,12 +178,17 @@ def test_letter_pipeline_golden(scenario):
             assert template is None
 
     counters = get_counters()
+    tag = scenario["action_tag"]
     if template:
         assert counters.get("router.candidate_selected") == 1
+        assert counters.get(f"router.candidate_selected.{tag}") == 1
         assert counters.get("router.finalized") == 1
+        assert counters.get(f"router.finalized.{tag}") == 1
     else:
         assert "router.candidate_selected" not in counters
+        assert f"router.candidate_selected.{tag}" not in counters
         assert "router.finalized" not in counters
+        assert f"router.finalized.{tag}" not in counters
 
     if scenario["expect_html"]:
         assert counters.get(f"letter_template_selected.{template}") == 1


### PR DESCRIPTION
## Summary
- call `select_template` with minimal context at the start of goodwill letter generation
- call `select_template` with minimal context at the start of custom letter generation
- assert tag-specific candidate metrics in letter pipeline golden tests

## Testing
- `pre-commit run --files backend/core/logic/letters/generate_goodwill_letters.py backend/core/logic/letters/generate_custom_letters.py tests/letters/test_letter_pipeline_golden.py`
- `pytest tests/letters/test_letter_pipeline_golden.py -q`
- `pytest tests/letters/test_no_goodwill_on_collections_custom.py tests/letters/test_custom_letter_policy_conflict.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4eb465a6483259c2030577d914156