### PR TITLE
feat: add tri-merge metrics and restrict labels

### DIFF
--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -68,7 +68,7 @@ def emit_counter(name: str, increment: float | Mapping[str, Any] = 1) -> None:
         if isinstance(increment, Mapping):
             _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
             for key, value in increment.items():
-                if value is None or key not in {"tag", "outcome", "cycle", "field", "reason"}:
+                if value is None or key not in {"bureau", "mismatch_type"}:
                     continue
                 attr_name = f"{name}.{key}.{value}"
                 _COUNTERS[attr_name] = _COUNTERS.get(attr_name, 0) + 1

--- a/backend/core/letters/field_population.py
+++ b/backend/core/letters/field_population.py
@@ -49,9 +49,10 @@ def _mark_missing(ctx: dict, tag: str, field: str, reason: str = "missing") -> N
         "fields.populate_errors",
         {"tag": tag, "field": field, "reason": reason},
     )
-    emit_counter(
-        "fields.populate_errors", {"tag": tag, "field": field, "reason": reason}
-    )
+    emit_counter("fields.populate_errors")
+    emit_counter(f"fields.populate_errors.tag.{tag}")
+    emit_counter(f"fields.populate_errors.field.{field}")
+    emit_counter(f"fields.populate_errors.reason.{reason}")
     missing = ctx.setdefault("missing_fields", [])
     if field not in missing:
         missing.append(field)
@@ -143,7 +144,9 @@ def apply_field_fillers(
     # Missing field handling -----------------------------------------------------
     for field in CRITICAL_FIELDS | OPTIONAL_FIELDS:
         if field in initial_missing and ctx.get(field):
-            emit_counter("fields.populated_total", {"tag": tag, "field": field})
+            emit_counter("fields.populated_total")
+            emit_counter(f"fields.populated_total.tag.{tag}")
+            emit_counter(f"fields.populated_total.field.{field}")
         if not ctx.get(field):
             _mark_missing(ctx, tag, field)
 

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -702,7 +702,11 @@ def run_credit_repair_process(
                                 data=acc,
                             )
                         )
+            _start = time.perf_counter()
             families = normalize_and_match(tradelines)
+            emit_counter(
+                "tri_merge.process_time_ms", (time.perf_counter() - _start) * 1000
+            )
             compute_mismatches(families)
             tri_session = get_session(session_id) if session_id else None
             tri_evidence = (

--- a/letters/candidate_router.py
+++ b/letters/candidate_router.py
@@ -83,7 +83,8 @@ def select_template(
         selected = "default_dispute.html"
         metric_tag = "default"
 
-    emit_counter("router.candidate_selected", {"tag": metric_tag})
+    emit_counter("router.candidate_selected")
+    emit_counter(f"router.candidate_selected.{metric_tag}")
 
     if audit is not None:
         payload = f"{tag}:{selected}".encode("utf-8")


### PR DESCRIPTION
## Summary
- emit tri-merge metrics with bureau labels and gauge match confidence
- record tri-merge processing time and tighten metric label whitelist

## Testing
- `pytest tests/report_analysis/test_tri_merge.py tests/letters/test_candidate_routing.py tests/letters/test_field_population_pipeline.py tests/fields/test_population_errors.py`

------
https://chatgpt.com/codex/tasks/task_b_68a7445962ac8325a3e980807aa1262f