### PR TITLE
docs: add rulebook overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Python backend powering ingestion, analysis, strategy generation, letter creatio
 ### docs
 Reference materials such as data models, stage guides, and contributing
 instructions. Includes pipeline docs like [Stage 2.5](docs/STAGE_2_5.md)
-and [Stage 3 Hardening](docs/stage3_hardening.md). No dedicated README;
-browse files within [`docs`](docs) for deeper documentation.
+and [Stage 3 Hardening](docs/stage3_hardening.md). The mismatch-to-tag
+rulebook lives in [`docs/rulebook`](docs/rulebook/README.md). No dedicated
+README; browse files within [`docs`](docs) for deeper documentation.
 
 ### frontend
 React client that interacts with the API to upload reports and display results. See [frontend/README.md](frontend/README.md) for build and run instructions.

--- a/docs/rulebook/README.md
+++ b/docs/rulebook/README.md
@@ -1,0 +1,28 @@
+# Rulebook
+
+The rulebook converts tri-merge account diffs into semantic tags that drive downstream routing.
+
+## Mismatch-to-tag mapping
+
+Tri-merge diffs surface discrepancies across credit bureaus. Each rule inspects a mismatch and emits a tag describing the issue.
+Examples:
+
+- Name or address discrepancies → `identity_mismatch`
+- Balance or status differences → `account_mismatch`
+- Missing or extra accounts → `presence_mismatch`
+
+## Precedence
+
+Rules execute in priority order. When multiple rules match the same mismatch, the first rule wins and its tag suppresses lower-priority rules.
+
+## Metrics
+
+The engine tracks:
+
+- Count of diffs evaluated
+- Tag emission counts
+- Rule evaluation latency
+
+These metrics surface in dashboards and help tune rule quality.
+
+See [flow.mmd](flow.mmd) for a visual overview of the evaluation pipeline.

--- a/docs/rulebook/flow.mmd
+++ b/docs/rulebook/flow.mmd
@@ -1,0 +1,5 @@
+flowchart TD
+    diffs[Tri-merge diffs]
+    diffs --> rules[Rule evaluation]
+    rules --> tags[Tag emission]
+    tags --> router[Router]


### PR DESCRIPTION
## Summary
- document mismatch-to-tag rulebook and metrics
- include mermaid flow diagram of rule evaluation pipeline
- reference rulebook from main README

## Testing
- `DISABLE_PDF_RENDER=true pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a613d863ac8325aa9ae54808409e6f