### PR TITLE
Add letter templates and router configuration

### DIFF
--- a/letters/templates/dispute_letter_template.html
+++ b/letters/templates/dispute_letter_template.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <p>Dear {{ bureau }},</p>
+    <p>This is a dispute letter.</p>
+  </body>
+</html>

--- a/letters/templates/fraud_dispute_letter_template.html
+++ b/letters/templates/fraud_dispute_letter_template.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <p>Creditor: {{ creditor_name }}</p>
+    <p>Account: {{ account_number_masked }}</p>
+    <p>Bureau: {{ bureau }}</p>
+    <p>{{ legal_safe_summary }}</p>
+    <p>Identity theft: {{ is_identity_theft }}</p>
+  </body>
+</html>

--- a/letters/templates/goodwill_letter_template.html
+++ b/letters/templates/goodwill_letter_template.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <p>Dear {{ creditor }},</p>
+    <p>This is a goodwill request letter.</p>
+  </body>
+</html>

--- a/letters/templates/instruction_template.html
+++ b/letters/templates/instruction_template.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <p>{{ client_name }}</p>
+    <p>Date: {{ date }}</p>
+    <p>Accounts: {{ accounts_summary }}</p>
+    <p>Actions: {{ per_account_actions }}</p>
+  </body>
+</html>

--- a/router/config_validator.py
+++ b/router/config_validator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path(__file__).with_name("template_config.yaml")
+
+
+def validate() -> None:
+    with CONFIG_PATH.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    errors = []
+    for tag, templates in data.items():
+        if not templates:
+            errors.append(f"action_tag '{tag}' has no candidate templates")
+            continue
+        for entry in templates:
+            if "required_fields" not in entry or not entry["required_fields"]:
+                tpl = entry.get("template", "<unknown>")
+                errors.append(
+                    f"template '{tpl}' missing required_fields for action_tag '{tag}'"
+                )
+
+    if errors:
+        raise SystemExit("Config validation failed:\n" + "\n".join(errors))
+
+
+if __name__ == "__main__":
+    validate()

--- a/router/template_config.yaml
+++ b/router/template_config.yaml
@@ -1,0 +1,23 @@
+dispute:
+  - template: dispute_letter_template.html
+    required_fields:
+      - bureau
+goodwill:
+  - template: goodwill_letter_template.html
+    required_fields:
+      - creditor
+instruction:
+  - template: instruction_template.html
+    required_fields:
+      - client_name
+      - date
+      - accounts_summary
+      - per_account_actions
+fraud_dispute:
+  - template: fraud_dispute_letter_template.html
+    required_fields:
+      - creditor_name
+      - account_number_masked
+      - bureau
+      - legal_safe_summary
+      - is_identity_theft


### PR DESCRIPTION
## Summary
- add minimal letter templates for dispute, goodwill, instruction, and fraud dispute
- map action tags to templates and required fields via router/template_config.yaml
- implement router/config_validator.py to ensure templates and required fields are defined

## Testing
- `pre-commit run --files router/config_validator.py router/template_config.yaml letters/templates/dispute_letter_template.html letters/templates/goodwill_letter_template.html letters/templates/fraud_dispute_letter_template.html letters/templates/instruction_template.html`
- `pytest tests/letters/test_letter_pipeline_golden.py`


------
https://chatgpt.com/codex/tasks/task_b_68a61894fd98832593afb1b8b876ff0c