### PR TITLE
docs: add canary monitoring sign-off

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -55,3 +55,7 @@ One short paragraph describing: PDF+email → analysis → explanations → stra
 
 ## Follow-ups (nice-to-have)
 - CRA alignment enhancements, soft-rule telemetry, clean demo assets, optional Celery path.
+
+## Pre-Outcome Ingestion sign-off
+- Staging canary observed for one cycle; no elevated `router.error`, `planner.error_count`, or `planner.sla_violations_total` metrics.
+- Audit logs for planner transitions reviewed; events are deterministic and replay-safe.


### PR DESCRIPTION
## Summary
- document canary monitoring and audit-log review sign-off before Outcome Ingestion work

## Testing
- `DISABLE_PDF_RENDER=true pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a66aeacb508325be7cd9fa2ae61e5c