### PR TITLE
feat: add tri-merge normalization and mismatch logic

### DIFF
--- a/backend/core/logic/report_analysis/tri_merge.py
+++ b/backend/core/logic/report_analysis/tri_merge.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+"""Utilities for merging and comparing bureau tradeline data."""
+
+import hashlib
+import os
+import re
+from typing import Dict, Iterable, List, Tuple
+
+from backend.analytics.analytics_tracker import emit_counter
+from backend.audit.audit import emit_event
+from backend.core.logic.utils.names_normalization import canonicalize_creditor
+from backend.core.logic.utils.pii import mask_account
+from backend.api.session_manager import get_session, update_session
+
+from .tri_merge_models import Mismatch, Tradeline, TradelineFamily
+
+BUREAUS = ["Experian", "Equifax", "TransUnion"]
+
+
+def _last4(account_number: str | None) -> str:
+    digits = re.sub(r"\D", "", account_number or "")
+    return digits[-4:]
+
+
+def normalize_and_match(bureau_data: Iterable[Tradeline]) -> List[TradelineFamily]:
+    """Normalize input tradelines and group likely matches.
+
+    ``bureau_data`` is an iterable of :class:`Tradeline` items from any bureau.
+    Groups are keyed by canonicalized creditor, last four digits of the account
+    number, and basic date attributes. Each group becomes a
+    :class:`TradelineFamily` with a stable ``family_id`` and a ``match_confidence``
+    attribute indicating how reliable the grouping is.
+    """
+
+    groups: Dict[Tuple[str, str, str, str], TradelineFamily] = {}
+
+    for tl in bureau_data:
+        creditor = canonicalize_creditor(tl.creditor)
+        last4 = _last4(tl.account_number)
+        opened = str(tl.data.get("date_opened") or tl.data.get("open_date") or "")
+        reported = str(
+            tl.data.get("date_reported")
+            or tl.data.get("report_date")
+            or ""
+        )
+        key = (creditor, last4, opened, reported)
+
+        family = groups.get(key)
+        if not family:
+            family = TradelineFamily(account_number=mask_account(tl.account_number or ""))
+            groups[key] = family
+        if tl.bureau in family.tradelines:
+            # Track duplicates for mismatch analysis
+            dups = getattr(family, "_duplicates", [])
+            dups.append(tl)
+            family._duplicates = dups
+        else:
+            family.tradelines[tl.bureau] = tl
+
+    families: List[TradelineFamily] = []
+    for key, family in groups.items():
+        features = "|".join(key)
+        family_id = hashlib.sha1(features.encode("utf-8")).hexdigest()[:10]
+        feature_count = sum(1 for part in key if part)
+        match_confidence = feature_count / 4.0
+        family.family_id = family_id  # type: ignore[attr-defined]
+        family.match_confidence = match_confidence  # type: ignore[attr-defined]
+        families.append(family)
+
+        bucket = int(match_confidence * 10) * 10
+        emit_counter(f"tri_merge.match_confidence_hist.{bucket}")
+        if match_confidence < 0.5:
+            emit_event(
+                "tri_merge.low_match_confidence",
+                {"family_id": family_id, "creditor": key[0], "confidence": match_confidence},
+            )
+
+    emit_counter("tri_merge.families_total", len(families))
+    return families
+
+
+def compute_mismatches(families: Iterable[TradelineFamily]) -> List[TradelineFamily]:
+    """Compare tradeline families to surface mismatches.
+
+    Detected mismatches are appended to each family's ``mismatches`` list and a
+    snapshot of the raw evidence is stored in the session under
+    ``session["tri_merge"]["evidence"][family_id]``.
+    """
+
+    session_id = os.getenv("SESSION_ID", "")
+    session = get_session(session_id) if session_id else None
+    tri_store = session.setdefault("tri_merge", {}).setdefault("evidence", {}) if session else {}
+
+    total_mismatches = 0
+
+    def _record(fam: TradelineFamily, mismatch: Mismatch) -> None:
+        nonlocal total_mismatches
+        fam.mismatches.append(mismatch)
+        total_mismatches += 1
+        emit_counter(f"tri_merge.mismatch.{mismatch.field}")
+
+    for fam in families:
+        present = set(fam.tradelines.keys())
+        missing = [b for b in BUREAUS if b not in present]
+        if missing:
+            values = {b: (b in present) for b in BUREAUS}
+            _record(fam, Mismatch(field="presence", values=values))
+
+        def cmp(field: str, mtype: str) -> None:
+            values = {b: tl.data.get(field) for b, tl in fam.tradelines.items()}
+            if len(set(values.values())) > 1:
+                _record(fam, Mismatch(field=mtype, values=values))
+
+        cmp("balance", "balance")
+        cmp("status", "status")
+        cmp("date_opened", "dates")
+        cmp("remarks", "remarks")
+        cmp("utilization", "utilization")
+        cmp("personal_info", "personal_info")
+
+        if getattr(fam, "_duplicates", None):
+            counts = {tl.bureau: len(getattr(fam, "_duplicates")) + 1}
+            _record(fam, Mismatch(field="duplicate", values=counts))
+
+        if tri_store is not None:
+            tri_store[getattr(fam, "family_id", "")] = {
+                "tradelines": {b: tl.data for b, tl in fam.tradelines.items()},
+                "mismatches": [m.field for m in fam.mismatches],
+            }
+
+    if session_id:
+        update_session(session_id, tri_merge={"evidence": tri_store})
+
+    emit_counter("tri_merge.mismatches_total", total_mismatches)
+    return list(families)


### PR DESCRIPTION
## Summary
- add tri_merge utilities for grouping tradelines with canonical creditor names and masked account numbers
- compute mismatches between bureaus and store evidence snapshots
- emit analytics counters for match confidence and mismatch totals

## Testing
- `python -m py_compile backend/core/logic/report_analysis/tri_merge.py`
- `pytest -q` *(fails: FileNotFoundError and assertion errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68a513eb47108325829773668ca2b970