### PR TITLE
Implement planner SLA gating with per-account locks

### DIFF
--- a/backend/core/locks.py
+++ b/backend/core/locks.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simple per-account locking utilities.
+
+This module provides a lightweight in-memory locking mechanism keyed by
+account id.  In a production system this would likely be backed by a
+shared resource such as Redis using ``SETNX`` or a database row lock.
+For our purposes an in-process ``threading.Lock`` is sufficient to
+prevent concurrent planner operations for the same account.
+"""
+
+from contextlib import contextmanager
+import threading
+from typing import Dict
+
+# Global map of account_id -> Lock
+_locks: Dict[str, threading.Lock] = {}
+_master_lock = threading.Lock()
+
+
+@contextmanager
+def account_lock(account_id: str):
+    """Context manager acquiring a lock for the given account id."""
+    with _master_lock:
+        lock = _locks.setdefault(account_id, threading.Lock())
+    lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()

--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Dict, Iterable, List
 
 from backend.api.session_manager import get_session, update_session
@@ -30,7 +31,9 @@ def _ensure_account_states(
     return stored_states
 
 
-def plan_next_step(session: dict, action_tags: Iterable[str]) -> List[str]:
+def plan_next_step(
+    session: dict, action_tags: Iterable[str], now: datetime | None = None
+) -> List[str]:
     """Evaluate the FSM for all accounts and persist results.
 
     The function loads persisted ``AccountState`` objects for the provided
@@ -57,9 +60,13 @@ def plan_next_step(session: dict, action_tags: Iterable[str]) -> List[str]:
     states_data = _ensure_account_states(session, states_data)
 
     allowed: List[str] = []
+    now = now or datetime.utcnow()
     for acc_id, data in states_data.items():
         state = load_state(data)
-        tags, next_eligible_at = evaluate_state(state)
+        if state.next_eligible_at and now < state.next_eligible_at:
+            states_data[acc_id] = dump_state(state)
+            continue
+        tags, next_eligible_at = evaluate_state(state, now=now)
         state.next_eligible_at = next_eligible_at
         states_data[acc_id] = dump_state(state)
         allowed.extend(tags)
@@ -70,3 +77,35 @@ def plan_next_step(session: dict, action_tags: Iterable[str]) -> List[str]:
 
     update_session(session_id, account_states=states_data)
     return sorted(set(allowed))
+
+
+def record_send(
+    session: dict,
+    account_ids: Iterable[str],
+    now: datetime | None = None,
+    sla_days: int = 30,
+) -> None:
+    """Record that letters were sent for the given accounts."""
+
+    session_id = session.get("session_id")
+    if not session_id:
+        return
+
+    stored = get_session(session_id) or {}
+    states_data: Dict[str, dict] = stored.get("account_states", {}) or {}
+    if not states_data:
+        return
+
+    now = now or datetime.utcnow()
+    for acc_id in account_ids:
+        data = states_data.get(str(acc_id))
+        if not data:
+            continue
+        state = load_state(data)
+        state.last_sent_at = now
+        state.next_eligible_at = now + timedelta(days=sla_days)
+        state.status = AccountStatus.SENT
+        state.current_step += 1
+        states_data[str(acc_id)] = dump_state(state)
+
+    update_session(session_id, account_states=states_data)

--- a/tactical/__init__.py
+++ b/tactical/__init__.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 """Tactical actions executed after planning."""
 
-from typing import Iterable
+from typing import Iterable, List
+from contextlib import ExitStack
+
+from backend.core.locks import account_lock
+
 
 def generate_letters(session: dict, allowed_tags: Iterable[str]):
     """Generate letters for accounts whose tags are allowed by the planner."""
 
     from backend.core.orchestrators import generate_letters as _core_generate_letters
+    import planner
 
     strategy = session.get("strategy") or {}
     accounts = strategy.get("accounts", [])
@@ -17,16 +22,24 @@ def generate_letters(session: dict, allowed_tags: Iterable[str]):
         strategy = dict(strategy)
         strategy["accounts"] = accounts
 
-    return _core_generate_letters(
-        session.get("client_info"),
-        session.get("bureau_data"),
-        session.get("sections"),
-        session.get("today_folder"),
-        session.get("is_identity_theft", False),
-        strategy,
-        session.get("audit"),
-        session.get("log_messages"),
-        session.get("classification_map"),
-        session.get("ai_client"),
-        session.get("app_config"),
-    )
+    account_ids: List[str] = [str(acc.get("account_id")) for acc in accounts if acc.get("account_id")]
+
+    with ExitStack() as stack:
+        for acc_id in account_ids:
+            stack.enter_context(account_lock(acc_id))
+        result = _core_generate_letters(
+            session.get("client_info"),
+            session.get("bureau_data"),
+            session.get("sections"),
+            session.get("today_folder"),
+            session.get("is_identity_theft", False),
+            strategy,
+            session.get("audit"),
+            session.get("log_messages"),
+            session.get("classification_map"),
+            session.get("ai_client"),
+            session.get("app_config"),
+        )
+        if account_ids:
+            planner.record_send(session, account_ids)
+    return result

--- a/tests/test_account_state_sla.py
+++ b/tests/test_account_state_sla.py
@@ -1,0 +1,44 @@
+import planner
+from backend.api import session_manager
+from datetime import datetime, timedelta
+
+
+def test_next_eligible_at_and_planner_skip(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    allowed = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    assert allowed == ["dispute"]
+
+    send_time = datetime(2024, 1, 2)
+    planner.record_send(session, ["1"], now=send_time, sla_days=30)
+
+    # Before SLA expires - planner should skip account
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 1, 20))
+    assert allowed == []
+
+    state_data = store["s1"]["account_states"]["1"]
+    state = planner.load_state(state_data)
+    assert state.last_sent_at == send_time
+    assert state.next_eligible_at == send_time + timedelta(days=30)
+
+    # After SLA expires
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 2, 5))
+    assert allowed == ["followup"]


### PR DESCRIPTION
## Summary
- track account send history and compute next_eligible_at after each planner advancement
- skip planner evaluation for accounts not yet eligible based on SLA
- prevent concurrent letter generation by locking per-account and recording sends

## Testing
- `pytest tests/test_planner_routing_integration.py::test_candidate_routing_precedes_planner_and_finalize_after -q`
- `pytest tests/test_account_state_sla.py::test_next_eligible_at_and_planner_skip -q`
- `pytest -q` *(fails: router finalize tests expect different templates)*


------
https://chatgpt.com/codex/tasks/task_b_68a6552ee0c08325b1c1202fa8f8d771