### PR TITLE
Add action tag conflict resolution in stage 2.5

### DIFF
--- a/backend/core/logic/compliance/constants.py
+++ b/backend/core/logic/compliance/constants.py
@@ -14,6 +14,11 @@ VALID_ACTION_TAGS = {
     "cease_and_desist",
     "direct_dispute",
     "ignore",
+    "obsolescence",
+    "bureau_dispute",
+    "inquiry_dispute",
+    "medical_dispute",
+    "paydown_first",
 }
 
 # Map common strategist phrases to canonical action tags.
@@ -72,6 +77,19 @@ _ACTION_ALIAS_MAP = {
     "direct dispute": "direct_dispute",
     "direct_to_furnisher": "direct_dispute",
     "direct to furnisher": "direct_dispute",
+    "obsolescence": "obsolescence",
+    "obsolete": "obsolescence",
+    "bureau_dispute": "bureau_dispute",
+    "bureau dispute": "bureau_dispute",
+    "cra_dispute": "bureau_dispute",
+    "cra dispute": "bureau_dispute",
+    "inquiry_dispute": "inquiry_dispute",
+    "inquiry dispute": "inquiry_dispute",
+    "medical_dispute": "medical_dispute",
+    "medical dispute": "medical_dispute",
+    "paydown_first": "paydown_first",
+    "paydown first": "paydown_first",
+    "pay_down_first": "paydown_first",
 }
 
 _DISPLAY_NAME = {
@@ -86,6 +104,11 @@ _DISPLAY_NAME = {
     "cease_and_desist": "Cease and Desist",
     "direct_dispute": "Direct Dispute",
     "ignore": "Ignore",
+    "obsolescence": "Obsolescence",
+    "bureau_dispute": "Bureau Dispute",
+    "inquiry_dispute": "Inquiry Dispute",
+    "medical_dispute": "Medical Dispute",
+    "paydown_first": "Pay Down First",
 }
 
 

--- a/backend/core/logic/strategy/normalizer_2_5.py
+++ b/backend/core/logic/strategy/normalizer_2_5.py
@@ -291,6 +291,7 @@ def evaluate_rules(
     final_hits: list[str] = []
     needs_evidence: list[str] = []
     suggested_dispute_frame = ""
+    action_tags: list[str] = []
     suppressed: set[str] = set()
 
     for rule_id, effect in sorted_hits:
@@ -300,6 +301,9 @@ def evaluate_rules(
         needs_evidence.extend(effect.get("needs_evidence", []))
         if not suggested_dispute_frame and effect.get("suggested_dispute_frame"):
             suggested_dispute_frame = effect["suggested_dispute_frame"]
+        tag = effect.get("action_tag")
+        if tag:
+            action_tags.append(tag)
         for ex in (exclusions or {}).get(rule_id, []):
             suppressed.add(ex)
 
@@ -308,12 +312,15 @@ def evaluate_rules(
     final_hits = [x for x in final_hits if not (x in seen_hits or seen_hits.add(x))]
     seen_ev: set[str] = set()
     needs_evidence = [x for x in needs_evidence if not (x in seen_ev or seen_ev.add(x))]
+    seen_tags: set[str] = set()
+    action_tags = [x for x in action_tags if not (x in seen_tags or seen_tags.add(x))]
 
     return {
         "rule_hits": final_hits,
         "needs_evidence": needs_evidence,
         "red_flags": red_flags,
         "suggested_dispute_frame": suggested_dispute_frame,
+        "action_tag": action_tags[0] if action_tags else "",
     }
 
 

--- a/backend/core/logic/strategy/stage_2_5_schema.json
+++ b/backend/core/logic/strategy/stage_2_5_schema.json
@@ -8,6 +8,7 @@
   "required": [
     "legal_safe_summary",
     "suggested_dispute_frame",
+    "action_tag",
     "rule_hits",
     "needs_evidence",
     "red_flags",
@@ -43,7 +44,27 @@
       ],
       "default": ""
     },
-    "rule_hits": {
+    "action_tag": {
+      "type": "string",
+      "description": "First surviving action tag after applying precedence/exclusions.",
+      "enum": [
+        "",
+        "fraud_dispute",
+        "debt_validation",
+        "mov",
+        "obsolescence",
+        "bureau_dispute",
+        "direct_dispute",
+        "inquiry_dispute",
+        "medical_dispute",
+        "paydown_first",
+        "goodwill",
+        "pay_for_delete",
+        "cease_and_desist"
+      ],
+        "default": ""
+      },
+      "rule_hits": {
       "type": "array",
       "description": "List of rule IDs that matched for this account.",
       "items": {

--- a/backend/policy/rulebook.yaml
+++ b/backend/policy/rulebook.yaml
@@ -67,6 +67,7 @@ rules:
       rule_hits: ["E_IDENTITY_NEEDS_AFFIDAVIT"]
       suggested_dispute_frame: "fraud"
       needs_evidence: ["identity_theft_affidavit"]
+      action_tag: fraud_dispute
       priority: High
 
   # --- 2) Collector 30-day validation window (FDCPA 1692g) ---


### PR DESCRIPTION
## Summary
- add missing `action_tag` to identity-theft evidence rule
- propagate rule action tags through precedence/exclusion logic and expose as `action_tag`
- recognize new action tags in compliance constants and schema
- test deterministic tag selection for conflicting rules

## Testing
- `pytest tests/strategy/test_stage_2_5_rules.py`
- `pytest tests/strategy/test_stage_2_5_pipeline.py tests/strategy/test_normalizer_2_5.py tests/strategy/test_rule_logging.py`
- `pytest tests/test_logic_fixes.py::test_normalize_action_tag_aliases tests/test_logic_fixes.py::test_normalize_action_tag_new_aliases`


------
https://chatgpt.com/codex/tasks/task_b_68a4ed368db883258f890c98deb4747f