### PR TITLE
Add outcome ingestion service and planner integration

### DIFF
--- a/backend/outcomes/__init__.py
+++ b/backend/outcomes/__init__.py
@@ -1,0 +1,1 @@
+from .models import OutcomeEvent

--- a/backend/outcomes/models.py
+++ b/backend/outcomes/models.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+@dataclass
+class OutcomeEvent:
+    """Record produced when a bureau responds to a dispute."""
+
+    outcome_id: str
+    account_id: str
+    cycle: int
+    result: str

--- a/services/outcome_ingestion/__init__.py
+++ b/services/outcome_ingestion/__init__.py
@@ -1,0 +1,17 @@
+from typing import List
+
+import planner
+from backend.outcomes import OutcomeEvent
+
+_events: List[OutcomeEvent] = []
+
+
+def ingest(session: dict, event: OutcomeEvent) -> None:
+    """Persist an outcome event and update planner state."""
+    _events.append(event)
+    planner.handle_outcome(session, event)
+
+
+def get_events() -> List[OutcomeEvent]:
+    """Return ingested outcome events."""
+    return list(_events)

--- a/tests/test_outcome_event_planner.py
+++ b/tests/test_outcome_event_planner.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+import planner
+from backend.api import session_manager
+from backend.core.models import AccountStatus
+from backend.outcomes import OutcomeEvent
+from services import outcome_ingestion
+
+
+def test_ingested_outcome_updates_planner(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    planner.record_send(session, ["1"], now=datetime(2024, 1, 2))
+
+    outcome_ingestion._events.clear()
+    event = OutcomeEvent(outcome_id="o1", account_id="1", cycle=0, result="verified")
+    outcome_ingestion.ingest(session, event)
+
+    assert outcome_ingestion.get_events() == [event]
+
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 3, 5))
+    assert allowed == []
+    final_state = planner.load_state(store["s1"]["account_states"]["1"])
+    assert final_state.status == AccountStatus.COMPLETED


### PR DESCRIPTION
## Summary
- add OutcomeEvent schema to capture CRA results
- introduce outcome_ingestion service that records events and updates planner
- allow planner to process outcome events via `handle_outcome`
- cover outcome ingestion flow with a unit test

## Testing
- `pytest tests/test_outcome_event_planner.py -q`
- `pytest tests/test_outcome_ingestion_integration.py -q`
- `pytest tests/test_planner_fsm.py tests/test_outcomes_store.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a66c4739d0832592f65f7e70383afd