### PR TITLE
Handle tri-merge mismatches in rule evaluation

### DIFF
--- a/backend/core/logic/policy/precedence.py
+++ b/backend/core/logic/policy/precedence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Mapping, Sequence
 
 # Increment whenever the precedence resolution algorithm changes.
-precedence_version = "1"
+precedence_version = "2"
 
 
 def get_precedence(rulebook: Mapping[str, Any] | Any) -> list[str]:

--- a/backend/policy/rulebook.yaml
+++ b/backend/policy/rulebook.yaml
@@ -20,6 +20,14 @@ precedence:
   - D_VALIDATION
   - C_MOV
   - H_OBSOL
+  - TM_PRESENCE
+  - TM_BALANCE
+  - TM_STATUS
+  - TM_DATES
+  - TM_REMARKS
+  - TM_UTILIZATION
+  - TM_PERSONAL_INFO
+  - TM_DUPLICATE
   - A_CRA_DISPUTE
   - B_DIRECT_DISPUTE
   - L_DUPLICATE_TRADELINE
@@ -32,7 +40,22 @@ precedence:
 
 # חוקים שמבטלים/מדכאים אחרים (rule → [rules])
 exclusions:
-  E_IDENTITY: [F_GOODWILL, G_PFD, D_VALIDATION, A_CRA_DISPUTE, B_DIRECT_DISPUTE, H_OBSOL]
+  E_IDENTITY: [
+    F_GOODWILL,
+    G_PFD,
+    D_VALIDATION,
+    A_CRA_DISPUTE,
+    B_DIRECT_DISPUTE,
+    H_OBSOL,
+    TM_PRESENCE,
+    TM_BALANCE,
+    TM_STATUS,
+    TM_DATES,
+    TM_REMARKS,
+    TM_UTILIZATION,
+    TM_PERSONAL_INFO,
+    TM_DUPLICATE,
+  ]
   E_IDENTITY_NEEDS_AFFIDAVIT: []
   D_VALIDATION: [A_CRA_DISPUTE, B_DIRECT_DISPUTE, G_PFD]
   C_MOV: [G_PFD]
@@ -116,7 +139,105 @@ rules:
       action_tag: obsolescence
       priority: High
 
-  # --- 5) Bureau dispute (אי־דיוק/מידע חסר/אי־יכולת אימות) ---
+  # --- 5) Tri-merge mismatches ---
+  - id: TM_PRESENCE
+    description: Tradeline present on some bureaus but missing on others → dispute with bureau.
+    when:
+      all:
+        - { field: "tri_merge.presence", eq: true }
+    effect:
+      rule_hits: ["TM_PRESENCE"]
+      suggested_dispute_frame: "bureau_dispute"
+      action_tag: bureau_dispute
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_BALANCE
+    description: Balances differ across bureaus → request Method of Verification.
+    when:
+      all:
+        - { field: "tri_merge.balance", eq: true }
+    effect:
+      rule_hits: ["TM_BALANCE"]
+      suggested_dispute_frame: "mov_request"
+      action_tag: mov
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_STATUS
+    description: Account status inconsistent across bureaus → request Method of Verification.
+    when:
+      all:
+        - { field: "tri_merge.status", eq: true }
+    effect:
+      rule_hits: ["TM_STATUS"]
+      suggested_dispute_frame: "mov_request"
+      action_tag: mov
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_DATES
+    description: Date information mismatched between bureaus → request Method of Verification.
+    when:
+      all:
+        - { field: "tri_merge.dates", eq: true }
+    effect:
+      rule_hits: ["TM_DATES"]
+      suggested_dispute_frame: "mov_request"
+      action_tag: mov
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_REMARKS
+    description: Remarks differ among bureaus → dispute with bureau for accuracy.
+    when:
+      all:
+        - { field: "tri_merge.remarks", eq: true }
+    effect:
+      rule_hits: ["TM_REMARKS"]
+      suggested_dispute_frame: "bureau_dispute"
+      action_tag: bureau_dispute
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_UTILIZATION
+    description: Utilization reported inconsistently → request Method of Verification.
+    when:
+      all:
+        - { field: "tri_merge.utilization", eq: true }
+    effect:
+      rule_hits: ["TM_UTILIZATION"]
+      suggested_dispute_frame: "mov_request"
+      action_tag: mov
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_PERSONAL_INFO
+    description: Personal information differs across bureaus → request correction.
+    when:
+      all:
+        - { field: "tri_merge.personal_info", eq: true }
+    effect:
+      rule_hits: ["TM_PERSONAL_INFO"]
+      suggested_dispute_frame: "personal_info_correction"
+      action_tag: personal_info_correction
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  - id: TM_DUPLICATE
+    description: Possible duplicate tradelines across bureaus.
+    when:
+      all:
+        - { field: "tri_merge.duplicate", eq: true }
+    effect:
+      rule_hits: ["TM_DUPLICATE"]
+      suggested_dispute_frame: "bureau_dispute"
+      action_tag: bureau_dispute
+      flags: ["duplicate_tradeline"]
+      needs_evidence: ["tri_merge_snapshot"]
+      priority: High
+
+  # --- 6) Bureau dispute (אי־דיוק/מידע חסר/אי־יכולת אימות) ---
   - id: A_CRA_DISPUTE
     description: Dispute with CRA due to inaccuracy/incompleteness or inability to verify.
     when:
