### PR TITLE
Add substance checklist for base dispute and goodwill templates

### DIFF
--- a/backend/core/letters/validators.py
+++ b/backend/core/letters/validators.py
@@ -38,6 +38,18 @@ SUBSTANCE_CHECKLIST: Dict[str, Dict[str, str | None]] = {
         "cra_last_result": None,
         "days_since_cra_result": None,
     },
+    "dispute_letter_template.html": {
+        "fcra_611": r"611",
+        "investigation_request": r"investigat",
+        "account_number_masked": None,
+        "response_window": r"30\s*day",
+    },
+    "goodwill_letter_template.html": {
+        "non_promissory_tone": r"goodwill",
+        "positive_history_reference": r"positive|good",
+        "discretionary_request": r"request",
+        "no_admission": r"without\s+admit",
+    },
     "cease_and_desist_letter_template.html": {
         "stop_contact": r"stop\s*contact|cease|desist",
         "collector_name": None,

--- a/tests/golden_letter.html
+++ b/tests/golden_letter.html
@@ -70,7 +70,7 @@
 
 <div class="section">
     <p>To whom it may concern,</p>
-    <p>I dispute the following accounts</p>
+    <p>Under FCRA §611, I dispute the following accounts and request an investigation. Please respond within 30 days.</p>
 </div>
 
 <div class="section">

--- a/tests/letters/goldens/goodwill.html
+++ b/tests/letters/goldens/goodwill.html
@@ -1,0 +1,8 @@
+<p>Jane Doe</p>
+<p>123 Main St</p>
+<p>January 1, 2024</p><p>Good Bank</p>
+<p>Account 1234 (EXPERIAN)</p><p>I respectfully request goodwill adjustment based on my positive account history.</p><p>I respectfully request a goodwill adjustment based on my positive payment history without admitting responsibility.</p>
+<p>12</p>
+<p>I have a positive history with your bank.</p>
+<p>Jane Doe</p>
+

--- a/tests/letters/test_letter_pipeline_golden.py
+++ b/tests/letters/test_letter_pipeline_golden.py
@@ -126,6 +126,20 @@ SCENARIOS = [
         "golden": Path("tests/letters/goldens/duplicate_tradeline.html"),
     },
     {
+        "name": "goodwill",
+        "action_tag": "goodwill",
+        "initial_ctx": {
+            "creditor": "Good Bank",
+            "creditor_name": "Good Bank",
+            "legal_safe_summary": "I respectfully request a goodwill adjustment based on my positive payment history without admitting responsibility.",
+            "months_since_last_late": "12",
+            "account_history_good": "I have a positive history with your bank.",
+        },
+        "expect_html": True,
+        "template": "goodwill_letter_template.html",
+        "golden": Path("tests/letters/goldens/goodwill.html"),
+    },
+    {
         "name": "ignore",
         "action_tag": "ignore",
         "initial_ctx": {},

--- a/tests/test_dispute_flow_golden.py
+++ b/tests/test_dispute_flow_golden.py
@@ -35,7 +35,9 @@ def test_dispute_flow_golden(monkeypatch):
     )
     from backend.core.logic.letters.gpt_prompting import call_gpt_dispute_letter
 
-    payload = """{\n  \"opening_paragraph\": \"I dispute the following accounts\",\n  \"accounts\": [{\n    \"name\": \"ABC Bank\",\n    \"account_number\": \"1234\",\n    \"status\": \"Late\",\n    \"paragraph\": \"Please delete\",\n    \"requested_action\": \"Delete\"\n  }],\n  \"inquiries\": [{\n    \"creditor_name\": \"XYZ Bank\",\n    \"date\": \"2020-01-01\"\n  }],\n  \"closing_paragraph\": \"Thank you\"\n}"""
+    payload = (
+        """{\n  \"opening_paragraph\": \"Under FCRA §611, I dispute the following accounts and request an investigation. Please respond within 30 days.\",\n  \"accounts\": [{\n    \"name\": \"ABC Bank\",\n    \"account_number\": \"1234\",\n    \"status\": \"Late\",\n    \"paragraph\": \"Please delete\",\n    \"requested_action\": \"Delete\"\n  }],\n  \"inquiries\": [{\n    \"creditor_name\": \"XYZ Bank\",\n    \"date\": \"2020-01-01\"\n  }],\n  \"closing_paragraph\": \"Thank you\"\n}"""
+    )
     fake_ai = FakeAI(payload)
     ctx = call_gpt_dispute_letter(
         {},
@@ -63,8 +65,10 @@ def test_dispute_flow_golden(monkeypatch):
     decision = select_template(
         "dispute", {"bureau": "Experian"}, phase="finalize"
     )
+    ctx_dict = ctx.to_dict()
+    ctx_dict["account_number_masked"] = "1234"
     artifact = render_dispute_letter_html(
-        ctx, decision.template_path
+        ctx_dict, decision.template_path
     )
     monkeypatch.setattr(
         "backend.core.logic.compliance.compliance_pipeline.fix_draft_with_guardrails",

--- a/tests/test_goodwill_rendering.py
+++ b/tests/test_goodwill_rendering.py
@@ -13,7 +13,7 @@ def test_rendering_calls_compliance_and_pdf(tmp_path):
         return html
 
     gpt_data = {
-        "intro_paragraph": "hi",
+        "intro_paragraph": "I respectfully request a goodwill adjustment based on my positive payment history without admitting responsibility.",
         "hardship_paragraph": "hard",
         "recovery_paragraph": "rec",
         "closing_paragraph": "bye",
@@ -39,7 +39,7 @@ def test_rendering_calls_compliance_and_pdf(tmp_path):
     assert json_path.exists()
 
     gpt_data = {
-        "intro_paragraph": "hi",
+        "intro_paragraph": "I respectfully request a goodwill adjustment based on my positive payment history without admitting responsibility.",
         "hardship_paragraph": "hard",
         "recovery_paragraph": "rec",
         "closing_paragraph": "bye",


### PR DESCRIPTION
## Summary
- enforce FCRA §611, investigation request, account ID, and response window for base disputes
- require goodwill requests to mention positive history, goodwill, and no admission
- cover new validation with goldens and failure tests

## Testing
- `pytest tests/test_substance_validator.py tests/letters/test_letter_pipeline_golden.py tests/test_dispute_flow_golden.py tests/test_goodwill_rendering.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a4f0534f888325899c4326e2cdd830