### PR TITLE
Handle personal info correction routing

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -110,6 +110,16 @@ def select_template(
                 "days_since_cra_result",
             ],
         ),
+        "personal_info_correction": (
+            "personal_info_correction_template.html",
+            [
+                "client_name",
+                "client_address_lines",
+                "date_of_birth",
+                "ssn_last4",
+                "legal_safe_summary",
+            ],
+        ),
         "cease_and_desist": (
             "cease_and_desist_letter_template.html",
             ["collector_name", "account_number_masked", "legal_safe_summary"],

--- a/tests/letters/test_candidate_routing_tri_merge.py
+++ b/tests/letters/test_candidate_routing_tri_merge.py
@@ -20,6 +20,14 @@ BUREAU_FIELDS = {
     "legal_safe_summary",
 }
 
+PII_FIELDS = {
+    "client_name",
+    "client_address_lines",
+    "date_of_birth",
+    "ssn_last4",
+    "legal_safe_summary",
+}
+
 
 @pytest.mark.parametrize(
     "mismatch_type,template,fields",
@@ -30,6 +38,11 @@ BUREAU_FIELDS = {
         ("remarks", "bureau_dispute_letter_template.html", BUREAU_FIELDS),
         ("utilization", "mov_letter_template.html", MOV_FIELDS),
         ("duplicate", "bureau_dispute_letter_template.html", BUREAU_FIELDS),
+        (
+            "personal_info",
+            "personal_info_correction_template.html",
+            PII_FIELDS,
+        ),
     ],
 )
 def test_candidate_routing_emits_missing_fields_after_stage_2_5(


### PR DESCRIPTION
## Summary
- route `personal_info_correction` letters to `personal_info_correction_template.html`
- cover personal info mismatches in candidate routing tests

## Testing
- `pre-commit run --files backend/core/letters/router.py tests/letters/test_candidate_routing_tri_merge.py`
- `pytest tests/letters/test_candidate_routing_tri_merge.py::test_candidate_routing_emits_missing_fields_after_stage_2_5 -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5f5800acc8325874ac30a773660c9