### PR TITLE
feat: ingest outcome report and classify families

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -666,6 +666,12 @@ def run_credit_repair_process(
         pdf_path, sections, bureau_data, today_folder = analyze_credit_report(
             proofs_files, session_id, client_info, audit, log_messages, ai_client
         )
+        try:
+            from services.outcome_ingestion.ingest_report import ingest_report as ingest_outcome_report
+
+            ingest_outcome_report(None, bureau_data)
+        except Exception:
+            pass
         tri_merge_map: dict[str, dict[str, Any]] = {}
         if env_bool("ENABLE_TRI_MERGE", False):
             from backend.api.session_manager import get_session

--- a/services/outcome_ingestion/ingest_report.py
+++ b/services/outcome_ingestion/ingest_report.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Dict, Iterable, List, Mapping
+
+from backend.api import session_manager
+from backend.outcomes import OutcomeEvent
+from backend.outcomes.models import Outcome
+from backend.core.logic.report_analysis.tri_merge import normalize_and_match
+from backend.core.logic.report_analysis.tri_merge_models import Tradeline, TradelineFamily
+
+from . import ingest
+
+
+def _extract_tradelines(report: Mapping[str, Any]) -> List[Tradeline]:
+    """Flatten bureau payload into tradeline objects."""
+    tradelines: List[Tradeline] = []
+    for bureau, payload in report.items():
+        if not isinstance(payload, Mapping):
+            continue
+        for section, items in payload.items():
+            if section == "inquiries" or not isinstance(items, list):
+                continue
+            for acc in items:
+                tradelines.append(
+                    Tradeline(
+                        creditor=str(acc.get("name") or ""),
+                        bureau=bureau,
+                        account_number=acc.get("account_number"),
+                        data=acc,
+                    )
+                )
+    return tradelines
+
+
+def _snapshot_families(families: Iterable[TradelineFamily]) -> Dict[str, Dict[str, Any]]:
+    """Return a lightweight snapshot mapping family_id to bureau data."""
+    snapshot: Dict[str, Dict[str, Any]] = {}
+    for fam in families:
+        family_id = getattr(fam, "family_id", None)
+        if not family_id:
+            continue
+        snap = {b: tl.data for b, tl in fam.tradelines.items()}
+        snapshot[family_id] = snap
+    return snapshot
+
+
+def ingest_report(account_id: str | None, new_report: Mapping[str, Any]) -> List[OutcomeEvent]:
+    """Ingest a new credit report and emit outcome events.
+
+    Args:
+        account_id: Optional account id. If ``None``, all accounts present in
+            ``new_report`` are processed.
+        new_report: Parsed bureau payload mapping bureau name to sections.
+    Returns:
+        List of :class:`OutcomeEvent` instances that were persisted.
+    """
+
+    session_id = os.getenv("SESSION_ID")
+    if not session_id:
+        return []
+
+    tradelines = _extract_tradelines(new_report)
+    families = normalize_and_match(tradelines)
+
+    # Group family snapshots by account id
+    per_account: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for fam in families:
+        fam_id = getattr(fam, "family_id", None)
+        if not fam_id:
+            continue
+        snap = {b: tl.data for b, tl in fam.tradelines.items()}
+        for tl in fam.tradelines.values():
+            acc_id = str(tl.data.get("account_id") or "")
+            if not acc_id:
+                continue
+            per_account.setdefault(acc_id, {})[fam_id] = snap
+
+    # If a specific account_id was provided, filter to it
+    if account_id is not None:
+        per_account = {k: v for k, v in per_account.items() if k == str(account_id)}
+
+    stored = session_manager.get_session(session_id) or {}
+    tri_merge = stored.get("tri_merge", {}) or {}
+    prev_snapshots: Dict[str, Dict[str, Dict[str, Any]]] = tri_merge.get("snapshots", {}) or {}
+
+    events: List[OutcomeEvent] = []
+
+    for acc_id, new_snap in per_account.items():
+        prev_snap = prev_snapshots.get(acc_id, {})
+        if not prev_snap:
+            # No prior snapshot; store baseline and continue
+            prev_snapshots[acc_id] = new_snap
+            continue
+
+        # Union of family ids
+        all_fids = set(prev_snap) | set(new_snap)
+        for fid in all_fids:
+            if fid not in new_snap:
+                outcome = Outcome.DELETED
+                diff = {"previous": prev_snap[fid], "current": None}
+            elif fid not in prev_snap:
+                outcome = Outcome.NOCHANGE
+                diff = None
+            elif prev_snap[fid] != new_snap[fid]:
+                outcome = Outcome.UPDATED
+                diff = {"previous": prev_snap[fid], "current": new_snap[fid]}
+            else:
+                outcome = Outcome.VERIFIED
+                diff = None
+            event = OutcomeEvent(
+                outcome_id=str(uuid.uuid4()),
+                account_id=acc_id,
+                cycle_id=0,
+                family_id=fid,
+                outcome=outcome,
+                diff_snapshot=diff,
+            )
+            ingest({"session_id": session_id}, event)
+            events.append(event)
+        prev_snapshots[acc_id] = new_snap
+
+    # Persist updated snapshots
+    tri_merge["snapshots"] = prev_snapshots
+    session_manager.update_session(session_id, tri_merge=tri_merge)
+
+    return events

--- a/tests/test_ingest_report.py
+++ b/tests/test_ingest_report.py
@@ -1,0 +1,79 @@
+import os
+
+from backend.api import session_manager
+from backend.outcomes import load_outcome_history
+from services.outcome_ingestion.ingest_report import ingest_report
+from backend.outcomes.models import Outcome
+
+
+def _make_report(accounts):
+    return {"Experian": {"negative_accounts": accounts}}
+
+
+def test_ingest_report_classifies_and_persists(monkeypatch, tmp_path):
+    sess_file = tmp_path / "sessions.json"
+    monkeypatch.setattr(session_manager, "SESSION_FILE", sess_file)
+    monkeypatch.setenv("SESSION_ID", "sess1")
+
+    baseline_accounts = [
+        {
+            "account_id": "acct1",
+            "name": "CredA",
+            "account_number": "1111",
+            "balance": 100,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+        {
+            "account_id": "acct1",
+            "name": "CredB",
+            "account_number": "2222",
+            "balance": 200,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+        {
+            "account_id": "acct1",
+            "name": "CredC",
+            "account_number": "3333",
+            "balance": 300,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+    ]
+    ingest_report(None, _make_report(baseline_accounts))
+
+    new_accounts = [
+        {
+            "account_id": "acct1",
+            "name": "CredA",
+            "account_number": "1111",
+            "balance": 100,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+        {
+            "account_id": "acct1",
+            "name": "CredB",
+            "account_number": "2222",
+            "balance": 250,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+        {
+            "account_id": "acct1",
+            "name": "CredD",
+            "account_number": "4444",
+            "balance": 400,
+            "date_opened": "2020",
+            "date_reported": "2024",
+        },
+    ]
+    ingest_report(None, _make_report(new_accounts))
+
+    history = load_outcome_history("sess1", "acct1")
+    outcomes = {e.outcome for e in history}
+    assert outcomes == {Outcome.VERIFIED, Outcome.UPDATED, Outcome.DELETED, Outcome.NOCHANGE}
+
+    session = session_manager.get_session("sess1")
+    assert "tri_merge" in session and "snapshots" in session["tri_merge"]

--- a/tests/test_orchestrator_calls_ingest_report.py
+++ b/tests/test_orchestrator_calls_ingest_report.py
@@ -1,0 +1,65 @@
+import tactical
+from backend.core.models import ClientInfo, ProofDocuments
+from backend.core import orchestrators
+from backend.core.letters import router as letters_router
+
+
+def test_orchestrator_calls_ingest_report(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_ingest_report(account_id, report):
+        called['args'] = (account_id, report)
+        return []
+
+    monkeypatch.setattr(
+        'services.outcome_ingestion.ingest_report.ingest_report',
+        fake_ingest_report,
+    )
+
+    class DummyConfig:
+        ai = {}
+        rulebook_fallback_enabled = True
+        wkhtmltopdf_path = None
+        smtp_server = ""
+        smtp_port = 0
+        smtp_username = ""
+        smtp_password = ""
+        export_trace_file = False
+
+    monkeypatch.setattr(orchestrators, 'get_app_config', lambda: DummyConfig())
+    monkeypatch.setattr(
+        'backend.core.services.ai_client.build_ai_client', lambda *a, **k: None
+    )
+    monkeypatch.setattr(orchestrators, 'process_client_intake', lambda c, a: ('sess', {}, {}))
+    monkeypatch.setattr(orchestrators, 'classify_client_responses', lambda *a, **k: {})
+    monkeypatch.setattr(
+        orchestrators,
+        'normalize_and_tag',
+        lambda account_cls, facts, rulebook, account_id=None: facts,
+    )
+    sections = {"negative_accounts": []}
+    bureau_data = {"Experian": {}}
+    monkeypatch.setattr(
+        orchestrators,
+        'analyze_credit_report',
+        lambda *a, **k: (tmp_path / 'r.pdf', sections, bureau_data, tmp_path),
+    )
+    monkeypatch.setattr(orchestrators, 'load_rulebook', lambda: {})
+    monkeypatch.setattr(orchestrators, 'generate_strategy_plan', lambda *a, **k: {"accounts": []})
+    monkeypatch.setattr(orchestrators, 'plan_next_step', lambda session, tags: tags)
+    monkeypatch.setattr(tactical, 'generate_letters', lambda session, tags: None)
+    monkeypatch.setattr(orchestrators, 'finalize_outputs', lambda *a, **k: None)
+    monkeypatch.setattr(orchestrators, 'save_log_file', lambda *a, **k: None)
+    monkeypatch.setattr(orchestrators, 'send_email_with_attachment', lambda *a, **k: None)
+    monkeypatch.setattr(orchestrators, 'save_analytics_snapshot', lambda *a, **k: None)
+    monkeypatch.setattr(orchestrators, 'update_session', lambda *a, **k: None)
+    monkeypatch.setattr(letters_router, 'select_template', lambda *a, **k: type('D', (), {'template_path': ''})())
+
+    client = ClientInfo.from_dict({"name": "Jane", "email": "jane@example.com", "session_id": "sess"})
+    report_path = tmp_path / 'report.pdf'
+    report_path.write_text('dummy')
+    proofs = ProofDocuments.from_dict({"smartcredit_report": str(report_path)})
+
+    orchestrators.run_credit_repair_process(client, proofs, False)
+
+    assert 'args' in called


### PR DESCRIPTION
## Summary
- add ingest_report service to diff tri-merge snapshots and emit OutcomeEvents
- update orchestrator to ingest new reports before planner runs
- test outcome report ingestion and orchestrator integration

## Testing
- `pytest tests/test_ingest_report.py tests/test_orchestrator_calls_ingest_report.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a670a881048325ba4c97b791b7227b