### PR TITLE
Add planning FSM and tactical wrapper for letter generation

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -49,6 +49,8 @@ from backend.core.models import (
 )
 from backend.core.services.ai_client import AIClient, get_ai_client
 from backend.policy.policy_loader import load_rulebook
+from planner import plan_next_step
+import tactical
 
 
 def process_client_intake(client_info, audit):
@@ -693,19 +695,22 @@ def run_credit_repair_process(
             log_messages,
             ai_client,
         )
-        generate_letters(
-            client_info,
-            bureau_data,
-            sections,
-            today_folder,
-            is_identity_theft,
-            strategy,
-            audit,
-            log_messages,
-            classification_map,
-            ai_client,
-            app_config,
-        )
+        session_ctx = {
+            "session_id": session_id,
+            "client_info": client_info,
+            "bureau_data": bureau_data,
+            "sections": sections,
+            "today_folder": today_folder,
+            "is_identity_theft": is_identity_theft,
+            "strategy": strategy,
+            "audit": audit,
+            "log_messages": log_messages,
+            "classification_map": classification_map,
+            "ai_client": ai_client,
+            "app_config": app_config,
+        }
+        allowed_tags = plan_next_step(session_ctx)
+        tactical.generate_letters(session_ctx, allowed_tags)
         finalize_outputs(
             client_info, today_folder, sections, audit, log_messages, app_config
         )

