### PR TITLE
Pass Stage 2.5 tags through planner and verify routing order

### DIFF
--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -1,16 +1,18 @@
-from __future__ import annotations
-
 """Planner entry points."""
 
-from typing import Dict, List
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
 
 from backend.api.session_manager import get_session, update_session
 from backend.core.models import AccountState, AccountStatus
 
-from .state_machine import evaluate_state, dump_state, load_state
+from .state_machine import dump_state, evaluate_state, load_state
 
 
-def _ensure_account_states(session: dict, stored_states: Dict[str, dict]) -> Dict[str, dict]:
+def _ensure_account_states(
+    session: dict, stored_states: Dict[str, dict]
+) -> Dict[str, dict]:
     """Ensure every account in the current strategy has a tracked state."""
 
     strategy = session.get("strategy", {}) or {}
@@ -28,19 +30,22 @@ def _ensure_account_states(session: dict, stored_states: Dict[str, dict]) -> Dic
     return stored_states
 
 
-def plan_next_step(session: dict) -> List[str]:
+def plan_next_step(session: dict, action_tags: Iterable[str]) -> List[str]:
     """Evaluate the FSM for all accounts and persist results.
 
     The function loads persisted ``AccountState`` objects for the provided
     ``session``, evaluates them via the finite-state machine and stores the
     updated state back to the session manager *before* any tactical side
-    effects occur.
+    effects occur.  ``action_tags`` contains the Stage 2.5 tags that the
+    strategist proposed for this run; the planner intersects these with the
+    state machine's allowed tags to enforce cycle/SLA restrictions.
 
     Args:
         session: A mapping containing at least ``session_id`` and ``strategy``.
+        action_tags: Iterable of action tags proposed by the strategist.
 
     Returns:
-        A sorted list of allowed planner tags for the current step.
+        A sorted list of planner-approved tags for the current step.
     """
 
     session_id = session.get("session_id")
@@ -58,6 +63,10 @@ def plan_next_step(session: dict) -> List[str]:
         state.next_eligible_at = next_eligible_at
         states_data[acc_id] = dump_state(state)
         allowed.extend(tags)
+
+    action_set = {t for t in action_tags if t}
+    if action_set:
+        allowed = [t for t in allowed if t in action_set]
 
     update_session(session_id, account_states=states_data)
     return sorted(set(allowed))

--- a/tests/test_planner_routing_integration.py
+++ b/tests/test_planner_routing_integration.py
@@ -1,0 +1,99 @@
+import planner
+import tactical
+from backend.api import session_manager
+from backend.core.letters import router as letters_router
+
+
+def test_candidate_routing_precedes_planner_and_finalize_after(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+
+    # simple in-memory session store
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+
+    order = []
+
+    orig_select = letters_router.select_template
+
+    def wrapped_select(tag, ctx, phase, session_id=None):
+        order.append(f"{phase}:{tag}")
+        return orig_select(tag, ctx, phase, session_id=session_id)
+
+    monkeypatch.setattr(letters_router, "select_template", wrapped_select)
+
+    # Patch core letter generation to invoke finalize routing for allowed tags
+    import backend.core.orchestrators as core_orch
+
+    def fake_generate_letters(
+        client_info,
+        bureau_data,
+        sections,
+        today_folder,
+        is_identity_theft,
+        strategy,
+        audit,
+        log_messages,
+        classification_map,
+        ai_client,
+        app_config,
+    ):
+        for acc in strategy.get("accounts", []):
+            letters_router.select_template(acc.get("action_tag"), acc, phase="finalize")
+        return []
+
+    monkeypatch.setattr(core_orch, "generate_letters", fake_generate_letters)
+
+    orig_plan = planner.plan_next_step
+
+    def wrapped_plan(session, action_tags):
+        order.append("planner")
+        return orig_plan(session, action_tags)
+
+    monkeypatch.setattr(planner, "plan_next_step", wrapped_plan)
+
+    stage_2_5 = {
+        "1": {
+            "action_tag": "goodwill"
+        },  # missing creditor to trigger candidate warnings
+        "2": {"action_tag": "dispute", "bureau": "Experian"},
+    }
+
+    strategy = {
+        "accounts": [
+            {"account_id": "1", "action_tag": "goodwill"},
+            {"account_id": "2", "action_tag": "dispute", "bureau": "Experian"},
+        ]
+    }
+
+    session_ctx = {"session_id": "sess1", "strategy": strategy}
+
+    decisions = {
+        acc_id: letters_router.select_template(
+            ctx["action_tag"], ctx, phase="candidate"
+        )
+        for acc_id, ctx in stage_2_5.items()
+    }
+
+    allowed_tags = planner.plan_next_step(
+        session_ctx, [ctx["action_tag"] for ctx in stage_2_5.values()]
+    )
+    assert allowed_tags == ["dispute"]
+    tactical.generate_letters(session_ctx, allowed_tags)
+
+    assert order == [
+        "candidate:goodwill",
+        "candidate:dispute",
+        "planner",
+        "finalize:dispute",
+    ]
+    assert decisions["1"].required_fields == ["creditor"]


### PR DESCRIPTION
## Summary
- pass Stage 2.5 action tags into planner and filter by SLA cycle
- feed planner-approved allowed tags into tactical letter generation
- add integration test verifying candidate routing happens before planning and finalize routing after

## Testing
- `pre-commit run --files planner/__init__.py backend/core/orchestrators.py tests/test_planner_routing_integration.py`
- `pytest tests/test_planner_routing_integration.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6533a30c48325a81c36149776e1c6