### PR TITLE
Preload templates and regex; add finalize throughput benchmark

### DIFF
--- a/docs/finalize_benchmark.md
+++ b/docs/finalize_benchmark.md
@@ -1,0 +1,12 @@
+# Finalize Benchmark
+
+`backend/analytics/batch_runner.py` provides a `benchmark_finalize` helper to
+measure finalize routing throughput using the `route_accounts` thread pool.
+
+```bash
+$ PYTHONPATH=. LETTERS_ROUTER_PHASED=1 python -c "from backend.analytics.batch_runner import benchmark_finalize; benchmark_finalize(1000)"
+throughput_lps=3169.90
+```
+
+On synthetic data with 1,000 accounts this repo's environment produced the
+above throughput. Actual numbers will vary by hardware and configuration.


### PR DESCRIPTION
## Summary
- Preload Jinja environment and templates in router to cut down per-letter filesystem reads
- Precompile sanitizer regex patterns for thread-safe use across finalize threads
- Add `benchmark_finalize` helper and documentation for measuring finalize throughput

## Testing
- `scripts/run_checks.sh` *(mypy errors in backend/core/logic/report_analysis/tri_merge.py)*
- `pytest` *(21 failing tests: e.g. test_candidate_routing_missing_fields, test_letter_pipeline_golden, etc.)*
- `PYTHONPATH=. LETTERS_ROUTER_PHASED=1 python - <<'PY'
from backend.analytics.batch_runner import benchmark_finalize
benchmark_finalize(1000)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68a642c5c02483258843e00ff37c616d