### PR TITLE
Add planner state machine and workflow tests

### DIFF
--- a/tests/test_outcome_ingestion_integration.py
+++ b/tests/test_outcome_ingestion_integration.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import planner
+from backend.api import session_manager
+from backend.core.models import AccountStatus
+
+
+def test_outcome_ingestion_marks_account_completed(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    planner.record_send(session, ["1"], now=datetime(2024, 1, 2))
+
+    # simulate CRA response ingestion
+    state = planner.load_state(store["s1"]["account_states"]["1"])
+    state.transition(AccountStatus.CRA_RESPONDED_VERIFIED, actor="cra")
+    state.transition(AccountStatus.COMPLETED, actor="system")
+    store["s1"]["account_states"]["1"] = planner.dump_state(state)
+
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 3, 5))
+    assert allowed == []
+    final_state = planner.load_state(store["s1"]["account_states"]["1"])
+    assert final_state.status == AccountStatus.COMPLETED

--- a/tests/test_planner_fsm.py
+++ b/tests/test_planner_fsm.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+from backend.core.models import AccountState, AccountStatus
+from planner.state_machine import evaluate_state
+
+
+def test_fsm_transitions_and_idempotency():
+    state = AccountState(account_id="1", current_cycle=0, current_step=0, status=AccountStatus.PLANNED)
+    now = datetime(2024, 1, 1)
+    tags1, eligible1 = evaluate_state(state, now=now)
+    tags2, eligible2 = evaluate_state(state, now=now)
+    assert tags1 == ["dispute"]
+    assert eligible1 is None
+    assert (tags1, eligible1) == (tags2, eligible2)
+    assert state.status == AccountStatus.PLANNED
+
+    state.status = AccountStatus.SENT
+    state.last_sent_at = now
+    tags, eligible = evaluate_state(state, now=now + timedelta(days=10))
+    assert tags == []
+    assert eligible == now + timedelta(days=30)
+
+    tags, eligible = evaluate_state(state, now=now + timedelta(days=31))
+    assert tags == ["followup"]
+    assert eligible is None
+
+    state.status = AccountStatus.CRA_RESPONDED_DELETED
+    tags, eligible = evaluate_state(state, now=now + timedelta(days=40))
+    assert tags == []
+    assert eligible is None

--- a/tests/test_planner_replay.py
+++ b/tests/test_planner_replay.py
@@ -1,0 +1,34 @@
+import copy
+from datetime import datetime
+
+import planner
+from backend.api import session_manager
+
+
+def test_planner_replay_produces_same_results(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    allowed1 = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    snapshot = copy.deepcopy(store)
+    allowed2 = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+
+    assert allowed1 == allowed2 == ["dispute"]
+    assert store == snapshot

--- a/tests/test_planner_simulation_cycles.py
+++ b/tests/test_planner_simulation_cycles.py
@@ -1,0 +1,101 @@
+from datetime import datetime, timedelta
+
+import planner
+import tactical
+from backend.api import session_manager
+from backend.core.letters import router as letters_router
+
+
+def test_simulated_cycles_with_sla(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    order = []
+    orig_select = letters_router.select_template
+
+    def wrapped_select(tag, ctx, phase, session_id=None):
+        order.append(f"{phase}:{tag}")
+        return orig_select(tag, ctx, phase, session_id=session_id)
+
+    monkeypatch.setattr(letters_router, "select_template", wrapped_select)
+
+    send_times = [datetime(2024, 1, 1), datetime(2024, 2, 1)]
+    orig_record_send = planner.record_send
+
+    def fake_record_send(session, account_ids):
+        now = send_times.pop(0)
+        orig_record_send(session, account_ids, now=now, sla_days=30)
+
+    monkeypatch.setattr(planner, "record_send", fake_record_send)
+    orig_plan = planner.plan_next_step
+
+    def wrapped_plan(session, action_tags, now=None):
+        order.append("planner")
+        return orig_plan(session, action_tags, now=now)
+
+    monkeypatch.setattr(planner, "plan_next_step", wrapped_plan)
+
+    session = {"session_id": "s1", "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]}}
+
+    # Patch core letter generation to invoke finalize routing for allowed tags
+    import backend.core.orchestrators as core_orch
+
+    def fake_generate_letters(
+        client_info,
+        bureau_data,
+        sections,
+        today_folder,
+        is_identity_theft,
+        strategy,
+        audit,
+        log_messages,
+        classification_map,
+        ai_client,
+        app_config,
+    ):
+        for acc in strategy.get("accounts", []):
+            tag = acc.get("action_tag")
+            call_tag = "dispute" if tag == "followup" else tag
+            letters_router.select_template(call_tag, acc, phase="finalize")
+        return []
+
+    monkeypatch.setattr(core_orch, "generate_letters", fake_generate_letters)
+
+    stage_2_5 = {"1": {"action_tag": "dispute"}}
+    letters_router.select_template("dispute", stage_2_5["1"], phase="candidate")
+
+    allowed = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    assert allowed == ["dispute"]
+    tactical.generate_letters(session, allowed)
+
+    # before SLA expiry
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 1, 15))
+    assert allowed == []
+
+    # Second cycle - strategist proposes a follow-up action
+    session["strategy"]["accounts"][0]["action_tag"] = "followup"
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 2, 5))
+    assert allowed == ["followup"]
+    tactical.generate_letters(session, allowed)
+
+    state = planner.load_state(store["s1"]["account_states"]["1"])
+    assert state.current_step == 2
+    assert state.next_eligible_at == datetime(2024, 2, 1) + timedelta(days=30)
+
+    assert order[0] == "candidate:dispute"
+    assert order[1] == "planner"
+    assert order.count("planner") == 3
+    assert order.count("finalize:dispute") == 2


### PR DESCRIPTION
## Summary
- test FSM transitions for planning, SLA gating, and invalid states
- simulate multi-cycle planner/tactical flow verifying next_eligible_at
- add deterministic replay and outcome ingestion tests

## Testing
- `pytest tests/test_planner_fsm.py tests/test_planner_simulation_cycles.py tests/test_planner_replay.py tests/test_outcome_ingestion_integration.py`

------
https://chatgpt.com/codex/tasks/task_b_68a65fb0285c83258a0c86c47f9adbd9