### PR TITLE
Include template names in router candidate metrics

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -199,19 +199,25 @@ def select_template(
         )
 
     if template_path:
+        template_name = os.path.basename(template_path)
         # Emit both legacy and tag-specific router metrics for transition
         if phase == "candidate":
             emit_counter("router.candidate_selected")  # deprecated
             if tag:
                 emit_counter(f"router.candidate_selected.{tag}")
+                emit_counter(
+                    f"router.candidate_selected.{tag}.{template_name}"
+                )
         elif phase in {"final", "finalize"}:
             emit_counter("router.finalized")  # deprecated
             if tag:
                 emit_counter(f"router.finalized.{tag}")
 
-    if missing_fields:
-        for field in missing_fields:
-            emit_counter(f"router.missing_fields.{tag}.{template_path}.{field}")
+        if missing_fields:
+            for field in missing_fields:
+                emit_counter(
+                    f"router.missing_fields.{tag}.{template_name}.{field}"
+                )
 
     return TemplateDecision(
         template_path=template_path,

--- a/docs/letters_router.md
+++ b/docs/letters_router.md
@@ -62,3 +62,20 @@ These fields enrich the payload but are not mandatory:
 
 Extending the router generally involves adding a new strategy module
 and mapping it in `services/letters/router.py`.
+
+## Metrics
+
+- `router.candidate_selected.{action_tag}.{template_name}` – emitted for each
+  candidate template selection.
+- `router.missing_fields.{action_tag}.{template_name}.{field}` – emitted for
+  every required field absent from a candidate.
+
+Cardinality is bounded by the finite sets of action tags, template names and
+required field identifiers.
+
+### Grafana / Kibana panels
+
+- **Candidate selection** – count of `router.candidate_selected.*` by tag and
+  template. Alert if a tag registers zero selections for an hour.
+- **Missing field heatmap** – sum of `router.missing_fields.*` grouped by tag
+  and field to surface validation gaps.

--- a/tests/letters/test_candidate_routing_tri_merge.py
+++ b/tests/letters/test_candidate_routing_tri_merge.py
@@ -67,6 +67,12 @@ def test_candidate_routing_emits_missing_fields_after_stage_2_5(
     tag = ctx["action_tag"]
     assert counters.get("router.candidate_selected") == 1
     assert counters.get(f"router.candidate_selected.{tag}") == 1
+    assert (
+        counters.get(
+            f"router.candidate_selected.{tag}.{template}"
+        )
+        == 1
+    )
     for field in decision.missing_fields:
         key = f"router.missing_fields.{tag}.{template}.{field}"
         assert counters.get(key) == 1

--- a/tests/letters/test_letter_pipeline_golden.py
+++ b/tests/letters/test_letter_pipeline_golden.py
@@ -196,6 +196,12 @@ def test_letter_pipeline_golden(scenario):
     if template:
         assert counters.get("router.candidate_selected") == 1
         assert counters.get(f"router.candidate_selected.{tag}") == 1
+        assert (
+            counters.get(
+                f"router.candidate_selected.{tag}.{template}"
+            )
+            == 1
+        )
         assert counters.get("router.finalized") == 1
         assert counters.get(f"router.finalized.{tag}") == 1
     else:

--- a/tests/test_instruction_metrics.py
+++ b/tests/test_instruction_metrics.py
@@ -43,6 +43,9 @@ def test_instruction_metrics_emitted(monkeypatch, tmp_path):
     counters = get_counters()
     assert counters.get("router.candidate_selected")
     assert counters.get("router.candidate_selected.instruction")
+    assert counters.get(
+        "router.candidate_selected.instruction.instruction_template.html"
+    )
     assert counters.get("router.finalized")
     assert counters.get("router.finalized.instruction")
     assert counters.get("letter_template_selected.instruction_template.html")

--- a/tests/test_instruction_validation.py
+++ b/tests/test_instruction_validation.py
@@ -43,6 +43,9 @@ def test_instruction_validation_missing_actions(monkeypatch, tmp_path):
     # Router metrics still emitted
     assert counters.get("router.candidate_selected")
     assert counters.get("router.candidate_selected.instruction")
+    assert counters.get(
+        "router.candidate_selected.instruction.instruction_template.html"
+    )
     assert counters.get("router.finalized")
     assert counters.get("router.finalized.instruction")
     # No render should occur when validation fails


### PR DESCRIPTION
## Summary
- Emit `router.candidate_selected.{action_tag}.{template_name}` metrics during candidate routing
- Tag missing field counters with template names
- Document router metric cardinality and suggested dashboards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a61be5c3108325acfa47f10257c745