### PR TITLE
Deduplicate tri_merge metric emissions

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -628,11 +628,6 @@ def run_credit_repair_process(
                         )
             families = normalize_and_match(tradelines)
             compute_mismatches(families)
-            emit_counter("tri_merge.families_total", len(families))
-            emit_counter(
-                "tri_merge.mismatches_total",
-                sum(len(getattr(f, "mismatches", [])) for f in families),
-            )
             for fam in families:
                 family_id = getattr(fam, "family_id", None)
                 mismatch_types = [m.field for m in getattr(fam, "mismatches", [])]


### PR DESCRIPTION
## Summary
- emit tri_merge metric counters only inside tri_merge analysis routines
- stop orchestrator from double-counting tri_merge families and mismatches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a5e0bb98b08325a11f9929d4c39a68