### PR TITLE
Add idempotent field population helpers

### DIFF
--- a/fields/__init__.py
+++ b/fields/__init__.py
@@ -1,0 +1,1 @@
+"""Field population helpers."""

--- a/fields/populate_account_number_masked.py
+++ b/fields/populate_account_number_masked.py
@@ -1,0 +1,17 @@
+"""Populate account_number_masked from tri-merge evidence."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_account_number_masked(
+    ctx: dict, tri_merge: Mapping[str, str] | None = None
+) -> None:
+    """Populate ``account_number_masked`` on ``ctx`` if missing."""
+
+    if ctx.get("account_number_masked"):
+        return
+    tri_merge = tri_merge or {}
+    masked = tri_merge.get("account_number_masked") or tri_merge.get("account_number")
+    if masked:
+        ctx["account_number_masked"] = masked

--- a/fields/populate_address.py
+++ b/fields/populate_address.py
@@ -1,0 +1,20 @@
+"""Populate corrected address from profile or planner corrections."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_address(
+    ctx: dict,
+    profile: Mapping[str, str] | None = None,
+    corrections: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``address`` on ``ctx`` if missing."""
+
+    if ctx.get("address"):
+        return
+    corrections = corrections or {}
+    profile = profile or {}
+    addr = corrections.get("address") or profile.get("address")
+    if addr:
+        ctx["address"] = addr

--- a/fields/populate_amount.py
+++ b/fields/populate_amount.py
@@ -1,0 +1,18 @@
+"""Populate amount from evidence."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_amount(
+    ctx: dict,
+    evidence: Mapping[str, object] | None = None,
+) -> None:
+    """Populate ``amount`` on ``ctx`` if missing."""
+
+    if ctx.get("amount") is not None:
+        return
+    evidence = evidence or {}
+    amount = evidence.get("amount")
+    if amount is not None:
+        ctx["amount"] = amount

