### PR TITLE
docs: add router README

### DIFF
--- a/docs/router/README.md
+++ b/docs/router/README.md
@@ -1,0 +1,43 @@
+# Template Routing
+
+The letter router selects an HTML template for each `action_tag` based on
+available candidates and bureau evidence.
+
+## Routing flow
+1. Load candidate templates for the tag from `router/template_config.yaml`.
+2. If the evidence source matches the requested credit reporting agency (CRA),
+   templates whose filename includes `_bureau_<bureau>` are tried first.
+3. Otherwise the router falls back to a generic template for the tag.
+4. When no candidate exists, the router defaults to `default_dispute.html` and
+   labels the metric tag as `default`.
+5. A deterministic hash of `(action_tag, template)` is written to the audit log
+   when an `AuditLogger` is supplied.
+
+## Metrics
+- `router.candidate_selected{tag}` – emitted for every selection, with `tag`
+  set to the action tag or `default` on fallback.
+
+## Action tags
+| action_tag | candidate templates | required fields |
+|---|---|---|
+| dispute | `dispute_letter_template.html` | `bureau` |
+| goodwill | `goodwill_letter_template.html` | `creditor` |
+| fraud_dispute | `fraud_dispute_letter_template.html` | `creditor_name`, `account_number_masked`, `bureau`, `legal_safe_summary`, `is_identity_theft` |
+| personal_info_correction | `personal_info_correction_template.html` | `client_name`, `client_address_lines`, `date_of_birth`, `ssn_last4`, `legal_safe_summary` |
+| inquiry_dispute | `inquiry_dispute_letter_template.html` | `inquiry_creditor_name`, `account_number_masked`, `bureau`, `legal_safe_summary`, `inquiry_date` |
+| medical_dispute | `medical_dispute_letter_template.html` | `creditor_name`, `account_number_masked`, `bureau`, `legal_safe_summary`, `amount`, `medical_status` |
+| custom_letter | `general_letter_template.html` | `recipient` |
+| instruction | `instruction_template.html` | `client_name`, `date`, `accounts_summary`, `per_account_actions` |
+| duplicate | `duplicate_memo.html` | `memo` |
+
+## Example
+```python
+from backend.core.letters.router import select_template
+
+decision = select_template("dispute", {"bureau": "experian"}, phase="candidate")
+print(decision.template_path)
+```
+
+For deterministic rule evaluation and audit log details, see
+[Stage 2.5](../STAGE_2_5.md) and the
+[Post-Refactor Audit](../POST_REFACTOR_AUDIT.md).


### PR DESCRIPTION
## Summary
- document template routing flow and CRA-first selection
- list action_tag templates and required fields
- show example `select_template(..., phase="candidate")` usage and link to determinism/audit docs

## Testing
- `pytest tests/test_docs_updated.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a625dddeac8325a230c0d0b0588c04