### PR TITLE
Validate tri-merge mismatch rules

### DIFF
--- a/backend/policy/validators.py
+++ b/backend/policy/validators.py
@@ -34,12 +34,19 @@ def _collect_tri_merge_fields(obj: Any, found: Set[str]) -> None:
             _collect_tri_merge_fields(item, found)
 
 
-def validate_tri_merge_mismatch_rules(rulebook: Mapping[str, Any] | None = None) -> None:
+def validate_tri_merge_mismatch_rules(
+    rulebook: Mapping[str, Any] | None = None,
+    mismatch_types: Set[str] | None = None,
+) -> None:
     """Ensure every mismatch type has a corresponding rule in the rulebook.
 
-    If ``rulebook`` is not provided, ``backend/policy/rulebook.yaml`` is loaded.
-    A ``ValueError`` is raised if any known mismatch type is missing.
+    ``mismatch_types`` defaults to :data:`TRI_MERGE_MISMATCH_TYPES`. If ``rulebook``
+    is not provided, ``backend/policy/rulebook.yaml`` is loaded. A ``ValueError``
+    is raised if any known mismatch type is missing.
     """
+
+    if mismatch_types is None:
+        mismatch_types = TRI_MERGE_MISMATCH_TYPES
 
     if rulebook is None:
         path = Path(__file__).with_name("rulebook.yaml")
@@ -51,7 +58,7 @@ def validate_tri_merge_mismatch_rules(rulebook: Mapping[str, Any] | None = None)
         if when is not None:
             _collect_tri_merge_fields(when, found)
 
-    missing = TRI_MERGE_MISMATCH_TYPES - found
+    missing = mismatch_types - found
     if missing:
         raise ValueError(
             "Missing tri-merge rules for mismatch types: " + ", ".join(sorted(missing))

--- a/tests/policy/test_tri_merge_validator.py
+++ b/tests/policy/test_tri_merge_validator.py
@@ -1,0 +1,20 @@
+import pytest
+
+from backend.policy import policy_loader, validators
+
+
+def _reset_cache() -> None:
+    policy_loader._RULEBOOK_CACHE = None
+
+
+def test_validator_detects_missing_rule(monkeypatch) -> None:
+    _reset_cache()
+    rulebook = policy_loader.load_rulebook()
+    monkeypatch.setattr(
+        validators,
+        "TRI_MERGE_MISMATCH_TYPES",
+        validators.TRI_MERGE_MISMATCH_TYPES | {"bogus"},
+    )
+    with pytest.raises(ValueError):
+        validators.validate_tri_merge_mismatch_rules(rulebook)
+    _reset_cache()


### PR DESCRIPTION
## Summary
- extend tri-merge mismatch rule validation to accept a custom mismatch type set and load the rulebook when needed
- ensure rulebook validation errors if a mismatch type lacks a corresponding rule
- add regression test for missing rule coverage

## Testing
- `pytest tests/policy -vv`


------
https://chatgpt.com/codex/tasks/task_b_68a6004075a48325a29cbadcd843da91