--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Planner entry points."""
+
+from typing import Dict, List
+
+from backend.api.session_manager import get_session, update_session
+from backend.core.models import AccountState, AccountStatus
+
+from .state_machine import evaluate_state, dump_state, load_state
+
+
+def _ensure_account_states(session: dict, stored_states: Dict[str, dict]) -> Dict[str, dict]:
+    """Ensure every account in the current strategy has a tracked state."""
+
+    strategy = session.get("strategy", {}) or {}
+    accounts = strategy.get("accounts", [])
+    for acc in accounts:
+        acc_id = str(acc.get("account_id") or "")
+        if acc_id and acc_id not in stored_states:
+            state = AccountState(
+                account_id=acc_id,
+                current_cycle=0,
+                current_step=0,
+                status=AccountStatus.PLANNED,
+            )
+            stored_states[acc_id] = dump_state(state)
+    return stored_states
+
+
+def plan_next_step(session: dict) -> List[str]:
+    """Evaluate the FSM for all accounts and persist results.
+
+    The function loads persisted ``AccountState`` objects for the provided
+    ``session``, evaluates them via the finite-state machine and stores the
+    updated state back to the session manager *before* any tactical side
+    effects occur.
+
+    Args:
+        session: A mapping containing at least ``session_id`` and ``strategy``.
+
+    Returns:
+        A sorted list of allowed planner tags for the current step.
+    """
+
+    session_id = session.get("session_id")
+    if not session_id:
+        return []
+
+    stored = get_session(session_id) or {}
+    states_data: Dict[str, dict] = stored.get("account_states", {}) or {}
+    states_data = _ensure_account_states(session, states_data)
+
+    allowed: List[str] = []
+    for acc_id, data in states_data.items():
+        state = load_state(data)
+        tags, next_eligible_at = evaluate_state(state)
+        state.next_eligible_at = next_eligible_at
+        states_data[acc_id] = dump_state(state)
+        allowed.extend(tags)
+
+    update_session(session_id, account_states=states_data)
+    return sorted(set(allowed))

--- a/planner/state_machine.py
+++ b/planner/state_machine.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Simple finite-state machine for account planning.
+
+This module defines allowed transitions for ``AccountState`` records and
+imposes SLA gates between steps.  ``evaluate_state`` returns a tuple of
+``(allowed_tags, next_eligible_at)`` describing the actions that may be
+performed now and, if no action is currently permitted, the next time the
+account becomes eligible.
+"""
+
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from typing import List, Tuple
+
+from backend.core.models import AccountState, AccountStatus
+
+# Number of days that must elapse before the next action is allowed after
+# letters are sent to the bureaus.
+_DEFAULT_SLA_DAYS = 30
+
+
+def _serialize_dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _deserialize_dt(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+def evaluate_state(state: AccountState, now: datetime | None = None) -> Tuple[List[str], datetime | None]:
+    """Evaluate the state machine for a single account.
+
+    Args:
+        state: The account state to evaluate.
+        now:   Optional override for the current time.
+
+    Returns:
+        A tuple ``(allowed_tags, next_eligible_at)``. ``allowed_tags`` is a
+        list of planner tags that may be executed immediately.  If the list is
+        empty, ``next_eligible_at`` contains the datetime when the account will
+        become eligible for the next step.
+    """
+
+    now = now or datetime.utcnow()
+    if state.status == AccountStatus.PLANNED:
+        # Initial cycle – we can send the first dispute letter immediately.
+        return ["dispute"], None
+
+    if state.status == AccountStatus.SENT:
+        # We must wait for the SLA period before allowing a follow-up.
+        if state.last_sent_at:
+            eligible_at = state.last_sent_at + timedelta(days=_DEFAULT_SLA_DAYS)
+            if now >= eligible_at:
+                return ["followup"], None
+            return [], eligible_at
+        return ["followup"], None
+
+    # Any terminal state – no further actions are allowed.
+    return [], None
+
+
+def dump_state(state: AccountState) -> dict:
+    """Serialize ``AccountState`` for storage in the session manager."""
+
+    data = asdict(state)
+    data["last_sent_at"] = _serialize_dt(state.last_sent_at)
+    data["next_eligible_at"] = _serialize_dt(state.next_eligible_at)
+    for hist in data.get("history", []):
+        hist["timestamp"] = _serialize_dt(hist.get("timestamp"))
+    return data
+
+
+def load_state(data: dict) -> AccountState:
+    """Deserialize an ``AccountState`` from session data."""
+
+    data = dict(data)
+    if isinstance(data.get("last_sent_at"), str):
+        data["last_sent_at"] = _deserialize_dt(data["last_sent_at"])
+    if isinstance(data.get("next_eligible_at"), str):
+        data["next_eligible_at"] = _deserialize_dt(data["next_eligible_at"])
+    hist = []
+    for item in data.get("history", []):
+        ts = item.get("timestamp")
+        if isinstance(ts, str):
+            item["timestamp"] = _deserialize_dt(ts)
+        hist.append(item)
+    data["history"] = hist
+    return AccountState(**data)

--- a/tactical/__init__.py
+++ b/tactical/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Tactical actions executed after planning."""
+
+from typing import Iterable
+
+def generate_letters(session: dict, allowed_tags: Iterable[str]):
+    """Generate letters for accounts whose tags are allowed by the planner."""
+
+    from backend.core.orchestrators import generate_letters as _core_generate_letters
+
+    strategy = session.get("strategy") or {}
+    accounts = strategy.get("accounts", [])
+    allowed = set(allowed_tags)
+    if allowed:
+        accounts = [acc for acc in accounts if acc.get("action_tag") in allowed]
+        strategy = dict(strategy)
+        strategy["accounts"] = accounts
+
+    return _core_generate_letters(
+        session.get("client_info"),
+        session.get("bureau_data"),
+        session.get("sections"),
+        session.get("today_folder"),
+        session.get("is_identity_theft", False),
+        strategy,
+        session.get("audit"),
+        session.get("log_messages"),
+        session.get("classification_map"),
+        session.get("ai_client"),
+        session.get("app_config"),
+    )

--- a/tests/test_local_workflow.py
+++ b/tests/test_local_workflow.py
@@ -324,8 +324,8 @@ def test_stage_2_5_data_propagates_to_strategy():
         captured = {}
         stage_2_5 = {}
 
-        def fake_generate_letters(*args, **kwargs):
-            captured["strategy"] = args[5]
+        def fake_generate_letters(session, allowed_tags):
+            captured["strategy"] = session.get("strategy")
 
         def fake_save_report(
             self, report, client_info, run_date, base_dir="Clients", stage_2_5_data=None
@@ -363,7 +363,7 @@ def test_stage_2_5_data_propagates_to_strategy():
                 "services.ai_client.build_ai_client", return_value=FakeAIClient()
             ),
             mock.patch(
-                "orchestrators.generate_letters", side_effect=fake_generate_letters
+                "tactical.generate_letters", side_effect=fake_generate_letters
             ),
             mock.patch("orchestrators.finalize_outputs"),
             mock.patch(


### PR DESCRIPTION
## Summary
- add finite-state machine for account planning with SLA gating
- persist account plan state and compute allowed letter tags
- orchestrate tactical letter generation via planner wrapper

## Testing
- `pytest` *(fails: missing template routing in letters, 21 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68a650dbbb488325abdf40a2cbff586c