### PR TITLE
Track duplicate tradelines by bureau

### DIFF
--- a/backend/core/logic/report_analysis/tri_merge.py
+++ b/backend/core/logic/report_analysis/tri_merge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Utilities for merging and comparing bureau tradeline data."""
 
+import collections
 import hashlib
 import os
 import re
@@ -119,9 +120,10 @@ def compute_mismatches(families: Iterable[TradelineFamily]) -> List[TradelineFam
         cmp("utilization", "utilization")
         cmp("personal_info", "personal_info")
 
-        if getattr(fam, "_duplicates", None):
-            counts = {tl.bureau: len(getattr(fam, "_duplicates")) + 1}
-            _record(fam, Mismatch(field="duplicate", values=counts))
+        dups = getattr(fam, "_duplicates", None)
+        if dups:
+            counts = collections.Counter(d.bureau for d in dups)
+            _record(fam, Mismatch(field="duplicate", values=dict(counts)))
 
         if tri_store is not None:
             tri_store[getattr(fam, "family_id", "")] = {

--- a/tests/report_analysis/test_tri_merge.py
+++ b/tests/report_analysis/test_tri_merge.py
@@ -94,3 +94,27 @@ def test_presence_and_field_mismatches():
     assert mism["remarks"].values == {"Experian": "OK", "Equifax": "Late"}
     assert mism["utilization"].values == {"Experian": 0.1, "Equifax": 0.5}
     assert mism["personal_info"].values == {"Experian": "PI1", "Equifax": "PI2"}
+
+
+def test_duplicate_mismatch_counts():
+    tls = [
+        Tradeline(
+            creditor="Chase",
+            bureau="Experian",
+            account_number="12341234",
+            data={"date_opened": "2020-01-01", "date_reported": "2020-02-01"},
+        ),
+        Tradeline(
+            creditor="Chase",
+            bureau="Experian",
+            account_number="12341234",
+            data={"date_opened": "2020-01-01", "date_reported": "2020-02-01"},
+        ),
+    ]
+
+    families = normalize_and_match(tls)
+    families = compute_mismatches(families)
+    fam = families[0]
+    mism = {m.field: m for m in fam.mismatches}
+
+    assert mism["duplicate"].values == {"Experian": 1}


### PR DESCRIPTION
## Summary
- Count duplicate tradelines per bureau using collections.Counter
- Emit duplicate mismatch with per-bureau counts
- Add unit test validating duplicate mismatch counts

## Testing
- `pytest tests/report_analysis/test_tri_merge.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5dcec8f8c8325bba9647d9eb57c2a