### PR TITLE
Add finalize router test fixtures and pipeline tests

### DIFF
--- a/tests/letters/goldens/router_finalize_debt_validation_negative.json
+++ b/tests/letters/goldens/router_finalize_debt_validation_negative.json
@@ -1,0 +1,9 @@
+{
+  "action_tag": "debt_validation",
+  "initial_ctx": {
+    "legal_safe_summary": "FDCPA 1692g requires validation; please respond within 30 days.",
+    "days_since_first_contact": "5"
+  },
+  "template": "default_dispute.html",
+  "missing_fields": ["collector_name"]
+}

--- a/tests/letters/goldens/router_finalize_debt_validation_positive.json
+++ b/tests/letters/goldens/router_finalize_debt_validation_positive.json
@@ -1,0 +1,10 @@
+{
+  "action_tag": "debt_validation",
+  "initial_ctx": {
+    "collector_name": "Collector Inc",
+    "legal_safe_summary": "FDCPA 1692g requires validation; please respond within 30 days.",
+    "days_since_first_contact": "5"
+  },
+  "template": "debt_validation_letter_template.html",
+  "golden": "tests/letters/goldens/debt_validation.html"
+}

--- a/tests/letters/goldens/router_finalize_mov_negative.json
+++ b/tests/letters/goldens/router_finalize_mov_negative.json
@@ -1,0 +1,10 @@
+{
+  "action_tag": "mov",
+  "initial_ctx": {
+    "creditor_name": "Bank",
+    "cra_last_result": "verified",
+    "days_since_cra_result": "45"
+  },
+  "template": "default_dispute.html",
+  "missing_fields": ["legal_safe_summary"]
+}

--- a/tests/letters/goldens/router_finalize_mov_positive.json
+++ b/tests/letters/goldens/router_finalize_mov_positive.json
@@ -1,0 +1,11 @@
+{
+  "action_tag": "mov",
+  "initial_ctx": {
+    "creditor_name": "Bank",
+    "legal_safe_summary": "Please reinvestigate this item.",
+    "cra_last_result": "verified",
+    "days_since_cra_result": "45"
+  },
+  "template": "mov_letter_template.html",
+  "golden": "tests/letters/goldens/mov.html"
+}

--- a/tests/letters/goldens/router_finalize_pay_for_delete_negative.json
+++ b/tests/letters/goldens/router_finalize_pay_for_delete_negative.json
@@ -1,0 +1,9 @@
+{
+  "action_tag": "pay_for_delete",
+  "initial_ctx": {
+    "legal_safe_summary": "I will pay if you delete this account.",
+    "offer_terms": "Delete account and we pay 60%."
+  },
+  "template": "default_dispute.html",
+  "missing_fields": ["collector_name"]
+}

--- a/tests/letters/goldens/router_finalize_pay_for_delete_positive.json
+++ b/tests/letters/goldens/router_finalize_pay_for_delete_positive.json
@@ -1,0 +1,10 @@
+{
+  "action_tag": "pay_for_delete",
+  "initial_ctx": {
+    "collector_name": "Collector Inc",
+    "legal_safe_summary": "I will pay if you delete this account.",
+    "offer_terms": "Delete account and we pay 60%."
+  },
+  "template": "pay_for_delete_letter_template.html",
+  "golden": "tests/letters/goldens/pay_for_delete.html"
+}

--- a/tests/letters/test_finalize_router_pipeline.py
+++ b/tests/letters/test_finalize_router_pipeline.py
@@ -1,0 +1,85 @@
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.analytics.analytics_tracker import get_counters, reset_counters
+from backend.core.letters.client_context import format_safe_client_context
+from backend.core.letters.router import select_template
+from backend.core.logic.rendering.letter_rendering import render_dispute_letter_html
+
+BASE_CTX = {
+    "client": {"full_name": "Jane Doe", "address_line": "123 Main St"},
+    "today": "January 1, 2024",
+    "account_number_masked": "1234",
+    "bureau": "Experian",
+}
+
+POSITIVES = [
+    Path("tests/letters/goldens/router_finalize_pay_for_delete_positive.json"),
+    Path("tests/letters/goldens/router_finalize_mov_positive.json"),
+    Path("tests/letters/goldens/router_finalize_debt_validation_positive.json"),
+]
+
+NEGATIVES = [
+    Path("tests/letters/goldens/router_finalize_pay_for_delete_negative.json"),
+    Path("tests/letters/goldens/router_finalize_mov_negative.json"),
+    Path("tests/letters/goldens/router_finalize_debt_validation_negative.json"),
+]
+
+
+def _load_case(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+@pytest.mark.parametrize("path", POSITIVES, ids=[p.stem for p in POSITIVES])
+def test_finalize_router_positive(path: Path):
+    case = _load_case(path)
+    os.environ["LETTERS_ROUTER_PHASED"] = "1"
+    reset_counters()
+
+    ctx = BASE_CTX.copy()
+    ctx.update(case["initial_ctx"])
+    ctx["client_context_sentence"] = format_safe_client_context(case["action_tag"], "", {}, [])
+
+    decision = select_template(case["action_tag"], ctx, phase="finalize")
+    assert decision.template_path == case["template"]
+    assert decision.missing_fields == []
+
+    artifact = render_dispute_letter_html(ctx, decision.template_path)
+    html = re.sub(r"\s+", " ", artifact.html).strip()
+    expected = re.sub(r"\s+", " ", Path(case["golden"]).read_text()).strip()
+    assert html == expected
+
+    counters = get_counters()
+    tag = case["action_tag"]
+    template = case["template"]
+    assert counters.get("router.finalized") == 1
+    assert counters.get(f"router.finalized.{tag}") == 1
+    assert counters.get(f"router.finalized.{tag}.{template}") == 1
+    assert counters.get(f"sanitizer.applied.{template}") == 1
+
+
+@pytest.mark.parametrize("path", NEGATIVES, ids=[p.stem for p in NEGATIVES])
+def test_finalize_router_negative(path: Path):
+    case = _load_case(path)
+    os.environ["LETTERS_ROUTER_PHASED"] = "1"
+    reset_counters()
+
+    ctx = BASE_CTX.copy()
+    ctx.update(case["initial_ctx"])
+    ctx["client_context_sentence"] = format_safe_client_context(case["action_tag"], "", {}, [])
+
+    decision = select_template(case["action_tag"], ctx, phase="finalize")
+    assert decision.template_path == case["template"]
+    assert decision.missing_fields == case["missing_fields"]
+
+    counters = get_counters()
+    tag = case["action_tag"]
+    assert counters.get("router.finalize_errors") == 1
+    assert counters.get("router.finalized") == 1
+    assert counters.get(f"router.finalized.{tag}") == 1
+    assert counters.get(f"router.finalized.{tag}.{case['template']}") == 1
+    assert not any(k.startswith("sanitizer.applied") for k in counters)


### PR DESCRIPTION
## Summary
- add golden positive and negative fixtures for finalize routing cases
- test finalize routing metrics and sanitized output

## Testing
- `pytest tests/letters/test_finalize_router_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a63bfc5b5c83258f82ef7b95879f20