### PR TITLE
feat: add routes for new letter templates

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -118,6 +118,40 @@ def select_template(
                 "furnisher_address",
             ],
         ),
+        "bureau_dispute": (
+            "bureau_dispute_letter_template.html",
+            [
+                "creditor_name",
+                "account_number_masked",
+                "bureau",
+                "legal_safe_summary",
+            ],
+        ),
+        "inquiry_dispute": (
+            "inquiry_dispute_letter_template.html",
+            [
+                "inquiry_creditor_name",
+                "account_number_masked",
+                "bureau",
+                "legal_safe_summary",
+                "inquiry_date",
+            ],
+        ),
+        "medical_dispute": (
+            "medical_dispute_letter_template.html",
+            [
+                "creditor_name",
+                "account_number_masked",
+                "bureau",
+                "legal_safe_summary",
+                "amount",
+                "medical_status",
+            ],
+        ),
+        "paydown_first": (
+            "instruction_template.html",
+            ["client_name", "date", "accounts_summary", "per_account_actions"],
+        ),
     }
 
     if tag == "ignore":

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -15,6 +15,63 @@ def test_router_basic_mappings(monkeypatch):
         select_template("custom_letter", {"recipient": "Joe"}, phase="finalize").template_path
         == "general_letter_template.html"
     )
+    assert (
+        select_template(
+            "bureau_dispute",
+            {
+                "creditor_name": "Creditor",
+                "account_number_masked": "1234",
+                "bureau": "Experian",
+                "legal_safe_summary": "summary",
+            },
+            phase="finalize",
+        ).template_path
+        == "bureau_dispute_letter_template.html"
+    )
+    assert (
+        select_template(
+            "inquiry_dispute",
+            {
+                "inquiry_creditor_name": "Creditor",
+                "account_number_masked": "1234",
+                "bureau": "Experian",
+                "legal_safe_summary": "summary",
+                "inquiry_date": "2024-01-01",
+            },
+            phase="finalize",
+        ).template_path
+        == "inquiry_dispute_letter_template.html"
+    )
+    assert (
+        select_template(
+            "medical_dispute",
+            {
+                "creditor_name": "Creditor",
+                "account_number_masked": "1234",
+                "bureau": "Experian",
+                "legal_safe_summary": "summary",
+                "amount": "100",
+                "medical_status": "paid",
+            },
+            phase="finalize",
+        ).template_path
+        == "medical_dispute_letter_template.html"
+    )
+    assert (
+        select_template(
+            "paydown_first",
+            {
+                "client_name": "Jane",
+                "date": "2024-01-01",
+                "accounts_summary": "summary",
+                "per_account_actions": [
+                    {"account_ref": "1", "action_sentence": "Pay down balance"}
+                ],
+            },
+            phase="finalize",
+        ).template_path
+        == "instruction_template.html"
+    )
     decision = select_template("ignore", {}, phase="finalize")
     assert decision.template_path is None
     assert decision.router_mode == "skip"
@@ -25,4 +82,22 @@ def test_missing_fields(monkeypatch):
     decision = select_template("goodwill", {}, phase="candidate")
     assert decision.missing_fields == ["creditor"]
     decision = select_template("goodwill", {"creditor": "XYZ"}, phase="candidate")
+    assert decision.missing_fields == []
+    decision = select_template("bureau_dispute", {}, phase="candidate")
+    assert decision.missing_fields == [
+        "creditor_name",
+        "account_number_masked",
+        "bureau",
+        "legal_safe_summary",
+    ]
+    decision = select_template(
+        "bureau_dispute",
+        {
+            "creditor_name": "Creditor",
+            "account_number_masked": "1234",
+            "bureau": "Experian",
+            "legal_safe_summary": "summary",
+        },
+        phase="candidate",
+    )
     assert decision.missing_fields == []


### PR DESCRIPTION
## Summary
- route bureau, inquiry, medical disputes and paydown-first actions to appropriate templates
- verify new routes and required-field handling in tests

## Testing
- `pytest tests/test_letter_template_router.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4fc89c5dc8325a891db08d1e9c628