### PR TITLE
Validate finalize-phase letter instruction checks

### DIFF
--- a/backend/core/letters/router.py
+++ b/backend/core/letters/router.py
@@ -262,10 +262,12 @@ def select_template(
     log_canary_decision("canary", template_path or "unknown")
 
     missing_fields: List[str] = []
-    if template_path and (tag != "instruction" or phase == "finalize"):
+    if template_path and phase == "finalize":
         missing_fields = validators.validate_required_fields(
             template_path, ctx, required, validators.CHECKLIST
         )
+        missing_fields += validators.validate_substance(template_path, ctx)
+        missing_fields = sorted(set(missing_fields))
 
     if template_path:
         template_name = os.path.basename(template_path)

--- a/backend/core/letters/validators.py
+++ b/backend/core/letters/validators.py
@@ -15,6 +15,26 @@ CHECKLIST: Dict[str, List[str]] = {
         "accounts_summary",
         "per_account_actions",
     ],
+    "bureau_dispute_letter_template.html": [
+        "creditor_name",
+        "account_number_masked",
+        "bureau",
+        "legal_safe_summary",
+    ],
+    "mov_letter_template.html": [
+        "creditor_name",
+        "account_number_masked",
+        "legal_safe_summary",
+        "cra_last_result",
+        "days_since_cra_result",
+    ],
+    "personal_info_correction_letter_template.html": [
+        "client_name",
+        "client_address_lines",
+        "date_of_birth",
+        "ssn_last4",
+        "legal_safe_summary",
+    ],
 }
 
 
