### PR TITLE
Include date_reported in tri-merge mismatch checks

### DIFF
--- a/backend/core/logic/report_analysis/tri_merge.py
+++ b/backend/core/logic/report_analysis/tri_merge.py
@@ -113,9 +113,20 @@ def compute_mismatches(families: Iterable[TradelineFamily]) -> List[TradelineFam
             if len(set(values.values())) > 1:
                 _record(fam, Mismatch(field=mtype, values=values))
 
+        def cmp_dates() -> None:
+            values = {
+                b: (
+                    tl.data.get("date_opened"),
+                    tl.data.get("date_reported"),
+                )
+                for b, tl in fam.tradelines.items()
+            }
+            if len(set(values.values())) > 1:
+                _record(fam, Mismatch(field="dates", values=values))
+
         cmp("balance", "balance")
         cmp("status", "status")
-        cmp("date_opened", "dates")
+        cmp_dates()
         cmp("remarks", "remarks")
         cmp("utilization", "utilization")
         cmp("personal_info", "personal_info")

--- a/tests/report_analysis/test_tri_merge.py
+++ b/tests/report_analysis/test_tri_merge.py
@@ -69,7 +69,7 @@ def test_presence_and_field_mismatches():
         {
             "balance": 200,
             "status": "closed",
-            "date_opened": "2020-02-01",
+            "date_reported": "2020-03-01",
             "remarks": "Late",
             "utilization": 0.5,
             "personal_info": "PI2",
@@ -88,8 +88,8 @@ def test_presence_and_field_mismatches():
     assert mism["balance"].values == {"Experian": 100, "Equifax": 200}
     assert mism["status"].values == {"Experian": "open", "Equifax": "closed"}
     assert mism["dates"].values == {
-        "Experian": "2020-01-01",
-        "Equifax": "2020-02-01",
+        "Experian": ("2020-01-01", "2020-02-01"),
+        "Equifax": ("2020-01-01", "2020-03-01"),
     }
     assert mism["remarks"].values == {"Experian": "OK", "Equifax": "Late"}
     assert mism["utilization"].values == {"Experian": 0.1, "Equifax": 0.5}


### PR DESCRIPTION
## Summary
- ensure `compute_mismatches` considers both `date_opened` and `date_reported`
- test mismatch detection when bureaus report different `date_reported`

## Testing
- `pytest tests/report_analysis/test_tri_merge.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5df6bbb788325b4bb39fee5a052ab