### PR TITLE
Add metrics for field population and finalize missing fields

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -68,7 +68,7 @@ def emit_counter(name: str, increment: float | Mapping[str, Any] = 1) -> None:
         if isinstance(increment, Mapping):
             _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
             for key, value in increment.items():
-                if value is None or key not in {"tag", "outcome", "cycle"}:
+                if value is None or key not in {"tag", "outcome", "cycle", "field", "reason"}:
                     continue
                 attr_name = f"{name}.{key}.{value}"
                 _COUNTERS[attr_name] = _COUNTERS.get(attr_name, 0) + 1

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -791,6 +791,11 @@ def run_credit_repair_process(
             tag = acc_ctx.get("action_tag")
             acc_strat = strategy_accounts.get(acc_id, {})
             apply_field_fillers(acc_ctx, strategy=acc_strat, profile=client_info)
+            if tag:
+                for _ in acc_ctx.get("missing_fields", []):
+                    emit_counter(
+                        "finalize.missing_fields_after_population", {"tag": tag}
+                    )
             letters_router.select_template(tag, acc_ctx, phase="finalize")
         if session_id:
             update_session(session_id, stage_2_5=stage_2_5)

--- a/tests/fields/test_population_errors.py
+++ b/tests/fields/test_population_errors.py
@@ -1,27 +1,20 @@
 from backend.core.letters.field_population import apply_field_fillers
+from backend.analytics.analytics_tracker import reset_counters, get_counters
 
 
-def test_critical_field_failure_emits_event_and_defers(monkeypatch):
-    events = []
-    monkeypatch.setattr(
-        "backend.core.letters.field_population.emit_event",
-        lambda e, p: events.append((e, p)),
-    )
+def test_critical_field_failure_emits_metric_and_defers():
+    reset_counters()
     ctx = {"action_tag": "pay_for_delete"}
     apply_field_fillers(ctx)
+    counters = get_counters()
     assert "name" in ctx["missing_fields"]
     assert ctx.get("defer_action_tag") is True
-    assert any(
-        e == "fields.populate_errors" and p["field"] == "name" for e, p in events
-    )
+    assert counters.get("fields.populate_errors.field.name") == 1
+    assert counters.get("fields.populate_errors.tag.pay_for_delete")
 
 
-def test_optional_field_failure_does_not_defer(monkeypatch):
-    events = []
-    monkeypatch.setattr(
-        "backend.core.letters.field_population.emit_event",
-        lambda e, p: events.append((e, p)),
-    )
+def test_optional_field_failure_does_not_defer():
+    reset_counters()
     ctx = {
         "action_tag": "mov",
         "name": "X",
@@ -34,9 +27,8 @@ def test_optional_field_failure_does_not_defer(monkeypatch):
         "inquiry_date": "2024-01-01",
     }
     apply_field_fillers(ctx)
+    counters = get_counters()
     assert "days_since_cra_result" in ctx["missing_fields"]
     assert ctx.get("defer_action_tag") is not True
-    assert any(
-        e == "fields.populate_errors" and p["field"] == "days_since_cra_result"
-        for e, p in events
-    )
+    assert counters.get("fields.populate_errors.field.days_since_cra_result") == 1
+    assert counters.get("fields.populate_errors.tag.mov")


### PR DESCRIPTION
## Summary
- track populated and failed fields with labeled metrics
- record remaining missing fields after population
- whitelist new metric labels and test instrumentation

## Testing
- `pytest tests/fields/test_population_errors.py tests/letters/test_field_population_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a738c584f88325bb6fd508c2949a16