### PR TITLE
feat(router): add parallel batch routing and template cache

### DIFF
--- a/docs/router_benchmark.md
+++ b/docs/router_benchmark.md
@@ -1,0 +1,15 @@
+# Router Benchmark
+
+The `scripts/benchmark_router.py` utility compares sequential routing using
+`select_template` against the new parallel `route_accounts` helper.
+
+```
+$ PYTHONPATH=. LETTERS_ROUTER_PHASED=1 python scripts/benchmark_router.py 1000
+sequential_ms=5.54
+parallel_ms=12.90
+```
+
+On synthetic data with 1,000 accounts the parallel version is slower due to the
+thread‑pool overhead. For workloads where template selection performs heavier
+I/O, the batch API allows the router to take advantage of multiple CPU cores and
+can provide noticeable speedups.

--- a/scripts/benchmark_router.py
+++ b/scripts/benchmark_router.py
@@ -1,0 +1,33 @@
+import time
+
+from backend.core.letters.router import route_accounts, select_template
+
+
+def _build_accounts(n: int):
+    base_ctx = {
+        "bureau": "experian",
+        "creditor_name": "Acme",
+        "account_number_masked": "1234",
+        "legal_safe_summary": "ok",
+        "is_identity_theft": True,
+    }
+    return [("fraud_dispute", dict(base_ctx), f"sess-{i}") for i in range(n)]
+
+
+def main(num: int = 100) -> None:
+    accounts = _build_accounts(num)
+    start = time.perf_counter()
+    for tag, ctx, sid in accounts:
+        select_template(tag, ctx, "candidate", sid)
+    sequential = (time.perf_counter() - start) * 1000
+
+    start = time.perf_counter()
+    route_accounts(accounts, phase="candidate")
+    parallel = (time.perf_counter() - start) * 1000
+
+    print(f"sequential_ms={sequential:.2f}")
+    print(f"parallel_ms={parallel:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_router_batch.py
+++ b/tests/test_router_batch.py
@@ -1,0 +1,30 @@
+import os
+
+from backend.analytics.analytics_tracker import reset_counters
+from backend.core.letters.router import route_accounts, select_template
+
+
+def _setup_env():
+    os.environ["LETTERS_ROUTER_PHASED"] = "1"
+    reset_counters()
+
+
+def test_route_accounts_matches_sequential(monkeypatch):
+    _setup_env()
+    accounts = [
+        (
+            "fraud_dispute",
+            {
+                "bureau": "experian",
+                "creditor_name": "Acme",
+                "account_number_masked": "1234",
+                "legal_safe_summary": "ok",
+                "is_identity_theft": True,
+            },
+            "s1",
+        ),
+        ("custom_letter", {"recipient": "Friend"}, "s2"),
+    ]
+    seq = [select_template(tag, ctx, "candidate", sid) for tag, ctx, sid in accounts]
+    par = route_accounts(accounts, phase="candidate", max_workers=2)
+    assert [d.template_path for d in par] == [d.template_path for d in seq]


### PR DESCRIPTION
## Summary
- cache candidate templates with an LRU to avoid repeated disk scans
- add thread-safe router cache and `route_accounts` helper for parallel routing
- guard analytics metrics with locks and document benchmark results

## Testing
- `pre-commit run --files letters/candidate_router.py backend/core/letters/router.py backend/analytics/analytics_tracker.py scripts/benchmark_router.py docs/router_benchmark.md tests/test_router_batch.py`
- `PYTHONPATH=. pytest tests/test_letter_template_router.py tests/letters/test_candidate_routing.py tests/test_router_batch.py`


------
https://chatgpt.com/codex/tasks/task_b_68a62433c3508325acf051ccd847d1cc