### PR TITLE
feat: backfill session fields from history

### DIFF
--- a/tests/test_session_backfill.py
+++ b/tests/test_session_backfill.py
@@ -1,0 +1,31 @@
+from backend.api.session_manager import populate_from_history, update_session
+
+
+def test_backfill_fields_across_cycles(tmp_path, monkeypatch):
+    sess_file = tmp_path / "sessions.json"
+    monkeypatch.setattr("backend.api.session_manager.SESSION_FILE", sess_file)
+
+    session_id = "s1"
+    update_session(
+        session_id,
+        tri_merge={"evidence": {"fam1": {"a": 1}}},
+        outcome_history={"acct1": [{"outcome": "Deleted"}]},
+    )
+
+    fresh = {"session_id": session_id}
+    populate_from_history(fresh)
+    assert fresh["tri_merge"]["evidence"] == {"fam1": {"a": 1}}
+    assert fresh["outcome_history"] == {"acct1": [{"outcome": "Deleted"}]}
+    assert fresh["_provenance"] == {
+        "tri_merge.evidence": "history",
+        "outcome_history": "history",
+    }
+
+    newer = {"session_id": session_id}
+    populate_from_history(newer)
+    assert newer["tri_merge"] == fresh["tri_merge"]
+    assert newer["outcome_history"] == fresh["outcome_history"]
+    assert newer["_provenance"] == {
+        "tri_merge.evidence": "history",
+        "outcome_history": "history",
+    }


### PR DESCRIPTION
## Summary
- add populate_from_history to backfill tri-merge evidence and planner outcomes
- track provenance for fields copied forward
- test that backfilled fields remain stable across cycles

## Testing
- `pytest tests/test_session_tri_merge.py tests/test_session_backfill.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a729aeaa28832587cfe2446b59da2b