@@ -130,7 +251,7 @@ rules:
       action_tag: bureau_dispute
       priority: High
 
-  # --- 6) Direct dispute (יש כתובת ישירה של furnisher) ---
+  # --- 7) Direct dispute (יש כתובת ישירה של furnisher) ---
   - id: B_DIRECT_DISPUTE
     description: Send direct dispute to furnisher when address is available and item is inaccurate/incomplete.
     when:
@@ -144,7 +265,7 @@ rules:
       action_tag: direct_dispute
       priority: High
 
-  # --- 7) Duplicate tradeline (לחסום כפילויות) ---
+  # --- 8) Duplicate tradeline (לחסום כפילויות) ---
   - id: L_DUPLICATE_TRADELINE
     description: Duplicate tradelines should be deduped and disputed once.
     when:
@@ -158,7 +279,7 @@ rules:
       action_tag: bureau_dispute
       priority: Medium
 
-  # --- 8) Unauthorized / stale inquiry ---
+  # --- 9) Unauthorized / stale inquiry ---
   - id: M_UNAUTHORIZED_INQUIRY
     description: Old or unauthorized inquiries → dispute with CRA.
     when:
@@ -174,7 +295,7 @@ rules:
       action_tag: inquiry_dispute
       priority: Medium
 
-  # --- 9) Medical policy (קטן/שולם) ---
+  # --- 10) Medical policy (קטן/שולם) ---
   - id: J_MEDICAL
     description: Medical debts under threshold or already paid → apply medical policy.
     when:
@@ -191,7 +312,7 @@ rules:
       action_tag: medical_dispute
       priority: Medium
 
-  # --- 10) High utilization on open revolving (לשלם לפני מחלוקת) ---
+  # --- 11) High utilization on open revolving (לשלם לפני מחלוקת) ---
   - id: K_UTILIZATION_PAYDOWN
     description: Open revolving utilization ≥ threshold → pay down before disputing.
     when:
@@ -205,7 +326,7 @@ rules:
       action_tag: paydown_first
       priority: Medium
 
-  # --- 11) Goodwill (רק ל-late, היסטוריה טובה, לא collections כשflag פעיל) ---
+  # --- 12) Goodwill (רק ל-late, היסטוריה טובה, לא collections כשflag פעיל) ---
   - id: F_GOODWILL
     description: Soft goodwill request for late payments with otherwise good history.
     when:
@@ -223,7 +344,7 @@ rules:
       action_tag: goodwill
       priority: Low
 
-  # --- 12) Pay-for-Delete (מוצא אחרון בקולקשנס כשאין עילות אחרות) ---
+  # --- 13) Pay-for-Delete (מוצא אחרון בקולקשנס כשאין עילות אחרות) ---
   - id: G_PFD
     description: Negotiated pay-for-delete only when no legal dispute frame applies.
     when:
@@ -240,7 +361,7 @@ rules:
       action_tag: pay_for_delete
       priority: Low
 
-  # --- 13) Cease & Desist (תמיד אם ביקש) ---
+  # --- 14) Cease & Desist (תמיד אם ביקש) ---
   - id: I_CEASE
     description: If the customer asked to stop collection calls, send cease & desist.
     when:

--- a/tests/strategy/test_rule_evaluation.py
+++ b/tests/strategy/test_rule_evaluation.py
@@ -29,3 +29,20 @@ def test_validation_excludes_pay_for_delete() -> None:
     result = evaluate_rules("", facts, rb)
     assert result["rule_hits"] == ["D_VALIDATION"]
     assert result["suggested_dispute_frame"] == "debt_validation"
+
+
+def test_tri_merge_presence_rule() -> None:
+    rb = {
+        "rules": [
+            {
+                "id": "TM_PRESENCE",
+                "when": {"field": "tri_merge.presence", "eq": True},
+                "effect": {"rule_hits": ["TM_PRESENCE"]},
+            }
+        ],
+        "precedence": ["TM_PRESENCE"],
+    }
+    tri = {"mismatch_types": ["presence"], "evidence_snapshot_id": "snap1"}
+    result = evaluate_rules("", {}, rb, tri)
+    assert result["rule_hits"] == ["TM_PRESENCE"]
+    assert result["tri_merge"]["evidence_snapshot_id"] == "snap1"


### PR DESCRIPTION
## Summary
- allow `evaluate_rules` to accept tri-merge data and propagate it through `normalize_and_tag`
- add rulebook entries and precedence/exclusions for tri-merge mismatch types requiring `tri_merge_snapshot`
- bump precedence version and cover tri-merge evaluation with tests

## Testing
- `pytest tests/strategy/test_rule_evaluation.py tests/strategy/test_precedence_helper.py tests/strategy/test_normalizer_2_5.py`


------
https://chatgpt.com/codex/tasks/task_b_68a51b6acfd88325988ff6a3238d96e1