### PR TITLE
Sanitize instruction HTML before compliance

### DIFF
--- a/backend/core/logic/rendering/instructions_generator.py
+++ b/backend/core/logic/rendering/instructions_generator.py
@@ -24,6 +24,7 @@ from backend.core.models import BureauPayload, ClientInfo
 from backend.core.services.ai_client import AIClient
 from backend.core.letters.router import select_template
 from backend.analytics.analytics_tracker import emit_counter
+from backend.core.letters.sanitizer import sanitize_rendered_html
 
 
 def get_logo_base64() -> str:
@@ -92,6 +93,7 @@ def generate_instruction_file(
             )
         return
     html = build_instruction_html(context, decision.template_path)
+    html, _ = sanitize_rendered_html(html, decision.template_path, context)
     emit_counter(f"letter_template_selected.{decision.template_path}")
     run_compliance_pipeline(
         html,


### PR DESCRIPTION
## Summary
- sanitize generated instruction HTML and run compliance checks on sanitized content

## Testing
- `pytest tests/test_post_render_sanitizer.py tests/test_all_render_calls_use_router.py`

------
https://chatgpt.com/codex/tasks/task_b_68a5052e3e3083259271d09b0f5277b5