### PR TITLE
Track router skipped tags in analytics snapshot

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -98,6 +98,19 @@ def get_missing_fields_heatmap() -> Dict[str, Dict[str, int]]:
     return heatmap
 
 
+def get_router_skipped_counts() -> Dict[str, int]:
+    """Return counts of skipped router tags."""
+
+    prefix = "router.skipped."
+    skipped: Dict[str, int] = {}
+    for key, count in _COUNTERS.items():
+        if not key.startswith(prefix):
+            continue
+        tag = key[len(prefix) :]
+        skipped[tag] = skipped.get(tag, 0) + int(count)
+    return skipped
+
+
 def _write_cache_snapshot() -> None:
     """Persist current cache metrics to ``analytics_data`` and reset counters."""
 
@@ -245,10 +258,11 @@ def check_canary_guardrails(
 
     templates = set()
     for key in counters:
-        if key.startswith("router.finalized.") or key.startswith(
-            "validation.failed."
-        ) or key.startswith("sanitizer.applied.") or key.startswith(
-            "letter.render_ms."
+        if (
+            key.startswith("router.finalized.")
+            or key.startswith("validation.failed.")
+            or key.startswith("sanitizer.applied.")
+            or key.startswith("letter.render_ms.")
         ):
             templates.add(key.split(".")[-1])
 
@@ -332,6 +346,7 @@ def save_analytics_snapshot(
     snapshot["metrics"] = {
         "counters": get_counters(),
         "ai": get_ai_stats(),
+        "router_skipped": get_router_skipped_counts(),
     }
 
     snapshot["canary"] = get_canary_decisions()

--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -6,10 +6,11 @@ from dataclasses import dataclass
 from typing import List, Literal
 
 from backend.analytics.analytics_tracker import (
-    emit_counter,
     check_canary_guardrails,
+    emit_counter,
     log_canary_decision,
 )
+
 from . import validators
 
 
@@ -33,10 +34,9 @@ def _enabled() -> bool:
     if check_canary_guardrails(ceiling, sanitizer_limit, ai_cap):
         return False
 
-    if (
-        "ROUTER_CANARY_PERCENT" not in os.environ
-        and os.getenv("LETTERS_ROUTER_PHASED", "").lower() in {"1", "true", "yes"}
-    ):
+    if "ROUTER_CANARY_PERCENT" not in os.environ and os.getenv(
+        "LETTERS_ROUTER_PHASED", ""
+    ).lower() in {"1", "true", "yes"}:
         return True
 
     try:
@@ -93,7 +93,12 @@ def select_template(
         ),
         "pay_for_delete": (
             "pay_for_delete_letter_template.html",
-            ["collector_name", "account_number_masked", "legal_safe_summary", "offer_terms"],
+            [
+                "collector_name",
+                "account_number_masked",
+                "legal_safe_summary",
+                "offer_terms",
+            ],
         ),
         "mov": (
             "mov_letter_template.html",
@@ -154,6 +159,8 @@ def select_template(
         ),
     }
 
+    if tag in {"ignore", "paydown_first"}:
+        emit_counter(f"router.skipped.{tag}")
     if tag == "ignore":
         return TemplateDecision(
             template_path=None,
@@ -205,4 +212,3 @@ def select_template(
 
 
 __all__ = ["TemplateDecision", "select_template"]
-

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -1,10 +1,14 @@
+from backend.analytics.analytics_tracker import get_counters, reset_counters
 from backend.core.letters.router import select_template
 
 
 def test_router_basic_mappings(monkeypatch):
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
     assert (
-        select_template("dispute", {"bureau": "Experian"}, phase="finalize").template_path
+        select_template(
+            "dispute", {"bureau": "Experian"}, phase="finalize"
+        ).template_path
         == "dispute_letter_template.html"
     )
     assert (
@@ -12,7 +16,9 @@ def test_router_basic_mappings(monkeypatch):
         == "goodwill_letter_template.html"
     )
     assert (
-        select_template("custom_letter", {"recipient": "Joe"}, phase="finalize").template_path
+        select_template(
+            "custom_letter", {"recipient": "Joe"}, phase="finalize"
+        ).template_path
         == "general_letter_template.html"
     )
     assert (
@@ -75,6 +81,10 @@ def test_router_basic_mappings(monkeypatch):
     decision = select_template("ignore", {}, phase="finalize")
     assert decision.template_path is None
     assert decision.router_mode == "skip"
+
+    counters = get_counters()
+    assert counters.get("router.skipped.paydown_first") == 1
+    assert counters.get("router.skipped.ignore") == 1
 
 
 def test_missing_fields(monkeypatch):

--- a/tests/test_router_skipped_counts_snapshot.py
+++ b/tests/test_router_skipped_counts_snapshot.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from backend.analytics.analytics_tracker import (
+    emit_counter,
+    reset_counters,
+    save_analytics_snapshot,
+)
+
+
+def test_snapshot_records_router_skipped(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    reset_counters()
+    emit_counter("router.skipped.ignore")
+    emit_counter("router.skipped.paydown_first", 2)
+    save_analytics_snapshot({}, {})
+    file = next(Path("analytics_data").glob("*.json"))
+    data = json.loads(file.read_text())
+    skipped = data["metrics"]["router_skipped"]
+    assert skipped["ignore"] == 1
+    assert skipped["paydown_first"] == 2


### PR DESCRIPTION
## Summary
- emit `router.skipped.{tag}` counter when routing tags `ignore` or `paydown_first`
- capture skipped counts in analytics snapshots via `router_skipped`
- test router and snapshot metrics for skipped tags

## Testing
- `pre-commit run --files backend/core/letters/router.py backend/analytics/analytics_tracker.py tests/test_letter_template_router.py tests/test_router_skipped_counts_snapshot.py`
- `pytest tests/test_letter_template_router.py tests/test_router_skipped_counts_snapshot.py`


------
https://chatgpt.com/codex/tasks/task_b_68a509a24d708325b5d4e75c8d8100e4