### PR TITLE
Add routing templates for new dispute types

### DIFF
--- a/letters/templates/duplicate_memo.html
+++ b/letters/templates/duplicate_memo.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>This dispute was marked as a duplicate and no letter was generated.</p>
+  </body>
+</html>

--- a/letters/templates/general_letter_template.html
+++ b/letters/templates/general_letter_template.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>To: {{ recipient }}</p>
+  </body>
+</html>

--- a/letters/templates/inquiry_dispute_letter_template.html
+++ b/letters/templates/inquiry_dispute_letter_template.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <p>Creditor: {{ inquiry_creditor_name }}</p>
+    <p>Account: {{ account_number_masked }}</p>
+    <p>Bureau: {{ bureau }}</p>
+    <p>{{ legal_safe_summary }}</p>
+    <p>Inquiry date: {{ inquiry_date }}</p>
+  </body>
+</html>

--- a/letters/templates/medical_dispute_letter_template.html
+++ b/letters/templates/medical_dispute_letter_template.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <p>Creditor: {{ creditor_name }}</p>
+    <p>Account: {{ account_number_masked }}</p>
+    <p>Bureau: {{ bureau }}</p>
+    <p>{{ legal_safe_summary }}</p>
+    <p>Amount: {{ amount }}</p>
+    <p>Status: {{ medical_status }}</p>
+  </body>
+</html>

--- a/letters/templates/personal_info_correction_template.html
+++ b/letters/templates/personal_info_correction_template.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <p>{{ client_name }}</p>
+    <p>{{ client_address_lines }}</p>
+    <p>{{ date_of_birth }}</p>
+    <p>{{ ssn_last4 }}</p>
+    <p>{{ legal_safe_summary }}</p>
+  </body>
+</html>

--- a/router/template_config.yaml
+++ b/router/template_config.yaml
@@ -6,13 +6,6 @@ goodwill:
   - template: goodwill_letter_template.html
     required_fields:
       - creditor
-instruction:
-  - template: instruction_template.html
-    required_fields:
-      - client_name
-      - date
-      - accounts_summary
-      - per_account_actions
 fraud_dispute:
   - template: fraud_dispute_letter_template.html
     required_fields:
@@ -21,3 +14,43 @@ fraud_dispute:
       - bureau
       - legal_safe_summary
       - is_identity_theft
+personal_info_correction:
+  - template: personal_info_correction_template.html
+    required_fields:
+      - client_name
+      - client_address_lines
+      - date_of_birth
+      - ssn_last4
+      - legal_safe_summary
+inquiry_dispute:
+  - template: inquiry_dispute_letter_template.html
+    required_fields:
+      - inquiry_creditor_name
+      - account_number_masked
+      - bureau
+      - legal_safe_summary
+      - inquiry_date
+medical_dispute:
+  - template: medical_dispute_letter_template.html
+    required_fields:
+      - creditor_name
+      - account_number_masked
+      - bureau
+      - legal_safe_summary
+      - amount
+      - medical_status
+custom_letter:
+  - template: general_letter_template.html
+    required_fields:
+      - recipient
+instruction:
+  - template: instruction_template.html
+    required_fields:
+      - client_name
+      - date
+      - accounts_summary
+      - per_account_actions
+duplicate:
+  - template: duplicate_memo.html
+    required_fields:
+      - memo

--- a/tests/letters/test_candidate_routing.py
+++ b/tests/letters/test_candidate_routing.py
@@ -1,0 +1,121 @@
+import pytest
+
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+from backend.core.letters.router import select_template
+
+
+PII_FIELDS = {
+    "client_name",
+    "client_address_lines",
+    "date_of_birth",
+    "ssn_last4",
+    "legal_safe_summary",
+}
+
+INQUIRY_FIELDS = {
+    "inquiry_creditor_name",
+    "account_number_masked",
+    "bureau",
+    "legal_safe_summary",
+    "inquiry_date",
+}
+
+MEDICAL_FIELDS = {
+    "creditor_name",
+    "account_number_masked",
+    "bureau",
+    "legal_safe_summary",
+    "amount",
+    "medical_status",
+}
+
+FRAUD_FIELDS = {
+    "creditor_name",
+    "account_number_masked",
+    "bureau",
+    "legal_safe_summary",
+    "is_identity_theft",
+}
+
+
+@pytest.mark.parametrize(
+    "tag,template,fields",
+    [
+        (
+            "personal_info_correction",
+            "personal_info_correction_template.html",
+            PII_FIELDS,
+        ),
+        (
+            "inquiry_dispute",
+            "inquiry_dispute_letter_template.html",
+            INQUIRY_FIELDS,
+        ),
+        (
+            "medical_dispute",
+            "medical_dispute_letter_template.html",
+            MEDICAL_FIELDS,
+        ),
+        ("fraud_dispute", "fraud_dispute_letter_template.html", FRAUD_FIELDS),
+        ("custom_letter", "general_letter_template.html", {"recipient"}),
+    ],
+)
+def test_candidate_routing_missing_fields(monkeypatch, tag, template, fields):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+
+    decision = select_template(tag, {}, phase="candidate")
+
+    assert decision.template_path == template
+    assert set(decision.missing_fields) == fields
+
+    counters = get_counters()
+    assert counters.get("router.candidate_selected") == 1
+    assert counters.get(f"router.candidate_selected.{tag}") == 1
+    assert counters.get(f"router.candidate_selected.{tag}.{template}") == 1
+    for field in fields:
+        key = f"router.missing_fields.{tag}.{template}.{field}"
+        assert counters.get(key) == 1
+
+
+def test_instruction_skips_validation(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+
+    decision = select_template("instruction", {}, phase="candidate")
+
+    assert decision.template_path == "instruction_template.html"
+    assert decision.missing_fields == []
+
+    counters = get_counters()
+    assert counters.get("router.candidate_selected") == 1
+    assert counters.get("router.candidate_selected.instruction") == 1
+    assert (
+        counters.get(
+            "router.candidate_selected.instruction.instruction_template.html"
+        )
+        == 1
+    )
+    assert not any(
+        key.startswith("router.missing_fields.instruction") for key in counters
+    )
+
+
+def test_duplicate_emits_metrics(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+
+    decision = select_template("duplicate", {}, phase="candidate")
+
+    assert decision.template_path is None
+    assert decision.missing_fields == []
+    assert decision.router_mode == "memo"
+
+    counters = get_counters()
+    assert counters.get("router.skipped.duplicate") == 1
+    assert counters.get("router.candidate_selected") == 1
+    assert counters.get("router.candidate_selected.duplicate") == 1
+    assert not any(
+        key.startswith("router.candidate_selected.duplicate.")
+        for key in counters
+    )


### PR DESCRIPTION
## Summary
- add templates and required field config for personal info correction, inquiry, medical, custom, instruction and duplicate tags
- update router to emit metrics for duplicate tags and skip validation for instructions
- test candidate routing edge cases across new tags

## Testing
- `python router/config_validator.py`
- `pytest tests/letters/test_candidate_routing.py tests/letters/test_candidate_routing_tri_merge.py`

------
https://chatgpt.com/codex/tasks/task_b_68a61d84ff348325b97be6f0a2697434