### PR TITLE
feat(router): support CRA-specific dispute templates

### DIFF
--- a/tests/letters/test_letter_template_router.py
+++ b/tests/letters/test_letter_template_router.py
@@ -1,0 +1,35 @@
+import pytest
+from backend.core.letters.router import select_template
+
+
+def _ctx(bureau: str) -> dict:
+    return {
+        "creditor_name": "Creditor",
+        "account_number_masked": "1234",
+        "bureau": bureau,
+        "legal_safe_summary": "summary",
+    }
+
+
+def test_finalize_prefers_cra_specific_template(monkeypatch, tmp_path):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    from backend.core.letters import router as router_mod
+    router_mod._ROUTER_CACHE.clear()
+    (tmp_path / "experian_bureau_dispute_letter_template.html").write_text("dummy")
+    monkeypatch.setattr(router_mod, "TEMPLATES_DIRS", [tmp_path])
+
+    decision = select_template("bureau_dispute", _ctx("Experian"), phase="finalize")
+
+    assert decision.template_path == "experian_bureau_dispute_letter_template.html"
+
+
+def test_finalize_falls_back_to_generic(monkeypatch, tmp_path):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    from backend.core.letters import router as router_mod
+    router_mod._ROUTER_CACHE.clear()
+    (tmp_path / "bureau_dispute_letter_template.html").write_text("dummy")
+    monkeypatch.setattr(router_mod, "TEMPLATES_DIRS", [tmp_path])
+
+    decision = select_template("bureau_dispute", _ctx("Equifax"), phase="finalize")
+
+    assert decision.template_path == "bureau_dispute_letter_template.html"


### PR DESCRIPTION
## Summary
- prefer bureau-specific templates when finalizing disputes and fall back to generic
- persist routing decisions keyed by session, action tag, and phase
- add tests for CRA-specific finalize routing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a62af9e05c8325ad2616c93dfc030f