### PR TITLE
Add field population metrics dashboard and runbook guidance

### DIFF
--- a/deployment/grafana/field_population.json
+++ b/deployment/grafana/field_population.json
@@ -1,0 +1,37 @@
+{
+  "title": "Field Population",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Fields Populated",
+      "targets": [
+        {
+          "expr": "sum by (field) (rate(fields_populated_total[5m]))",
+          "legendFormat": "{{field}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Populate Errors",
+      "targets": [
+        {
+          "expr": "sum by (field) (rate(fields_populate_errors[5m]))",
+          "legendFormat": "{{field}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Missing Fields After Population",
+      "targets": [
+        {
+          "expr": "sum by (tag) (rate(finalize_missing_fields_after_population[5m]))",
+          "legendFormat": "{{tag}}"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/fields/runbook.md
+++ b/docs/fields/runbook.md
@@ -15,6 +15,37 @@ The event payload identifies the action tag, the missing field, and the reason
 for failure. The field is recorded on the account context under
 `missing_fields` for downstream consumers.
 
+## Metrics
+
+Three counters track filler performance:
+
+* `fields.populated_total` – incremented when a filler successfully populates a
+  field. Labeled by `tag` and `field`; aggregate by `field` for dashboards to
+  avoid high cardinality.
+* `fields.populate_errors` – emitted when a filler fails. Labels include
+  `tag`, `field`, and `reason`; aggregate by `field`.
+* `finalize.missing_fields_after_population` – counts tags that still lack
+  required fields after the population step. Labeled by `tag` only.
+
+### Alert thresholds
+
+* **Populate errors** – alert if
+  `sum(rate(fields_populate_errors[5m])) by (field)` exceeds `0` for any field.
+* **Missing after population** – page when
+  `sum(rate(finalize_missing_fields_after_population[5m]))` is greater than
+  `1`.
+* **Populated total** – investigate if
+  `sum(rate(fields_populated_total[5m])) by (field)` drops to `0` for any field
+  for five minutes.
+
+### Example queries
+
+```promql
+sum by(field) (rate(fields_populated_total[5m]))
+sum by(field) (rate(fields_populate_errors[5m]))
+sum by(tag) (rate(finalize_missing_fields_after_population[5m]))
+```
+
 ## Escalation
 
 * **Critical fields** – `name`, `address`, `date_of_birth`, `ssn_masked`,
@@ -27,6 +58,12 @@ for failure. The field is recorded on the account context under
 
 The planner or letter router can reference `critical_missing_fields` on the
 context to determine which pathway was taken.
+
+## Rollout
+
+Enable the feature by setting `ENABLE_FIELD_POPULATION=1`. Ramp traffic by
+increasing `FIELD_POPULATION_CANARY_PERCENT` from `0` to `100` while monitoring
+the metrics above for regressions.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary
- Add Grafana dashboard panels for field population success, errors, and remaining missing fields
- Document metrics, alerts, example queries, and rollout steps for ENABLE_FIELD_POPULATION

## Testing
- `pytest tests/letters/test_field_population_pipeline.py tests/test_field_population_flags.py`

------
https://chatgpt.com/codex/tasks/task_b_68a73d4b7f088325a562257aafa3ff98