### PR TITLE
Track and persist dispute outcome events

### DIFF
--- a/backend/outcomes/__init__.py
+++ b/backend/outcomes/__init__.py
@@ -1,1 +1,13 @@
-from .models import OutcomeEvent
+from .models import (
+    Outcome,
+    OutcomeEvent,
+    load_outcome_history,
+    save_outcome_event,
+)
+
+__all__ = [
+    "Outcome",
+    "OutcomeEvent",
+    "save_outcome_event",
+    "load_outcome_history",
+]

--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -184,9 +184,15 @@ def handle_outcome(session: dict, event: OutcomeEvent) -> None:
             "updated": AccountStatus.CRA_RESPONDED_UPDATED,
             "nochange": AccountStatus.CRA_RESPONDED_NOCHANGE,
         }
-        status = result_map.get(event.result.lower())
+        outcome_val = (
+            event.outcome.value.lower()
+            if hasattr(event.outcome, "value")
+            else str(event.outcome).lower()
+        )
+        status = result_map.get(outcome_val)
         if not status:
             return
+        state.record_outcome(event)
         state.transition(status, actor="cra")
         state.transition(AccountStatus.COMPLETED, actor="system")
         states_data[str(event.account_id)] = dump_state(state)

--- a/planner/state_machine.py
+++ b/planner/state_machine.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import List, Tuple
 
 from backend.core.models import AccountState, AccountStatus, StateTransition
+from backend.outcomes.models import OutcomeEvent
 
 """Simple finite-state machine for account planning.
 
@@ -70,6 +71,9 @@ def dump_state(state: AccountState) -> dict:
     data["next_eligible_at"] = _serialize_dt(state.next_eligible_at)
     for hist in data.get("history", []):
         hist["timestamp"] = _serialize_dt(hist.get("timestamp"))
+    for ev in data.get("outcome_history", []):
+        if hasattr(ev.get("outcome"), "value"):
+            ev["outcome"] = ev["outcome"].value
     return data
 
 
@@ -95,4 +99,8 @@ def load_state(data: dict) -> AccountState:
             )
         )
     data["history"] = hist
+    events = []
+    for item in data.get("outcome_history", []):
+        events.append(OutcomeEvent(**item))
+    data["outcome_history"] = tuple(events)
     return AccountState(**data)

--- a/services/outcome_ingestion/__init__.py
+++ b/services/outcome_ingestion/__init__.py
@@ -1,17 +1,12 @@
-from typing import List
-
 import planner
-from backend.outcomes import OutcomeEvent
-
-_events: List[OutcomeEvent] = []
+from backend.outcomes import OutcomeEvent, save_outcome_event
 
 
 def ingest(session: dict, event: OutcomeEvent) -> None:
     """Persist an outcome event and update planner state."""
-    _events.append(event)
+
+    session_id = session.get("session_id")
+    if not session_id:
+        return
+    save_outcome_event(session_id, event)
     planner.handle_outcome(session, event)
-
-
-def get_events() -> List[OutcomeEvent]:
-    """Return ingested outcome events."""
-    return list(_events)


### PR DESCRIPTION
## Summary
- expand `OutcomeEvent` with detailed fields and persistence helpers
- extend `AccountState` to record outcomes and resolution cycles
- update planner and services to handle event history via session storage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a66f5517a48325b467ec8c1bd779d5