### PR TITLE
Validate rulebook contains tri-merge mismatch rules

### DIFF
--- a/backend/policy/policy_loader.py
+++ b/backend/policy/policy_loader.py
@@ -10,6 +10,8 @@ from typing import Any, Mapping
 import yaml
 from jsonschema import Draft7Validator, ValidationError
 
+from .validators import validate_tri_merge_mismatch_rules
+
 _RULEBOOK_PATH = Path(__file__).with_name("rulebook.yaml")
 _SCHEMA_PATH = Path(__file__).with_name("rulebook_schema.yaml")
 
@@ -65,6 +67,9 @@ def load_rulebook() -> Mapping[str, Any]:
         return value
 
     resolved = resolve(data)
+
+    # Ensure all known tri-merge mismatch types have corresponding rules.
+    validate_tri_merge_mismatch_rules(resolved)
 
     class RulebookDict(dict):
         def __init__(self, *args, **kwargs) -> None:

--- a/backend/policy/validators.py
+++ b/backend/policy/validators.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Additional validations for the policy rulebook."""
+
+from pathlib import Path
+from typing import Any, Mapping, Set
+
+import yaml
+
+# Mismatch types produced by ``compute_mismatches`` in
+# ``backend.core.logic.report_analysis.tri_merge``.
+TRI_MERGE_MISMATCH_TYPES: Set[str] = {
+    "presence",
+    "balance",
+    "status",
+    "dates",
+    "remarks",
+    "utilization",
+    "personal_info",
+    "duplicate",
+}
+
+
+def _collect_tri_merge_fields(obj: Any, found: Set[str]) -> None:
+    """Recursively collect tri-merge mismatch fields from condition trees."""
+    if isinstance(obj, dict):
+        field = obj.get("field")
+        if isinstance(field, str) and field.startswith("tri_merge."):
+            found.add(field.split(".", 1)[1])
+        for value in obj.values():
+            _collect_tri_merge_fields(value, found)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_tri_merge_fields(item, found)
+
+
+def validate_tri_merge_mismatch_rules(rulebook: Mapping[str, Any] | None = None) -> None:
+    """Ensure every mismatch type has a corresponding rule in the rulebook.
+
+    If ``rulebook`` is not provided, ``backend/policy/rulebook.yaml`` is loaded.
+    A ``ValueError`` is raised if any known mismatch type is missing.
+    """
+
+    if rulebook is None:
+        path = Path(__file__).with_name("rulebook.yaml")
+        rulebook = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    found: Set[str] = set()
+    for rule in rulebook.get("rules", []):
+        when = rule.get("when") or rule.get("conditions")
+        if when is not None:
+            _collect_tri_merge_fields(when, found)
+
+    missing = TRI_MERGE_MISMATCH_TYPES - found
+    if missing:
+        raise ValueError(
+            "Missing tri-merge rules for mismatch types: " + ", ".join(sorted(missing))
+        )
+
+
+__all__ = ["validate_tri_merge_mismatch_rules", "TRI_MERGE_MISMATCH_TYPES"]

--- a/tests/policy/test_policy_loader.py
+++ b/tests/policy/test_policy_loader.py
@@ -1,8 +1,15 @@
-from backend.policy.policy_loader import load_rulebook
+import pytest
+
+from backend.policy import policy_loader, validators
+
+
+def _reset_cache() -> None:
+    policy_loader._RULEBOOK_CACHE = None
 
 
 def test_load_rulebook_resolves_placeholders_and_exposes_version() -> None:
-    rulebook = load_rulebook()
+    _reset_cache()
+    rulebook = policy_loader.load_rulebook()
     # Ensure version attribute exists
     assert isinstance(rulebook.version, str) and rulebook.version
 
@@ -10,3 +17,14 @@ def test_load_rulebook_resolves_placeholders_and_exposes_version() -> None:
     rule = next(r for r in rulebook["rules"] if r["id"] == "D_VALIDATION")
     cond = rule["when"]["all"][1]
     assert cond["lte"] == rulebook["limits"]["D_VALIDATION_WINDOW_DAYS"]
+
+
+def test_load_rulebook_fails_when_mismatch_type_missing(monkeypatch) -> None:
+    _reset_cache()
+    monkeypatch.setattr(
+        validators,
+        "TRI_MERGE_MISMATCH_TYPES",
+        validators.TRI_MERGE_MISMATCH_TYPES | {"bogus"},
+    )
+    with pytest.raises(ValueError):
+        policy_loader.load_rulebook()


### PR DESCRIPTION
## Summary
- ensure all known tri-merge mismatch types have corresponding rules in the rulebook
- hook mismatch validator into rulebook loading
- test failure when rulebook lacks a required mismatch rule

## Testing
- `pytest tests/policy/test_policy_loader.py -q`
- `pytest tests/strategy/test_rule_evaluation.py tests/strategy/test_tri_merge_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5e3e76d088325862ae89fee46c581