### PR TITLE
Add planner metrics and monitoring

### DIFF
--- a/backend/analytics/README.md
+++ b/backend/analytics/README.md
@@ -24,6 +24,12 @@ Common counters emitted for dashboards:
 - `policy_override_reason.{reason}` – policy-based overrides grouped by reason.
 - `rulebook.tag_selected.{tag}` – counts how often a rulebook action tag is chosen.
 - `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
+- `planner.cycle_progress{cycle,step}` – tracker for step advancement per cycle (cycle/step labels each <10).
+- `planner.time_to_next_step_ms` – milliseconds until next eligible planner action (single gauge).
+- `planner.resolution_rate` – fraction of accounts completed in a run (single gauge).
+- `planner.avg_cycles_per_resolution` – average cycles required for completed accounts (single gauge).
+- `planner.sla_violations_total` – cumulative SLA violations when sends lag (single counter).
+- `planner.error_count` – planner exceptions caught (single counter).
 
 ## Entry points
 - `analytics_tracker.save_analytics_snapshot`

--- a/docs/planner/README.md
+++ b/docs/planner/README.md
@@ -1,0 +1,12 @@
+# Planner metrics
+
+The planner emits the following metrics for monitoring:
+
+- `planner.cycle_progress{cycle,step}` – counts step transitions per cycle. Cardinality: cycle and step each <10.
+- `planner.time_to_next_step_ms` – gauge of milliseconds until the next eligible planner action. Cardinality: 1.
+- `planner.resolution_rate` – fraction of accounts resolved in a run. Cardinality: 1.
+- `planner.avg_cycles_per_resolution` – average cycles spent per resolved account. Cardinality: 1.
+- `planner.sla_violations_total` – total number of SLA breaches when sends occur after the deadline. Cardinality: 1.
+- `planner.error_count` – total planner exceptions. Cardinality: 1.
+
+These metrics power dashboards used to track planner throughput and reliability.

--- a/tests/test_planner_metrics.py
+++ b/tests/test_planner_metrics.py
@@ -1,0 +1,61 @@
+import planner
+from datetime import datetime
+from backend.api import session_manager
+from backend.analytics.analytics_tracker import reset_counters, get_counters
+from backend.core.models import AccountState, AccountStatus
+
+
+def test_planner_metric_emissions(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    reset_counters()
+
+    # Prepopulate one completed account to exercise resolution gauges
+    state = AccountState(
+        account_id="1",
+        current_cycle=2,
+        current_step=0,
+        status=AccountStatus.COMPLETED,
+    )
+    store["s1"] = {"account_states": {"1": planner.dump_state(state)}}
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1"}, {"account_id": "2"}]},
+    }
+
+    allowed = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    assert allowed == ["dispute"]
+
+    planner.record_send(session, ["2"], now=datetime(2024, 1, 1), sla_days=30)
+
+    # Trigger time_to_next_step_ms by planning before SLA expires
+    planner.plan_next_step(session, ["followup"], now=datetime(2024, 1, 15))
+
+    # Second send after SLA window to count violation
+    planner.record_send(session, ["2"], now=datetime(2024, 2, 15), sla_days=30)
+
+    counters = get_counters()
+
+    assert counters["planner.cycle_progress"] == 2
+    assert counters["planner.cycle_progress.cycle.0"] == 2
+    assert counters["planner.cycle_progress.step.1"] == 1
+    assert counters["planner.cycle_progress.step.2"] == 1
+    assert counters["planner.sla_violations_total"] == 1
+    assert counters["planner.resolution_rate"] == 0.5
+    assert counters["planner.avg_cycles_per_resolution"] == 2.0
+    assert counters.get("planner.error_count", 0) == 0
+    assert counters["planner.time_to_next_step_ms"] > 0


### PR DESCRIPTION
## Summary
- instrument planner with cycle progress, next-step timing, resolution, SLA, and error metrics
- document planner metrics and cardinality for monitoring dashboards
- add integration test asserting planner metric emissions remain stable

## Testing
- `pytest` (fails: 21 failed, 301 passed, 9 xfailed, 4 xpassed)
- `pytest tests/test_planner_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a658c763f08325906db2f12e6fa68e