### PR TITLE
Add outcome ingestion and planner pipeline tests

### DIFF
--- a/tests/outcomes/test_ingest_report.py
+++ b/tests/outcomes/test_ingest_report.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import services.outcome_ingestion.ingest_report as ingest_mod
+from backend.api import session_manager
+from backend.core.logic.report_analysis.tri_merge_models import (
+    Tradeline,
+    TradelineFamily,
+)
+from backend.outcomes import load_outcome_history, save_outcome_event
+from backend.outcomes.models import Outcome, OutcomeEvent
+from services.outcome_ingestion.ingest_report import ingest_report
+
+
+def _family(fid: str, balance: int) -> TradelineFamily:
+    tl = Tradeline(
+        creditor="Cred",
+        bureau="Experian",
+        account_number="1",
+        data={"account_id": "1", "balance": balance},
+    )
+    fam = TradelineFamily(account_number="1", tradelines={"Experian": tl})
+    fam.family_id = fid  # type: ignore[attr-defined]
+    return fam
+
+
+def test_ingest_report_emits_all_outcomes(monkeypatch):
+    store: Dict[str, Dict] = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+
+    # avoid planner side effects
+    def fake_ingest(sess, event: OutcomeEvent) -> None:
+        save_outcome_event(sess["session_id"], event)
+
+    monkeypatch.setattr(ingest_mod, "ingest", fake_ingest)
+    monkeypatch.setenv("SESSION_ID", "s1")
+
+    baseline = [_family("f1", 100), _family("f2", 200), _family("f3", 300)]
+    updated = [_family("f1", 100), _family("f2", 250), _family("f4", 400)]
+    calls = {"n": 0}
+
+    def fake_normalize(tls: List[Tradeline]):
+        calls["n"] += 1
+        return baseline if calls["n"] == 1 else updated
+
+    monkeypatch.setattr(ingest_mod, "normalize_and_match", fake_normalize)
+
+    ingest_report(None, {})
+    events = ingest_report(None, {})
+
+    assert {e.outcome for e in events} == {
+        Outcome.VERIFIED,
+        Outcome.UPDATED,
+        Outcome.DELETED,
+        Outcome.NOCHANGE,
+    }
+    by_outcome = {e.outcome: e for e in events}
+    assert by_outcome[Outcome.VERIFIED].diff_snapshot is None
+    assert by_outcome[Outcome.NOCHANGE].diff_snapshot is None
+    assert by_outcome[Outcome.UPDATED].diff_snapshot == {
+        "previous": {"Experian": {"account_id": "1", "balance": 200}},
+        "current": {"Experian": {"account_id": "1", "balance": 250}},
+    }
+    assert by_outcome[Outcome.DELETED].diff_snapshot == {
+        "previous": {"Experian": {"account_id": "1", "balance": 300}},
+        "current": None,
+    }
+
+    history = load_outcome_history("s1", "1")
+    assert len(history) == 4
+
+    tri_merge = store["s1"]["tri_merge"]["snapshots"]["1"]
+    assert set(tri_merge.keys()) == {"f1", "f2", "f4"}
+    assert tri_merge["f2"]["Experian"]["balance"] == 250

--- a/tests/pipeline/goldens/planner_two_cycles.json
+++ b/tests/pipeline/goldens/planner_two_cycles.json
@@ -1,0 +1,12 @@
+{
+  "order": [
+    "candidate:dispute",
+    "planner",
+    "finalize:dispute",
+    "planner",
+    "planner",
+    "finalize:dispute"
+  ],
+  "final_current_step": 2,
+  "next_eligible_at": "2024-03-02T00:00:00"
+}

--- a/tests/pipeline/test_outcome_to_next_step.py
+++ b/tests/pipeline/test_outcome_to_next_step.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+
+import planner
+import services.outcome_ingestion.ingest_report as ingest_mod
+from backend.api import session_manager
+from backend.core.logic.report_analysis.tri_merge_models import (
+    Tradeline,
+    TradelineFamily,
+)
+from backend.core.models import AccountStatus
+from backend.outcomes import save_outcome_event
+from backend.outcomes.models import Outcome
+from services.outcome_ingestion.ingest_report import ingest_report
+
+
+def _family(fid: str, balance: int) -> TradelineFamily:
+    tl = Tradeline(
+        creditor="Cred",
+        bureau="Experian",
+        account_number="1",
+        data={"account_id": "1", "balance": balance},
+    )
+    fam = TradelineFamily(account_number="1", tradelines={"Experian": tl})
+    fam.family_id = fid  # type: ignore[attr-defined]
+    return fam
+
+
+SCENARIOS = [
+    (
+        [
+            _family("f1", 100),
+        ],
+        Outcome.VERIFIED,
+        ["mov", "direct_dispute"],
+        AccountStatus.CRA_RESPONDED_VERIFIED,
+    ),
+    (
+        [
+            _family("f1", 150),
+        ],
+        Outcome.UPDATED,
+        ["bureau_dispute"],
+        AccountStatus.CRA_RESPONDED_UPDATED,
+    ),
+    (
+        [
+            _family("f2", 200),
+        ],
+        Outcome.DELETED,
+        [],
+        AccountStatus.COMPLETED,
+    ),
+    (
+        [
+            _family("f1", 100),
+            _family("f2", 200),
+        ],
+        Outcome.NOCHANGE,
+        [],
+        AccountStatus.CRA_RESPONDED_NOCHANGE,
+    ),
+]
+
+
+def _setup_sessions(monkeypatch):
+    store: Dict[str, Dict] = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+    return store
+
+
+def test_outcome_to_next_step(monkeypatch):
+    store = _setup_sessions(monkeypatch)
+    monkeypatch.setenv("SESSION_ID", "s1")
+
+    # avoid auto planner updates during report ingest
+    def fake_ingest(sess, event):
+        save_outcome_event(sess["session_id"], event)
+
+    monkeypatch.setattr(ingest_mod, "ingest", fake_ingest)
+
+    baseline = [_family("f1", 100)]
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    for new_fams, outcome, expected_tags, final_status in SCENARIOS:
+        calls = {"n": 0}
+
+        def fake_normalize(tls: List[Tradeline]):
+            calls["n"] += 1
+            return baseline if calls["n"] == 1 else new_fams
+
+        monkeypatch.setattr(ingest_mod, "normalize_and_match", fake_normalize)
+
+        ingest_report(None, {})
+        events = ingest_report(None, {})
+        event = next(e for e in events if e.outcome == outcome)
+
+        planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+        planner.record_send(session, ["1"], now=datetime(2024, 1, 1))
+
+        allowed = planner.handle_outcome(session, event, now=datetime(2024, 1, 10))
+        state = planner.load_state(store["s1"]["account_states"]["1"])
+        assert state.status == final_status
+        assert allowed == expected_tags
+        if outcome is Outcome.NOCHANGE:
+            assert state.next_eligible_at is not None
+        else:
+            assert state.next_eligible_at is None
+
+        # reset for next scenario
+        store["s1"]["account_states"].pop("1")
+        store["s1"]["tri_merge"] = {"snapshots": {}}

