### PR TITLE
Add tri-merge dataclasses and masking helpers

### DIFF
--- a/backend/core/logic/report_analysis/tri_merge_models.py
+++ b/backend/core/logic/report_analysis/tri_merge_models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Tradeline:
+    """Single bureau tradeline entry."""
+
+    creditor: str
+    bureau: str
+    account_number: Optional[str] = None
+    data: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class Mismatch:
+    """Mismatch for a particular field across bureaus."""
+
+    field: str
+    values: Dict[str, object]
+
+
+@dataclass
+class TradelineFamily:
+    """Collection of tradelines believed to represent the same account."""
+
+    account_number: str
+    tradelines: Dict[str, Tradeline] = field(default_factory=dict)
+    mismatches: List[Mismatch] = field(default_factory=list)

--- a/backend/core/logic/utils/names_normalization.py
+++ b/backend/core/logic/utils/names_normalization.py
@@ -127,6 +127,12 @@ def normalize_creditor_name(raw_name: str) -> str:
     return name.strip()
 
 
+def canonicalize_creditor(name: str) -> str:
+    """Public helper wrapping :func:`normalize_creditor_name`."""
+
+    return normalize_creditor_name(name)
+
+
 def normalize_bureau_name(name: str | None) -> str:
     """Return canonical bureau name for various capitalizations/aliases."""
     if not name:

--- a/backend/core/logic/utils/pii.py
+++ b/backend/core/logic/utils/pii.py
@@ -38,6 +38,13 @@ def redact_pii(text: str) -> str:
     return redacted
 
 
+def mask_account(account_number: str) -> str:
+    """Return ``account_number`` masked except for the last four digits."""
+
+    digits = re.sub(r"\D", "", account_number)
+    return "****" + digits[-4:]
+
+
 def mask_account_fields(data: Dict[str, Any]) -> Dict[str, Any]:
     """Return a copy of ``data`` with account numbers and SSNs masked."""
 


### PR DESCRIPTION
## Summary
- add dataclasses for tri-merge report modeling
- expose canonicalize_creditor wrapper
- provide mask_account helper for masking account numbers

## Testing
- `DISABLE_PDF_RENDER=true pytest -q`
- `DISABLE_PDF_RENDER=true pytest tests/test_sensitive_language_filtered.py::test_dispute_letter_ignores_emotional_text -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_68a5127bdb2c8325b145ffccf5307633