### PR TITLE
Track rule tag selections and suppressed rules

### DIFF
--- a/backend/analytics/README.md
+++ b/backend/analytics/README.md
@@ -22,6 +22,8 @@ Common counters emitted for dashboards:
 - `letters_without_strategy_context` – attempts to generate letters without required strategy data.
 - `guardrail_fix_count.{letter_type}` – number of guardrail remediation passes by letter type.
 - `policy_override_reason.{reason}` – policy-based overrides grouped by reason.
+- `rulebook.tag_selected.{tag}` – counts how often a rulebook action tag is chosen.
+- `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
 
 ## Entry points
 - `analytics_tracker.save_analytics_snapshot`

--- a/backend/core/logic/strategy/normalizer_2_5.py
+++ b/backend/core/logic/strategy/normalizer_2_5.py
@@ -317,6 +317,7 @@ def evaluate_rules(
 
     for rule_id, effect in sorted_hits:
         if rule_id in suppressed:
+            emit_counter(f"rulebook.suppressed_rules.{rule_id}")
             continue
         final_hits.extend(effect.get("rule_hits", [rule_id]))
         needs_evidence.extend(effect.get("needs_evidence", []))
@@ -420,6 +421,9 @@ def normalize_and_tag(
     result["red_flags"] = list(
         dict.fromkeys(result.get("red_flags", []) + admission_flags)
     )
+
+    if result.get("action_tag"):
+        emit_counter(f"rulebook.tag_selected.{result['action_tag']}")
 
     _fill_defaults(result)
     _VALIDATOR.validate(result)

--- a/docs/STAGE_2_5.md
+++ b/docs/STAGE_2_5.md
@@ -38,6 +38,8 @@ Stage 2.5 emits counters via `analytics_tracker`:
 - `s2_5_latency_ms`
 - `s2_5_rule_hits_per_account`
 - `s2_5_admissions_detected_total`
+- `rulebook.tag_selected.{tag}`
+- `rulebook.suppressed_rules.{rule_name}`
 
 ## Rulebook Update Workflow
 1. Edit `backend/policy/rulebook.yaml` and bump its `version`.

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -32,6 +32,13 @@ flowchart LR
 - P95 latency ≤ 2s for routing.
 - No more than 0.1% invalid letters.
 
+## Monitoring
+
+Dashboards should surface the following counters:
+
+- `rulebook.tag_selected.{tag}` – frequency of chosen action tags.
+- `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
+
 ## Rollback
 
 1. Revert to the previous container tag.


### PR DESCRIPTION
## Summary
- emit counter when final rulebook action tag is selected
- track precedence/exclusion suppressions for rulebook rules
- document rule evaluation metrics in monitoring docs and runbook

## Testing
- `pytest tests/strategy/test_rule_evaluation.py tests/strategy/test_normalizer_2_5.py tests/strategy/test_rule_logging.py -q`
- `pytest tests/strategy/test_stage_2_5_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a610547c8883259c6327dadaefef2e