### PR TITLE
Add candidate finalize flow integration test

### DIFF
--- a/tests/pipeline/goldens/candidate_finalize_flow.json
+++ b/tests/pipeline/goldens/candidate_finalize_flow.json
@@ -1,0 +1,21 @@
+{
+  "candidate_template": "pay_for_delete_letter_template.html",
+  "final_template": "pay_for_delete_letter_template.html",
+  "candidate_missing_fields": ["collector_name", "offer_terms"],
+  "final_missing_fields": [],
+  "candidate_missing_heatmap": {
+    "pay_for_delete": {
+      "collector_name": 1,
+      "offer_terms": 1
+    }
+  },
+  "counters": {
+    "router.candidate_selected": 1,
+    "router.candidate_selected.pay_for_delete": 1,
+    "router.candidate_selected.pay_for_delete.pay_for_delete_letter_template.html": 1,
+    "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.collector_name": 1,
+    "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.offer_terms": 1,
+    "router.finalized": 1,
+    "router.finalized.pay_for_delete": 1
+  }
+}

--- a/tests/pipeline/test_candidate_finalize_flow.py
+++ b/tests/pipeline/test_candidate_finalize_flow.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from backend.analytics.analytics_tracker import (
+    get_counters,
+    get_missing_fields_heatmap,
+    reset_counters,
+)
+from backend.core.letters.router import select_template
+from backend.core.logic.letters.utils import populate_required_fields
+
+
+def test_candidate_finalize_flow_golden(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+
+    ctx = {"account_number_masked": "****1234", "legal_safe_summary": "Summary"}
+
+    candidate_decision = select_template("pay_for_delete", ctx, phase="candidate")
+    candidate_heatmap = get_missing_fields_heatmap()
+
+    acc = {"action_tag": "pay_for_delete", "name": "ABC Collections"}
+    strat = {"offer_terms": "50% settlement"}
+    populate_required_fields(acc, strat)
+    ctx.update({"collector_name": acc["collector_name"], "offer_terms": acc["offer_terms"]})
+
+    final_decision = select_template("pay_for_delete", ctx, phase="finalize")
+
+    assert len(final_decision.missing_fields) < len(candidate_decision.missing_fields)
+
+    result = {
+        "candidate_template": candidate_decision.template_path,
+        "final_template": final_decision.template_path,
+        "candidate_missing_fields": sorted(candidate_decision.missing_fields),
+        "final_missing_fields": final_decision.missing_fields,
+        "candidate_missing_heatmap": candidate_heatmap,
+        "counters": get_counters(),
+    }
+
+    golden_path = Path("tests/pipeline/goldens/candidate_finalize_flow.json")
+    expected = json.loads(golden_path.read_text())
+    assert result == expected


### PR DESCRIPTION
## Summary
- test candidate routing and finalize routing to ensure strategy merges resolve missing fields
- add golden fixture for deterministic template selections and metrics

## Testing
- `pytest tests/pipeline/test_candidate_finalize_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a62766089883258501b6c13ed600d8