### PR TITLE
Track outcome classifications and cycle success metrics

### DIFF
--- a/backend/analytics/README.md
+++ b/backend/analytics/README.md
@@ -25,11 +25,12 @@ Common counters emitted for dashboards:
 - `rulebook.tag_selected.{tag}` – counts how often a rulebook action tag is chosen.
 - `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
 - `planner.cycle_progress{cycle,step}` – tracker for step advancement per cycle (cycle/step labels each <10).
-- `planner.time_to_next_step_ms` – milliseconds until next eligible planner action (single gauge).
-- `planner.resolution_rate` – fraction of accounts completed in a run (single gauge).
-- `planner.avg_cycles_per_resolution` – average cycles required for completed accounts (single gauge).
+- `planner.time_to_next_step_ms` – milliseconds until next eligible planner action (single gauge; alert on sustained spikes).
+- `planner.cycle_success_rate` – fraction of accounts completed in a run (single gauge; alert if <0.8).
+- `planner.avg_cycles_per_resolution` – average cycles required for completed accounts (single gauge; watch >p95).
 - `planner.sla_violations_total` – cumulative SLA violations when sends lag (single counter).
 - `planner.error_count` – planner exceptions caught (single counter).
+- `outcome.verified`, `outcome.updated`, `outcome.deleted`, `outcome.nochange` – counts of bureau classification results (four counters).
 
 ## Entry points
 - `analytics_tracker.save_analytics_snapshot`

--- a/docs/planner/README.md
+++ b/docs/planner/README.md
@@ -50,15 +50,15 @@ The planner sits after candidate routing. It consumes Stage 2.5 tag output and d
 ### Monitoring metrics
 
 - `planner.cycle_progress{cycle,step}` – counts step transitions per cycle.
-- `planner.time_to_next_step_ms` – milliseconds until the next eligible action.
-- `planner.resolution_rate` – fraction of accounts resolved in a run.
-- `planner.avg_cycles_per_resolution` – average cycles per resolved account.
+- `planner.time_to_next_step_ms` – milliseconds until the next eligible action (gauge; alert on sustained spikes).
+- `planner.cycle_success_rate` – fraction of accounts resolved in a run (target ≥0.8, single gauge).
+- `planner.avg_cycles_per_resolution` – average cycles per resolved account (gauge; alert if above historical p95).
 - `planner.sla_violations_total` – total number of SLA breaches.
 - `planner.error_count` – total planner exceptions.
 - `router.candidate_selected.*` and `router.finalized.*` – verify routing
   throughput when the planner pipeline is enabled.
 
-Dashboard alerts should watch for sustained drops in resolution rate, increases in cycle count, or spikes in SLA violations and errors.
+Dashboard alerts should watch for sustained drops in cycle success rate, increases in cycle count, or spikes in SLA violations and errors.
 
 To roll back, deploy with `ENABLE_PLANNER_PIPELINE=0` to restore the legacy router ordering without planner intervention.
 

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -39,6 +39,7 @@ Dashboards should surface the following counters:
 - `rulebook.tag_selected.{tag}` – frequency of chosen action tags.
 - `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
 - `planner.*` – cycle progress, SLA waits and error counts.
+- `outcome.verified`, `outcome.updated`, `outcome.deleted`, `outcome.nochange` – bureau classification distribution (each counter ≤cardinality 1; alert if `outcome.deleted` spikes above baseline).
 - `router.*` – candidate and finalize template selections and validation errors.
 
 ## Rollback

--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -113,7 +113,7 @@ def plan_next_step(
 
         if total_accounts:
             set_metric(
-                "planner.resolution_rate",
+                "planner.cycle_success_rate",
                 resolved_accounts / total_accounts,
             )
         if resolved_accounts:

--- a/services/outcome_ingestion/ingest_report.py
+++ b/services/outcome_ingestion/ingest_report.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, List, Mapping
 from backend.api import session_manager
 from backend.outcomes import OutcomeEvent
 from backend.outcomes.models import Outcome
+from backend.analytics.analytics_tracker import emit_counter
 from backend.core.logic.report_analysis.tri_merge import normalize_and_match
 from backend.core.logic.report_analysis.tri_merge_models import Tradeline, TradelineFamily
 
@@ -109,6 +110,7 @@ def ingest_report(account_id: str | None, new_report: Mapping[str, Any]) -> List
             else:
                 outcome = Outcome.VERIFIED
                 diff = None
+            emit_counter(f"outcome.{outcome.name.lower()}")
             event = OutcomeEvent(
                 outcome_id=str(uuid.uuid4()),
                 account_id=acc_id,

--- a/tests/test_planner_metrics.py
+++ b/tests/test_planner_metrics.py
@@ -55,7 +55,7 @@ def test_planner_metric_emissions(monkeypatch):
     assert counters["planner.cycle_progress.step.1"] == 1
     assert counters["planner.cycle_progress.step.2"] == 1
     assert counters["planner.sla_violations_total"] == 1
-    assert counters["planner.resolution_rate"] == 0.5
+    assert counters["planner.cycle_success_rate"] == 0.5
     assert counters["planner.avg_cycles_per_resolution"] == 2.0
     assert counters.get("planner.error_count", 0) == 0
     assert counters["planner.time_to_next_step_ms"] > 0


### PR DESCRIPTION
## Summary
- Emit `outcome.*` counters during report ingestion
- Rename planner resolution metric to `planner.cycle_success_rate`
- Document metric cardinality and alert thresholds in runbooks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a6747924d0832598d8ce3bd7992272