### PR TITLE
Add tri-merge mismatch rule validator and deterministic action tag test

### DIFF
--- a/tests/policy/test_tri_merge_validator.py
+++ b/tests/policy/test_tri_merge_validator.py
@@ -18,3 +18,10 @@ def test_validator_detects_missing_rule(monkeypatch) -> None:
     with pytest.raises(ValueError):
         validators.validate_tri_merge_mismatch_rules(rulebook)
     _reset_cache()
+
+
+def test_rulebook_has_rules_for_all_tri_merge_mismatches() -> None:
+    _reset_cache()
+    rulebook = policy_loader.load_rulebook()
+    validators.validate_tri_merge_mismatch_rules(rulebook)
+    _reset_cache()

--- a/tests/strategy/test_rule_evaluation.py
+++ b/tests/strategy/test_rule_evaluation.py
@@ -46,3 +46,16 @@ def test_tri_merge_presence_rule() -> None:
     result = evaluate_rules("", {}, rb, tri)
     assert result["rule_hits"] == ["TM_PRESENCE"]
     assert result["tri_merge"]["evidence_snapshot_id"] == "snap1"
+
+
+def test_rule_evaluation_stable_action_tag() -> None:
+    rb = load_rulebook()
+    facts = {
+        "identity_theft": True,
+        "has_id_theft_affidavit": True,
+        "type": "collection",
+        "days_since_first_contact": 10,
+    }
+    res1 = evaluate_rules("", facts, rb)
+    res2 = evaluate_rules("", facts, rb)
+    assert res1["action_tag"] == res2["action_tag"]


### PR DESCRIPTION
## Summary
- ensure every tri-merge mismatch type has a rule with matching `source_mismatch`
- cover validator in tests and verify rule evaluation selects stable `action_tag`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a614ec0864832580eb9a1eb5334af0