### PR TITLE
feat(api): add token auth and throttling

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -38,3 +38,7 @@ Receives the PDF report and optional email, persists session data, and triggers 
 ## Guardrails / constraints
 - Session files store sanitized data; raw explanations remain in intake-only storage.
 - Secrets and API keys must come from environment variables.
+
+## Authentication & throttling
+- Set `API_AUTH_TOKENS` to a comma-separated list of bearer tokens. When provided, requests must include `Authorization: Bearer <token>`.
+- Configure `API_RATE_LIMIT_PER_MINUTE` to control how many requests a token or IP may make per minute. Exceeding the limit returns HTTP `429`.


### PR DESCRIPTION
## Summary\n- add environment-driven token auth and request rate limiting middleware\n- document auth and throttling configuration for API endpoints\n\n## Testing\n- `ruff check backend/api/app.py backend/api/config.py`\n- `pytest -q` *(fails: test_compliance_pipeline_usage, test_goodwill_integration, test_letter_fallback, test_letters_ignore_intake, test_logic_fixes, test_sensitive_language_filtered)*

------
https://chatgpt.com/codex/tasks/task_b_68a507e378dc8325a6aff2bd7d00a2f8