--- a/fields/populate_creditor_name.py
+++ b/fields/populate_creditor_name.py
@@ -1,0 +1,30 @@
+"""Populate creditor_name from tri-merge evidence.
+
+Idempotently fills the ``creditor_name`` field on the provided context. Values
+are pulled from a tri-merge family record which may expose the creditor name
+under either ``creditor_name`` or ``name``.  The field is only set when missing
+from ``ctx`` and a source value is available.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_creditor_name(ctx: dict, tri_merge: Mapping[str, str] | None = None) -> None:
+    """Populate ``creditor_name`` on ``ctx`` if missing.
+
+    Parameters
+    ----------
+    ctx:
+        The letter context to mutate.
+    tri_merge:
+        A mapping representing tri-merge evidence. Either ``creditor_name`` or
+        ``name`` may be supplied.
+    """
+
+    if ctx.get("creditor_name"):
+        return
+    tri_merge = tri_merge or {}
+    name = tri_merge.get("creditor_name") or tri_merge.get("name")
+    if name:
+        ctx["creditor_name"] = name

--- a/fields/populate_days_since_cra_result.py
+++ b/fields/populate_days_since_cra_result.py
@@ -1,0 +1,35 @@
+"""Compute days_since_cra_result from an outcome timestamp."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Mapping
+
+
+def populate_days_since_cra_result(
+    ctx: dict,
+    outcome: Mapping[str, object] | None = None,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Populate ``days_since_cra_result`` on ``ctx`` if missing.
+
+    ``outcome`` may provide a ``timestamp`` field representing the last CRA
+    result date. If ``timestamp`` is a string, it must be ISO formatted.
+    """
+
+    if ctx.get("days_since_cra_result") is not None:
+        return
+
+    if not outcome:
+        return
+
+    ts = outcome.get("timestamp") or outcome.get("cra_result_at")
+    if not ts:
+        return
+
+    if isinstance(ts, str):
+        result_time = datetime.fromisoformat(ts)
+    else:
+        result_time = ts
+    now = now or datetime.now(result_time.tzinfo or timezone.utc)
+    ctx["days_since_cra_result"] = (now - result_time).days

--- a/fields/populate_dob.py
+++ b/fields/populate_dob.py
@@ -1,0 +1,20 @@
+"""Populate date of birth from profile or corrections."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_dob(
+    ctx: dict,
+    profile: Mapping[str, str] | None = None,
+    corrections: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``date_of_birth`` on ``ctx`` if missing."""
+
+    if ctx.get("date_of_birth"):
+        return
+    corrections = corrections or {}
+    profile = profile or {}
+    dob = corrections.get("date_of_birth") or profile.get("date_of_birth")
+    if dob:
+        ctx["date_of_birth"] = dob

--- a/fields/populate_inquiry_creditor_name.py
+++ b/fields/populate_inquiry_creditor_name.py
@@ -1,0 +1,18 @@
+"""Populate inquiry_creditor_name from evidence."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_inquiry_creditor_name(
+    ctx: dict,
+    evidence: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``inquiry_creditor_name`` on ``ctx`` if missing."""
+
+    if ctx.get("inquiry_creditor_name"):
+        return
+    evidence = evidence or {}
+    name = evidence.get("inquiry_creditor_name") or evidence.get("name")
+    if name:
+        ctx["inquiry_creditor_name"] = name

--- a/fields/populate_inquiry_date.py
+++ b/fields/populate_inquiry_date.py
@@ -1,0 +1,18 @@
+"""Populate inquiry_date from evidence."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_inquiry_date(
+    ctx: dict,
+    evidence: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``inquiry_date`` on ``ctx`` if missing."""
+
+    if ctx.get("inquiry_date"):
+        return
+    evidence = evidence or {}
+    date = evidence.get("inquiry_date") or evidence.get("date")
+    if date:
+        ctx["inquiry_date"] = date

--- a/fields/populate_medical_status.py
+++ b/fields/populate_medical_status.py
@@ -1,0 +1,18 @@
+"""Populate medical_status from evidence."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_medical_status(
+    ctx: dict,
+    evidence: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``medical_status`` on ``ctx`` if missing."""
+
+    if ctx.get("medical_status"):
+        return
+    evidence = evidence or {}
+    status = evidence.get("medical_status") or evidence.get("status")
+    if status:
+        ctx["medical_status"] = status

--- a/fields/populate_name.py
+++ b/fields/populate_name.py
@@ -1,0 +1,20 @@
+"""Populate corrected name from profile or planner corrections."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def populate_name(
+    ctx: dict,
+    profile: Mapping[str, str] | None = None,
+    corrections: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``name`` on ``ctx`` if missing."""
+
+    if ctx.get("name"):
+        return
+    corrections = corrections or {}
+    profile = profile or {}
+    name = corrections.get("name") or profile.get("name")
+    if name:
+        ctx["name"] = name

--- a/fields/populate_ssn_masked.py
+++ b/fields/populate_ssn_masked.py
@@ -1,0 +1,29 @@
+"""Populate masked SSN from profile or corrections."""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def _mask(ssn: str) -> str:
+    if len(ssn) == 4:
+        return f"***-**-{ssn}"
+    if len(ssn) == 9:
+        return f"***-**-{ssn[-4:]}"
+    return ssn
+
+
+def populate_ssn_masked(
+    ctx: dict,
+    profile: Mapping[str, str] | None = None,
+    corrections: Mapping[str, str] | None = None,
+) -> None:
+    """Populate ``ssn_masked`` on ``ctx`` if missing."""
+
+    if ctx.get("ssn_masked"):
+        return
+    corrections = corrections or {}
+    profile = profile or {}
+    ssn = corrections.get("ssn") or corrections.get("ssn_last4")
+    ssn = ssn or profile.get("ssn") or profile.get("ssn_last4")
+    if ssn:
+        ctx["ssn_masked"] = _mask(str(ssn))

--- a/tests/fields/test_populators.py
+++ b/tests/fields/test_populators.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from fields.populate_account_number_masked import populate_account_number_masked
+from fields.populate_address import populate_address
+from fields.populate_amount import populate_amount
+from fields.populate_creditor_name import populate_creditor_name
+from fields.populate_days_since_cra_result import populate_days_since_cra_result
+from fields.populate_dob import populate_dob
+from fields.populate_inquiry_creditor_name import populate_inquiry_creditor_name
+from fields.populate_inquiry_date import populate_inquiry_date
+from fields.populate_medical_status import populate_medical_status
+from fields.populate_name import populate_name
+from fields.populate_ssn_masked import populate_ssn_masked
+
+
+def test_creditor_and_account_fields_idempotent():
+    ctx: dict = {}
+    populate_creditor_name(ctx, {"name": "ABC"})
+    populate_account_number_masked(ctx, {"account_number": "****1"})
+    assert ctx["creditor_name"] == "ABC"
+    assert ctx["account_number_masked"] == "****1"
+
+    populate_creditor_name(ctx, {"name": "XYZ"})
+    populate_account_number_masked(ctx, {"account_number": "****2"})
+    assert ctx["creditor_name"] == "ABC"
+    assert ctx["account_number_masked"] == "****1"
+
+
+def test_days_since_cra_result_computation():
+    ctx: dict = {}
+    ts = datetime(2024, 1, 1)
+    populate_days_since_cra_result(ctx, {"timestamp": ts}, now=datetime(2024, 1, 31))
+    assert ctx["days_since_cra_result"] == 30
+
+    # second call does not override
+    populate_days_since_cra_result(ctx, {"timestamp": ts}, now=datetime(2024, 2, 1))
+    assert ctx["days_since_cra_result"] == 30
+
+
+def test_pii_population():
+    ctx: dict = {}
+    profile = {
+        "name": "Profile Name",
+        "address": "123 Main St",
+        "date_of_birth": "2000-01-01",
+        "ssn_last4": "1234",
+    }
+    corrections = {"name": "Correct Name", "address": "456 Elm St"}
+    populate_name(ctx, profile, corrections)
+    populate_address(ctx, profile, corrections)
+    populate_dob(ctx, profile, corrections)
+    populate_ssn_masked(ctx, profile, corrections)
+    assert ctx == {
+        "name": "Correct Name",
+        "address": "456 Elm St",
+        "date_of_birth": "2000-01-01",
+        "ssn_masked": "***-**-1234",
+    }
+
+    populate_name(ctx, {"name": "Other"}, {})
+    assert ctx["name"] == "Correct Name"
+
+
+def test_inquiry_and_medical_fields():
+    ctx: dict = {}
+    inquiry_evidence = {"name": "Inq Co", "date": "2024-02-01"}
+    populate_inquiry_creditor_name(ctx, inquiry_evidence)
+    populate_inquiry_date(ctx, inquiry_evidence)
+    assert ctx["inquiry_creditor_name"] == "Inq Co"
+    assert ctx["inquiry_date"] == "2024-02-01"
+
+    populate_inquiry_creditor_name(ctx, {"name": "Other"})
+    assert ctx["inquiry_creditor_name"] == "Inq Co"
+
+    medical_evidence = {"amount": 100, "status": "Unpaid"}
+    populate_amount(ctx, medical_evidence)
+    populate_medical_status(ctx, medical_evidence)
+    assert ctx["amount"] == 100
+    assert ctx["medical_status"] == "Unpaid"
+
+    populate_amount(ctx, {"amount": 200})
+    assert ctx["amount"] == 100


### PR DESCRIPTION
## Summary
- add helpers to populate CRA-derived fields and days-since-CRA-result
- extract corrected PII with masking and idempotent rules
- populate inquiry and medical dispute details from evidence

## Testing
- `pytest tests/fields/test_populators.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a725511b908325b2a7ac07cd2fa64b