### PR TITLE
Wire sanitizer for all templates

### DIFF
--- a/backend/core/logic/rendering/letter_rendering.py
+++ b/backend/core/logic/rendering/letter_rendering.py
@@ -7,6 +7,7 @@ from backend.core.logic.rendering import pdf_renderer
 from backend.core.models.letter import LetterArtifact, LetterContext
 from backend.analytics.analytics_tracker import emit_counter
 from backend.core.letters import validators
+from backend.core.letters.sanitizer import sanitize_rendered_html
 
 
 def render_dispute_letter_html(
@@ -29,6 +30,7 @@ def render_dispute_letter_html(
     template = env.get_template(template_path)
     html = template.render(**ctx)
     emit_counter(f"letter_template_selected.{template_path}")
+    html, _ = sanitize_rendered_html(html, template_path, ctx)
     return LetterArtifact(html=html)
 
 

--- a/tests/test_post_render_sanitizer.py
+++ b/tests/test_post_render_sanitizer.py
@@ -1,5 +1,6 @@
 from backend.analytics.analytics_tracker import get_counters, reset_counters
 from backend.core.letters.sanitizer import sanitize_rendered_html
+from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
 
 
 def test_sanitize_blocks_goodwill_for_collections():
@@ -33,3 +34,35 @@ def test_sanitize_noop_for_clean_html():
     assert (
         "sanitizer.applied.dispute_letter_template.html" not in counters
     )
+
+
+def _base_ctx(body: str) -> dict:
+    return {
+        "client_name": "Jane Doe",
+        "client_street": "1 Main St",
+        "client_city": "Town",
+        "client_state": "CA",
+        "client_zip": "12345",
+        "date": "Jan 1, 2024",
+        "recipient_name": "Recipient",
+        "greeting_line": "Hello",
+        "body_paragraph": body,
+    }
+
+
+def test_render_dispute_letter_html_runs_sanitizer():
+    reset_counters()
+    ctx = _base_ctx("This includes a promise to pay statement.")
+    artifact = render_dispute_letter_html(ctx, "general_letter_template.html")
+    assert "promise to pay" not in artifact.html.lower()
+    counters = get_counters()
+    assert counters["sanitizer.applied.general_letter_template.html"] == 1
+
+
+def test_render_dispute_letter_html_noop_for_clean_doc():
+    reset_counters()
+    ctx = _base_ctx("Just a friendly note.")
+    artifact = render_dispute_letter_html(ctx, "general_letter_template.html")
+    assert "friendly note" in artifact.html
+    counters = get_counters()
+    assert "sanitizer.applied.general_letter_template.html" not in counters


### PR DESCRIPTION
## Summary
- run post-render sanitizer for every rendered letter template
- add integration tests ensuring sanitizer strips forbidden terms and logs metrics

## Testing
- `python -m pytest tests/test_post_render_sanitizer.py -q`
- `python -m pytest tests/letters/test_letter_pipeline_golden.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4f4f7ddb08325aec5eeeae729e79d