### PR TITLE
Track field filler failures and escalate

### DIFF
--- a/docs/fields/runbook.md
+++ b/docs/fields/runbook.md
@@ -1,0 +1,29 @@
+# Field population runbook
+
+This runbook explains how missing field data is escalated when automatic fillers
+cannot populate a value.
+
+## Error emission
+
+Filler failures emit an audit event:
+
+```
+fields.populate_errors{tag, field, reason}
+```
+
+The event payload identifies the action tag, the missing field, and the reason
+for failure. The field is recorded on the account context under
+`missing_fields` for downstream consumers.
+
+## Escalation
+
+* **Critical fields** – `name`, `address`, `date_of_birth`, `ssn_masked`,
+  `creditor_name`, `account_number_masked`, `inquiry_creditor_name`, and
+  `inquiry_date`. When any of these are missing the planner defers the
+  action tag and the user is prompted to supply the information.
+* **Optional fields** – `days_since_cra_result`, `amount`, and `medical_status`.
+  These fall back to a safe default template when missing and do not block
+  processing.
+
+The planner or letter router can reference `critical_missing_fields` on the
+context to determine which pathway was taken.

--- a/tests/fields/test_population_errors.py
+++ b/tests/fields/test_population_errors.py
@@ -1,0 +1,42 @@
+from backend.core.letters.field_population import apply_field_fillers
+
+
+def test_critical_field_failure_emits_event_and_defers(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        "backend.core.letters.field_population.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    ctx = {"action_tag": "pay_for_delete"}
+    apply_field_fillers(ctx)
+    assert "name" in ctx["missing_fields"]
+    assert ctx.get("defer_action_tag") is True
+    assert any(
+        e == "fields.populate_errors" and p["field"] == "name" for e, p in events
+    )
+
+
+def test_optional_field_failure_does_not_defer(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        "backend.core.letters.field_population.emit_event",
+        lambda e, p: events.append((e, p)),
+    )
+    ctx = {
+        "action_tag": "mov",
+        "name": "X",
+        "address": "123",
+        "date_of_birth": "2000-01-01",
+        "ssn_masked": "***-**-1234",
+        "creditor_name": "Cred",
+        "account_number_masked": "****1111",
+        "inquiry_creditor_name": "Inq",
+        "inquiry_date": "2024-01-01",
+    }
+    apply_field_fillers(ctx)
+    assert "days_since_cra_result" in ctx["missing_fields"]
+    assert ctx.get("defer_action_tag") is not True
+    assert any(
+        e == "fields.populate_errors" and p["field"] == "days_since_cra_result"
+        for e, p in events
+    )


### PR DESCRIPTION
## Summary
- emit `fields.populate_errors` for unfilled fields and defer critical actions
- document missing-field escalation in docs/fields/runbook.md
- add regression tests for field filler failure handling

## Testing
- `pre-commit run --files backend/core/letters/field_population.py tests/fields/test_population_errors.py docs/fields/runbook.md`
- `pytest tests/fields/test_population_errors.py tests/fields/test_populators.py tests/letters/test_field_population_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_68a72c96e6d88325a7eab6fe11a9388c