### PR TITLE
Persist tri-merge evidence in session store

### DIFF
--- a/backend/api/session_manager.py
+++ b/backend/api/session_manager.py
@@ -52,6 +52,17 @@ def update_session(session_id: str, **kwargs: Any) -> Dict[str, Any]:
         session = sessions.get(session_id, {})
         if "structured_summaries" in kwargs:
             invalidate_summary_cache(session_id)
+        tri_merge_update = kwargs.pop("tri_merge", None)
+        if tri_merge_update:
+            tri_merge_session = session.get("tri_merge", {})
+            evidence_update = tri_merge_update.get("evidence")
+            if evidence_update:
+                evidence_session = tri_merge_session.get("evidence", {})
+                evidence_session.update(evidence_update)
+                tri_merge_session["evidence"] = evidence_session
+                tri_merge_update.pop("evidence", None)
+            tri_merge_session.update(tri_merge_update)
+            session["tri_merge"] = tri_merge_session
         session.update(kwargs)
         sessions[session_id] = session
         _save_sessions(sessions)

--- a/tests/test_session_tri_merge.py
+++ b/tests/test_session_tri_merge.py
@@ -1,0 +1,16 @@
+from backend.api.session_manager import get_session, update_session
+
+
+def test_tri_merge_evidence_preserved(tmp_path, monkeypatch):
+    sess_file = tmp_path / "sessions.json"
+    monkeypatch.setattr(
+        "backend.api.session_manager.SESSION_FILE", sess_file
+    )
+
+    session_id = "sess1"
+    update_session(session_id, tri_merge={"evidence": {"snap1": {"a": 1}}})
+    update_session(session_id, tri_merge={"evidence": {"snap2": {"b": 2}}})
+
+    session = get_session(session_id)
+    assert session["tri_merge"]["evidence"]["snap1"] == {"a": 1}
+    assert session["tri_merge"]["evidence"]["snap2"] == {"b": 2}


### PR DESCRIPTION
## Summary
- Deep-merge tri-merge data when updating sessions to retain existing evidence
- Add regression test ensuring multiple tri-merge evidence snapshots persist

## Testing
- `pytest -q` *(fails: missing compliance pipeline / pdfkit dependencies)*
- `pytest tests/test_session_tri_merge.py::test_tri_merge_evidence_preserved -q`


------
https://chatgpt.com/codex/tasks/task_b_68a51f0de0888325acc36918fd1eed1d