### PR TITLE
feat: gate outcome ingestion

### DIFF
--- a/docs/outcomes/README.md
+++ b/docs/outcomes/README.md
@@ -47,3 +47,9 @@ graph TD
 1. Monitor outcome throughput and SLA adherence dashboards.
 2. Investigate drops in processed reports or rising SLA breaches.
 3. Use the metrics to fine-tune planner rules and capacity planning.
+
+### Rollback
+
+1. Disable outcome ingestion by setting `ENABLE_OUTCOME_INGESTION` to `false`.
+2. Alternatively, set `OUTCOME_INGESTION_CANARY_PERCENT` to `0` to bypass planner updates.
+3. Re-enable by restoring the flag or increasing the canary percentage when ready.

--- a/services/outcome_ingestion/__init__.py
+++ b/services/outcome_ingestion/__init__.py
@@ -1,5 +1,34 @@
+import hashlib
+import os
+
 import planner
 from backend.outcomes import OutcomeEvent, save_outcome_event
+
+
+def _eligible_for_ingestion(account_id: str) -> bool:
+    """Return ``True`` if planner should process outcomes for ``account_id``."""
+
+    if os.getenv("ENABLE_OUTCOME_INGESTION", "true").lower() not in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return False
+
+    percent_raw = os.getenv("OUTCOME_INGESTION_CANARY_PERCENT", "100")
+    try:
+        percent = float(percent_raw)
+    except ValueError:
+        percent = 0.0
+
+    if percent >= 100:
+        return True
+    if percent <= 0:
+        return False
+
+    digest = hashlib.sha256(account_id.encode()).hexdigest()
+    bucket = int(digest[:8], 16) % 100
+    return bucket < percent
 
 
 def ingest(session: dict, event: OutcomeEvent) -> None:
@@ -8,5 +37,9 @@ def ingest(session: dict, event: OutcomeEvent) -> None:
     session_id = session.get("session_id")
     if not session_id:
         return
+
     save_outcome_event(session_id, event)
-    planner.handle_outcome(session, event)
+
+    acc_id = getattr(event, "account_id", "")
+    if _eligible_for_ingestion(str(acc_id)):
+        planner.handle_outcome(session, event)

--- a/tests/test_outcome_ingestion_flags.py
+++ b/tests/test_outcome_ingestion_flags.py
@@ -1,0 +1,68 @@
+from backend.api import session_manager
+from backend.outcomes import OutcomeEvent
+from services import outcome_ingestion
+import planner
+
+
+def _setup_store(monkeypatch):
+    store = {}
+
+    def fake_get_session(sid):
+        return store.get(sid)
+
+    def fake_update_session(sid, **kwargs):
+        session = store.setdefault(sid, {})
+        session.update(kwargs)
+        return session
+
+    monkeypatch.setattr(session_manager, "get_session", fake_get_session)
+    monkeypatch.setattr(session_manager, "update_session", fake_update_session)
+    return store
+
+
+def _make_event():
+    return OutcomeEvent(
+        outcome_id="o1",
+        account_id="1",
+        cycle_id=0,
+        family_id="f1",
+        outcome="Verified",
+    )
+
+
+def test_ingest_respects_enable_flag(monkeypatch):
+    _setup_store(monkeypatch)
+    calls = {"n": 0}
+
+    def fake_handle(sess, ev):
+        calls["n"] += 1
+
+    monkeypatch.setattr(planner, "handle_outcome", fake_handle)
+
+    session = {"session_id": "s1"}
+    event = _make_event()
+
+    monkeypatch.setenv("ENABLE_OUTCOME_INGESTION", "false")
+    outcome_ingestion.ingest(session, event)
+    assert calls["n"] == 0
+
+
+def test_ingest_respects_canary(monkeypatch):
+    _setup_store(monkeypatch)
+    calls = {"n": 0}
+
+    def fake_handle(sess, ev):
+        calls["n"] += 1
+
+    monkeypatch.setattr(planner, "handle_outcome", fake_handle)
+
+    session = {"session_id": "s1"}
+    event = _make_event()
+
+    monkeypatch.setenv("OUTCOME_INGESTION_CANARY_PERCENT", "0")
+    outcome_ingestion.ingest(session, event)
+    assert calls["n"] == 0
+
+    monkeypatch.setenv("OUTCOME_INGESTION_CANARY_PERCENT", "100")
+    outcome_ingestion.ingest(session, event)
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- gate planner outcome updates behind `ENABLE_OUTCOME_INGESTION`
- add percent-based canary via `OUTCOME_INGESTION_CANARY_PERCENT`
- document rollback steps for disabling outcome ingestion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a67c3b14b083258b3b2bc97cd81ff1