--- a/tests/pipeline/test_planner_two_cycles_golden.py
+++ b/tests/pipeline/test_planner_two_cycles_golden.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import planner
+import tactical
+from backend.api import session_manager
+from backend.core.letters import router as letters_router
+
+
+def test_planner_two_cycles_golden(monkeypatch):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    monkeypatch.setattr(planner, "get_session", fake_get_session)
+    monkeypatch.setattr(planner, "update_session", fake_update_session)
+
+    order = []
+    orig_select = letters_router.select_template
+
+    def wrapped_select(tag, ctx, phase, session_id=None):
+        order.append(f"{phase}:{tag}")
+        return orig_select(tag, ctx, phase, session_id=session_id)
+
+    monkeypatch.setattr(letters_router, "select_template", wrapped_select)
+
+    send_times = [datetime(2024, 1, 1), datetime(2024, 2, 1)]
+    orig_record_send = planner.record_send
+
+    def fake_record_send(session, account_ids):
+        now = send_times.pop(0)
+        orig_record_send(session, account_ids, now=now, sla_days=30)
+
+    monkeypatch.setattr(planner, "record_send", fake_record_send)
+    orig_plan = planner.plan_next_step
+
+    def wrapped_plan(session, action_tags, now=None):
+        order.append("planner")
+        return orig_plan(session, action_tags, now=now)
+
+    monkeypatch.setattr(planner, "plan_next_step", wrapped_plan)
+
+    import backend.core.orchestrators as core_orch
+
+    def fake_generate_letters(
+        client_info,
+        bureau_data,
+        sections,
+        today_folder,
+        is_identity_theft,
+        strategy,
+        audit,
+        log_messages,
+        classification_map,
+        ai_client,
+        app_config,
+    ):
+        for acc in strategy.get("accounts", []):
+            tag = acc.get("action_tag")
+            call_tag = "dispute" if tag == "followup" else tag
+            letters_router.select_template(call_tag, acc, phase="finalize")
+        return []
+
+    monkeypatch.setattr(core_orch, "generate_letters", fake_generate_letters)
+
+    session = {
+        "session_id": "s1",
+        "strategy": {"accounts": [{"account_id": "1", "action_tag": "dispute"}]},
+    }
+
+    stage_2_5 = {"1": {"action_tag": "dispute"}}
+    letters_router.select_template("dispute", stage_2_5["1"], phase="candidate")
+
+    allowed = planner.plan_next_step(session, ["dispute"], now=datetime(2024, 1, 1))
+    tactical.generate_letters(session, allowed)
+
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 1, 15))
+    session["strategy"]["accounts"][0]["action_tag"] = "followup"
+    allowed = planner.plan_next_step(session, ["followup"], now=datetime(2024, 2, 5))
+    tactical.generate_letters(session, allowed)
+
+    state = planner.load_state(store["s1"]["account_states"]["1"])
+    result = {
+        "order": order,
+        "final_current_step": state.current_step,
+        "next_eligible_at": state.next_eligible_at.isoformat(),
+    }
+
+    golden_path = Path("tests/pipeline/goldens/planner_two_cycles.json")
+    expected = json.loads(golden_path.read_text())
+    assert result == expected


### PR DESCRIPTION
## Summary
- cover diff scenarios for ingest_report across all outcome types
- test planner.handle_outcome to advance account state and next steps
- add golden test for two-cycle planner flow with SLA waits

## Testing
- `pytest tests/outcomes/test_ingest_report.py tests/pipeline/test_outcome_to_next_step.py tests/pipeline/test_planner_two_cycles_golden.py -q`
- `pre-commit run --files tests/outcomes/test_ingest_report.py tests/pipeline/test_outcome_to_next_step.py tests/pipeline/test_planner_two_cycles_golden.py tests/pipeline/goldens/planner_two_cycles.json`


------
https://chatgpt.com/codex/tasks/task_b_68a6766cff308325b07c32bad8d11a5b