### PR TITLE
Add strategy plan and account state models

### DIFF
--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -6,6 +6,8 @@ from .client import ClientInfo, ProofDocuments
 from .letter import LetterAccount, LetterArtifact, LetterContext
 from .strategy import Recommendation, StrategyItem, StrategyPlan
 from .strategy_snapshot import StrategySnapshot
+from .strategy_plan_model import StrategyPlan as StrategyPlanModel, Cycle, Step
+from .account_state import AccountState, AccountStatus, StateTransition
 
 __all__ = [
     "Account",
@@ -19,6 +21,12 @@ __all__ = [
     "StrategyPlan",
     "StrategyItem",
     "StrategySnapshot",
+    "StrategyPlanModel",
+    "Cycle",
+    "Step",
+    "AccountState",
+    "AccountStatus",
+    "StateTransition",
     "Recommendation",
     "LetterContext",
     "LetterAccount",

--- a/backend/core/models/account_state.py
+++ b/backend/core/models/account_state.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+
+class AccountStatus(str, Enum):
+    PLANNED = "Planned"
+    SENT = "Sent"
+    CRA_RESPONDED_VERIFIED = "CRA_RespondedVerified"
+    CRA_RESPONDED_UPDATED = "CRA_RespondedUpdated"
+    CRA_RESPONDED_DELETED = "CRA_RespondedDeleted"
+    CRA_RESPONDED_NOCHANGE = "CRA_RespondedNoChange"
+    COMPLETED = "Completed"
+
+
+@dataclass
+class StateTransition:
+    """Record of a state change for auditing."""
+
+    from_status: AccountStatus
+    to_status: AccountStatus
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class AccountState:
+    """Tracks the current state of an account in the strategy pipeline."""
+
+    account_id: str
+    current_cycle: int
+    current_step: int
+    status: AccountStatus
+    last_sent_at: Optional[datetime] = None
+    next_eligible_at: Optional[datetime] = None
+    history: List[StateTransition] = field(default_factory=list)

--- a/backend/core/models/strategy_plan_model.py
+++ b/backend/core/models/strategy_plan_model.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+from uuid import NAMESPACE_URL, uuid5
+
+
+def stable_uuid(*components: str) -> str:
+    """Generate a deterministic UUID5 from the provided components."""
+    name = ":".join(components)
+    return str(uuid5(NAMESPACE_URL, name))
+
+
+@dataclass
+class Step:
+    """Single actionable step within a cycle."""
+
+    allowed_tags: List[str]
+    sla_days: int
+    dependent_on: Optional[str] = None
+    step_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.step_id:
+            comp = ",".join(sorted(self.allowed_tags))
+            comp = f"{comp}|{self.sla_days}|{self.dependent_on or ''}"
+            self.step_id = stable_uuid(comp)
+
+
+@dataclass
+class Cycle:
+    """A cycle groups a collection of steps."""
+
+    steps: List[Step] = field(default_factory=list)
+    cycle_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.cycle_id:
+            step_ids = ",".join(step.step_id for step in self.steps)
+            self.cycle_id = stable_uuid(step_ids)
+
+
+@dataclass
+class StrategyPlan:
+    """A full strategy plan composed of cycles and steps."""
+
+    version: int
+    cycles: List[Cycle] = field(default_factory=list)
+    plan_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.plan_id:
+            cycle_ids = ",".join(cycle.cycle_id for cycle in self.cycles)
+            self.plan_id = stable_uuid(str(self.version), cycle_ids)


### PR DESCRIPTION
## Summary
- define deterministic StrategyPlan schema with cycles and steps
- add AccountState and related enums for tracking account progress
- expose new models through core models package

## Testing
- `pytest` *(fails: finalize routing missing fields, letter pipeline, strategy merge, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a64f496f0c83258642449370a0e320