### PR TITLE
Instrument planner metrics with cycle/step labels

### DIFF
--- a/backend/analytics/README.md
+++ b/backend/analytics/README.md
@@ -26,7 +26,7 @@ Common counters emitted for dashboards:
 - `rulebook.suppressed_rules.{rule_name}` – rules skipped due to precedence or exclusion.
 - `planner.cycle_progress{cycle,step}` – tracker for step advancement per cycle (cycle/step labels each <10).
 - `planner.time_to_next_step_ms` – milliseconds until next eligible planner action (single gauge; alert on sustained spikes).
-- `planner.cycle_success_rate` – fraction of accounts completed in a run (single gauge; alert if <0.8).
+- `planner.resolution_rate` – fraction of accounts completed in a run (single gauge; alert if <0.8).
 - `planner.avg_cycles_per_resolution` – average cycles required for completed accounts (single gauge; watch >p95).
 - `planner.sla_violations_total` – cumulative SLA violations when sends lag (single counter).
 - `planner.error_count` – planner exceptions caught (single counter).

--- a/backend/analytics/analytics_tracker.py
+++ b/backend/analytics/analytics_tracker.py
@@ -67,8 +67,9 @@ def emit_counter(name: str, increment: float | Mapping[str, Any] = 1) -> None:
     with _COUNTER_LOCK:
         if isinstance(increment, Mapping):
             _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
+            allowed = {"bureau", "mismatch_type", "cycle", "step"}
             for key, value in increment.items():
-                if value is None or key not in {"bureau", "mismatch_type"}:
+                if value is None or key not in allowed:
                     continue
                 attr_name = f"{name}.{key}.{value}"
                 _COUNTERS[attr_name] = _COUNTERS.get(attr_name, 0) + 1

--- a/docs/planner/README.md
+++ b/docs/planner/README.md
@@ -51,14 +51,14 @@ The planner sits after candidate routing. It consumes Stage 2.5 tag output and d
 
 - `planner.cycle_progress{cycle,step}` – counts step transitions per cycle.
 - `planner.time_to_next_step_ms` – milliseconds until the next eligible action (gauge; alert on sustained spikes).
-- `planner.cycle_success_rate` – fraction of accounts resolved in a run (target ≥0.8, single gauge).
+- `planner.resolution_rate` – fraction of accounts resolved in a run (target ≥0.8, single gauge).
 - `planner.avg_cycles_per_resolution` – average cycles per resolved account (gauge; alert if above historical p95).
 - `planner.sla_violations_total` – total number of SLA breaches.
 - `planner.error_count` – total planner exceptions.
 - `router.candidate_selected.*` and `router.finalized.*` – verify routing
   throughput when the planner pipeline is enabled.
 
-Dashboard alerts should watch for sustained drops in cycle success rate, increases in cycle count, or spikes in SLA violations and errors.
+Dashboard alerts should watch for sustained drops in resolution rate, increases in cycle count, or spikes in SLA violations and errors.
 
 To roll back, deploy with `ENABLE_PLANNER_PIPELINE=0` to restore the legacy router ordering without planner intervention.
 

--- a/tests/test_planner_metrics.py
+++ b/tests/test_planner_metrics.py
@@ -52,10 +52,12 @@ def test_planner_metric_emissions(monkeypatch):
 
     assert counters["planner.cycle_progress"] == 2
     assert counters["planner.cycle_progress.cycle.0"] == 2
-    assert "planner.cycle_progress.step.1" not in counters
-    assert "planner.cycle_progress.step.2" not in counters
+    assert counters["planner.cycle_progress.step.1"] == 1
+    assert counters["planner.cycle_progress.step.2"] == 1
     assert counters["planner.sla_violations_total"] == 1
-    assert counters["planner.cycle_success_rate"] == 0.5
+    assert counters["planner.resolution_rate"] == 0.5
     assert counters["planner.avg_cycles_per_resolution"] == 2.0
     assert counters.get("planner.error_count", 0) == 0
     assert counters["planner.time_to_next_step_ms"] > 0
+    assert counters["planner.time_to_next_step_ms.cycle.0"] > 0
+    assert counters["planner.time_to_next_step_ms.step.1"] > 0


### PR DESCRIPTION
## Summary
- record time-to-next-step with cycle/step tags in the planner state machine
- expose planner resolution rate and labeled cycle progress during sends
- allow analytics tracker counters to accept cycle and step dimensions and update docs/tests

## Testing
- `pytest tests/test_planner_metrics.py::test_planner_metric_emissions -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7469c36e48325826e64dcc905aa04