### PR TITLE
Run field fillers before finalize routing

### DIFF
--- a/backend/core/letters/field_population.py
+++ b/backend/core/letters/field_population.py
@@ -1,0 +1,70 @@
+"""Helpers to populate missing fields prior to template validation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from backend.core.logic.letters.utils import populate_required_fields
+from fields.populate_account_number_masked import populate_account_number_masked
+from fields.populate_address import populate_address
+from fields.populate_amount import populate_amount
+from fields.populate_creditor_name import populate_creditor_name
+from fields.populate_days_since_cra_result import populate_days_since_cra_result
+from fields.populate_dob import populate_dob
+from fields.populate_inquiry_creditor_name import populate_inquiry_creditor_name
+from fields.populate_inquiry_date import populate_inquiry_date
+from fields.populate_medical_status import populate_medical_status
+from fields.populate_name import populate_name
+from fields.populate_ssn_masked import populate_ssn_masked
+
+
+def apply_field_fillers(
+    ctx: dict,
+    *,
+    strategy: Mapping[str, Any] | None = None,
+    profile: Mapping[str, Any] | None = None,
+    corrections: Mapping[str, Any] | None = None,
+) -> None:
+    """Populate ``ctx`` using available field fillers.
+
+    Parameters
+    ----------
+    ctx:
+        Context dictionary mutated in-place.
+    strategy:
+        Optional per-account strategy data used by ``populate_required_fields``.
+    profile:
+        Optional client profile supplying PII fields.
+    corrections:
+        Optional corrections overriding profile values.
+    """
+
+    tri_merge = ctx.get("tri_merge") or {}
+    inquiry = ctx.get("inquiry_evidence") or ctx.get("inquiry") or {}
+    medical = ctx.get("medical_evidence") or ctx.get("medical") or {}
+    outcome = ctx.get("cra_outcome") or ctx.get("outcome") or {}
+    profile = profile or ctx.get("profile") or ctx.get("client") or {}
+    corrections = corrections or ctx.get("corrections") or {}
+
+    # Client/profile fields -----------------------------------------------------
+    populate_name(ctx, profile, corrections)
+    populate_address(ctx, profile, corrections)
+    populate_dob(ctx, profile, corrections)
+    populate_ssn_masked(ctx, profile, corrections)
+
+    # Evidence-driven account fields -------------------------------------------
+    if tri_merge.get("name") and not ctx.get("name"):
+        ctx["name"] = tri_merge["name"]
+    populate_creditor_name(ctx, tri_merge)
+    populate_account_number_masked(ctx, tri_merge)
+    populate_days_since_cra_result(ctx, outcome)
+    populate_inquiry_creditor_name(ctx, inquiry)
+    populate_inquiry_date(ctx, inquiry)
+    populate_amount(ctx, medical)
+    populate_medical_status(ctx, medical)
+
+    # Strategy provided fields -------------------------------------------------
+    populate_required_fields(ctx, strategy)
+
+
+__all__ = ["apply_field_fillers"]

--- a/backend/core/letters/validators.py
+++ b/backend/core/letters/validators.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Dict, List
 import re
-from backend.core.logic.utils.pii import redact_pii
+from typing import Dict, List
 
+from backend.core.logic.utils.pii import redact_pii
 
 CHECKLIST: Dict[str, List[str]] = {
     "dispute_letter_template.html": ["bureau"],
@@ -97,7 +97,7 @@ def validate_required_fields(
     """Return missing required fields for ``template_path``."""
 
     expected = required or checklist.get(template_path or "", [])
-    missing = [field for field in expected if not ctx.get(field)]
+    missing = [field for field in expected if ctx.get(field) is None]
 
     sentence = ctx.get("client_context_sentence")
     if sentence:
@@ -129,7 +129,6 @@ def validate_required_fields(
                     missing.append("per_account_actions.action_verb")
                     break
 
-
     return missing
 
 
@@ -137,9 +136,7 @@ def validate_substance(template_path: str, ctx: dict) -> List[str]:
     """Return missing substantive markers for ``template_path``."""
 
     requirements = SUBSTANCE_CHECKLIST.get(template_path, {})
-    text = " ".join(
-        str(v).lower() for v in ctx.values() if isinstance(v, str)
-    )
+    text = " ".join(str(v).lower() for v in ctx.values() if isinstance(v, str))
     missing: List[str] = []
     for key, pattern in requirements.items():
         if pattern is None:
@@ -157,4 +154,3 @@ __all__ = [
     "CHECKLIST",
     "SUBSTANCE_CHECKLIST",
 ]
-

--- a/tests/letters/test_field_population_pipeline.py
+++ b/tests/letters/test_field_population_pipeline.py
@@ -1,0 +1,52 @@
+import pytest
+
+from backend.core.letters.field_population import apply_field_fillers
+from backend.core.letters.router import select_template
+
+SCENARIOS = [
+    (
+        "pay_for_delete",
+        {
+            "action_tag": "pay_for_delete",
+            "legal_safe_summary": "I will pay if you delete this account.",
+            "tri_merge": {
+                "name": "ABC Collections",
+                "account_number_masked": "****1234",
+            },
+        },
+        {"offer_terms": "Delete and pay 60%"},
+    ),
+    (
+        "inquiry_dispute",
+        {
+            "action_tag": "inquiry_dispute",
+            "bureau": "Experian",
+            "legal_safe_summary": "This inquiry was unauthorized.",
+            "tri_merge": {"account_number_masked": "****1111"},
+            "inquiry_evidence": {"name": "Inq Co", "date": "2024-01-01"},
+        },
+        None,
+    ),
+    (
+        "medical_dispute",
+        {
+            "action_tag": "medical_dispute",
+            "bureau": "Experian",
+            "legal_safe_summary": "Paid medical debt under $500 should be removed.",
+            "tri_merge": {"name": "Med Co", "account_number_masked": "****2222"},
+            "medical_evidence": {"amount": 100, "status": "Unpaid"},
+        },
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize("tag, ctx, strat", SCENARIOS)
+def test_field_population_pipeline(monkeypatch, tag, ctx, strat):
+    monkeypatch.setenv("LETTERS_ROUTER_PHASED", "1")
+    if strat:
+        apply_field_fillers(ctx, strategy=strat)
+    else:
+        apply_field_fillers(ctx)
+    decision = select_template(tag, ctx, phase="finalize")
+    assert decision.missing_fields == []


### PR DESCRIPTION
## Summary
- run field fillers and merge results before finalize template selection
- finalize validators now only report fields left as `None`
- cover green-path scenarios with field population pipeline tests

## Testing
- `pre-commit run --files backend/core/letters/field_population.py backend/core/letters/validators.py backend/core/orchestrators.py backend/core/logic/rendering/instructions_generator.py tests/letters/test_field_population_pipeline.py`
- `pytest tests/letters/test_field_population_pipeline.py`
- `pytest tests/test_strategy_merge_populates_fields.py tests/fields/test_populators.py`


------
https://chatgpt.com/codex/tasks/task_b_68a727d0a1608325883bda1aa4d086fc