### PR TITLE
Expose tri-merge evidence snapshots in evaluation context

### DIFF
--- a/backend/api/session_manager.py
+++ b/backend/api/session_manager.py
@@ -55,12 +55,11 @@ def update_session(session_id: str, **kwargs: Any) -> Dict[str, Any]:
         tri_merge_update = kwargs.pop("tri_merge", None)
         if tri_merge_update:
             tri_merge_session = session.get("tri_merge", {})
-            evidence_update = tri_merge_update.get("evidence")
+            evidence_update = tri_merge_update.pop("evidence", None)
             if evidence_update:
                 evidence_session = tri_merge_session.get("evidence", {})
                 evidence_session.update(evidence_update)
                 tri_merge_session["evidence"] = evidence_session
-                tri_merge_update.pop("evidence", None)
             tri_merge_session.update(tri_merge_update)
             session["tri_merge"] = tri_merge_session
         session.update(kwargs)


### PR DESCRIPTION
## Summary
- Attach tri-merge evidence snapshots to each account's evaluation context after mismatch computation
- Preserve tri-merge evidence snapshots across session updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a60ea867b0832597bde5baa29db723