@@ -35,12 +55,13 @@ SUBSTANCE_CHECKLIST: Dict[str, Dict[str, str | None]] = {
     },
     "mov_letter_template.html": {
         "reinvestigation_request": r"reinvestigat",
+        "method_of_verification": r"method\s+of\s+verif",
         "cra_last_result": None,
         "days_since_cra_result": None,
     },
     "bureau_dispute_letter_template.html": {
         "fcra_611": r"611",
-        "investigation_request": r"reinvestigat",
+        "reinvestigation_request": r"reinvestigat",
         "account_number_masked": None,
     },
     "dispute_letter_template.html": {

--- a/tests/letters/test_candidate_routing.py
+++ b/tests/letters/test_candidate_routing.py
@@ -10,6 +10,7 @@ PII_FIELDS = {
     "date_of_birth",
     "ssn_last4",
     "legal_safe_summary",
+    "update_request",
 }
 
 INQUIRY_FIELDS = {
@@ -35,6 +36,10 @@ FRAUD_FIELDS = {
     "bureau",
     "legal_safe_summary",
     "is_identity_theft",
+    "fcra_605b",
+    "ftc_report",
+    "block_or_remove_request",
+    "response_window",
 }
 
 
@@ -60,19 +65,18 @@ FRAUD_FIELDS = {
         ("custom_letter", "general_letter_template.html", {"recipient"}),
     ],
 )
-def test_candidate_routing_missing_fields(monkeypatch, tag, template, fields):
+def test_finalize_routing_missing_fields(monkeypatch, tag, template, fields):
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
     reset_counters()
 
-    decision = select_template(tag, {}, phase="candidate")
+    decision = select_template(tag, {}, phase="finalize")
 
     assert decision.template_path == template
     assert set(decision.missing_fields) == fields
 
     counters = get_counters()
-    assert counters.get("router.candidate_selected") == 1
-    assert counters.get(f"router.candidate_selected.{tag}") == 1
-    assert counters.get(f"router.candidate_selected.{tag}.{template}") == 1
+    assert counters.get("router.finalized") == 1
+    assert counters.get(f"router.finalized.{tag}") == 1
     for field in fields:
         key = f"router.missing_fields.{tag}.{template}.{field}"
         assert counters.get(key) == 1

--- a/tests/letters/test_instruction_validation.py
+++ b/tests/letters/test_instruction_validation.py
@@ -1,0 +1,26 @@
+import pytest
+
+from backend.core.letters.router import select_template
+from backend.analytics.analytics_tracker import reset_counters
+
+
+def test_missing_field_failure(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+    decision = select_template("bureau_dispute", {}, phase="finalize")
+    assert "bureau" in decision.missing_fields
+
+
+def test_substance_failure(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    reset_counters()
+    ctx = {
+        "creditor_name": "Cred",
+        "account_number_masked": "1234",
+        "legal_safe_summary": "summary",
+        "cra_last_result": "result",
+        "days_since_cra_result": 30,
+    }
+    decision = select_template("mov", ctx, phase="finalize")
+    assert "reinvestigation_request" in decision.missing_fields
+    assert "method_of_verification" in decision.missing_fields

--- a/tests/pipeline/goldens/candidate_finalize_flow.json
+++ b/tests/pipeline/goldens/candidate_finalize_flow.json
@@ -1,21 +1,27 @@
 {
-  "candidate_template": "pay_for_delete_letter_template.html",
+  "initial_template": "pay_for_delete_letter_template.html",
   "final_template": "pay_for_delete_letter_template.html",
-  "candidate_missing_fields": ["collector_name", "offer_terms"],
+  "initial_missing_fields": [
+    "collector_name",
+    "deletion_clause",
+    "offer_terms",
+    "payment_clause"
+  ],
   "final_missing_fields": [],
-  "candidate_missing_heatmap": {
+  "initial_missing_heatmap": {
     "pay_for_delete": {
       "collector_name": 1,
-      "offer_terms": 1
+      "offer_terms": 1,
+      "deletion_clause": 1,
+      "payment_clause": 1
     }
   },
   "counters": {
-    "router.candidate_selected": 1,
-    "router.candidate_selected.pay_for_delete": 1,
-    "router.candidate_selected.pay_for_delete.pay_for_delete_letter_template.html": 1,
+    "router.finalized": 2,
+    "router.finalized.pay_for_delete": 2,
     "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.collector_name": 1,
     "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.offer_terms": 1,
-    "router.finalized": 1,
-    "router.finalized.pay_for_delete": 1
+    "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.deletion_clause": 1,
+    "router.missing_fields.pay_for_delete.pay_for_delete_letter_template.html.payment_clause": 1
   }
 }

--- a/tests/pipeline/test_candidate_finalize_flow.py
+++ b/tests/pipeline/test_candidate_finalize_flow.py
@@ -16,24 +16,24 @@ def test_candidate_finalize_flow_golden(monkeypatch):
 
     ctx = {"account_number_masked": "****1234", "legal_safe_summary": "Summary"}
 
-    candidate_decision = select_template("pay_for_delete", ctx, phase="candidate")
-    candidate_heatmap = get_missing_fields_heatmap()
+    pre_decision = select_template("pay_for_delete", ctx, phase="finalize")
+    pre_heatmap = get_missing_fields_heatmap()
 
     acc = {"action_tag": "pay_for_delete", "name": "ABC Collections"}
-    strat = {"offer_terms": "50% settlement"}
+    strat = {"offer_terms": "Pay to delete"}
     populate_required_fields(acc, strat)
     ctx.update({"collector_name": acc["collector_name"], "offer_terms": acc["offer_terms"]})
 
     final_decision = select_template("pay_for_delete", ctx, phase="finalize")
 
-    assert len(final_decision.missing_fields) < len(candidate_decision.missing_fields)
+    assert len(final_decision.missing_fields) < len(pre_decision.missing_fields)
 
     result = {
-        "candidate_template": candidate_decision.template_path,
+        "initial_template": pre_decision.template_path,
         "final_template": final_decision.template_path,
-        "candidate_missing_fields": sorted(candidate_decision.missing_fields),
+        "initial_missing_fields": sorted(pre_decision.missing_fields),
         "final_missing_fields": final_decision.missing_fields,
-        "candidate_missing_heatmap": candidate_heatmap,
+        "initial_missing_heatmap": pre_heatmap,
         "counters": get_counters(),
     }
 

--- a/tests/test_letter_template_router.py
+++ b/tests/test_letter_template_router.py
@@ -91,26 +91,41 @@ def test_router_basic_mappings(monkeypatch):
 
 def test_missing_fields(monkeypatch):
     monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
-    decision = select_template("goodwill", {}, phase="candidate")
-    assert decision.missing_fields == ["creditor"]
-    decision = select_template("goodwill", {"creditor": "XYZ"}, phase="candidate")
+    decision = select_template("goodwill", {}, phase="finalize")
+    assert set(decision.missing_fields) == {
+        "creditor",
+        "non_promissory_tone",
+        "positive_history_reference",
+        "discretionary_request",
+        "no_admission",
+    }
+    decision = select_template(
+        "goodwill",
+        {
+            "creditor": "XYZ",
+            "legal_safe_summary": "goodwill positive request without admit",
+        },
+        phase="finalize",
+    )
     assert decision.missing_fields == []
-    decision = select_template("bureau_dispute", {}, phase="candidate")
-    assert decision.missing_fields == [
+    decision = select_template("bureau_dispute", {}, phase="finalize")
+    assert set(decision.missing_fields) == {
         "creditor_name",
         "account_number_masked",
         "bureau",
         "legal_safe_summary",
-    ]
+        "fcra_611",
+        "reinvestigation_request",
+    }
     decision = select_template(
         "bureau_dispute",
         {
             "creditor_name": "Creditor",
             "account_number_masked": "1234",
             "bureau": "Experian",
-            "legal_safe_summary": "summary",
+            "legal_safe_summary": "Please reinvestigate under section 611",
         },
-        phase="candidate",
+        phase="finalize",
     )
     assert decision.missing_fields == []
 

--- a/tests/test_strategy_merge_populates_fields.py
+++ b/tests/test_strategy_merge_populates_fields.py
@@ -17,12 +17,17 @@ def test_strategy_merge_resolves_missing_fields(monkeypatch):
         "account_number_masked": "****1234",
         "legal_safe_summary": "Summary",
     }
-    decision = select_template("pay_for_delete", ctx, phase="candidate")
-    assert set(decision.missing_fields) == {"collector_name", "offer_terms"}
+    decision = select_template("pay_for_delete", ctx, phase="finalize")
+    assert set(decision.missing_fields) == {
+        "collector_name",
+        "offer_terms",
+        "deletion_clause",
+        "payment_clause",
+    }
 
     # Strategy merge fills in required fields
     acc = {"action_tag": "pay_for_delete", "name": "ABC Collections"}
-    strat = {"offer_terms": "50% settlement"}
+    strat = {"offer_terms": "Pay to delete"}
     populate_required_fields(acc, strat)
     ctx.update({
         "collector_name": acc["collector_name"],

--- a/tests/test_substance_validator.py
+++ b/tests/test_substance_validator.py
@@ -66,7 +66,7 @@ def test_mov_substance():
         {
             "creditor_name": "Bank",
             "account_number_masked": "2222",
-            "legal_safe_summary": "Please reinvestigate this account.",
+            "legal_safe_summary": "Please reinvestigate this account and provide the method of verification.",
             "cra_last_result": "verified",
             "days_since_cra_result": "45",
         }


### PR DESCRIPTION
## Summary
- add required-field coverage for bureau dispute, MOV, and personal info correction templates
- expand substance checklist with legal patterns like FCRA 611 and Method of Verification
- run required-field and substance validation at finalize phase and test failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a633b438408325bf18764d8461a4d4