### PR TITLE
Add Grafana dashboards and alerts

### DIFF
--- a/deployment/grafana/alerts.yml
+++ b/deployment/grafana/alerts.yml
@@ -1,0 +1,33 @@
+groups:
+  - name: planner
+    rules:
+      - alert: PlannerSLAViolations
+        expr: increase(planner_sla_violations_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: "Planner SLA violation"
+          description: "Planner SLA violations detected over 5m."
+
+  - name: outcome
+    rules:
+      - alert: OutcomeIngestLatencyHigh
+        expr: histogram_quantile(0.95, sum(rate(outcome_ingest_latency_ms_bucket[5m])) by (le)) > 300000
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: "Outcome ingest latency high"
+          description: "p95 ingest latency over 5m for 15m."
+
+  - name: tri_merge
+    rules:
+      - alert: TriMergeMismatchSpike
+        expr: rate(tri_merge_mismatches_total[5m]) > 2 * rate(tri_merge_mismatches_total[1h])
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: "Tri-merge mismatches spiking"
+          description: "Mismatch rate over 2x 1h baseline."

--- a/deployment/grafana/batch_runner.json
+++ b/deployment/grafana/batch_runner.json
@@ -1,0 +1,24 @@
+{
+  "title": "Batch Runner",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Job Success/Failure",
+      "targets": [
+        {"expr": "sum(rate(batch_runner_job_success_total[5m]))", "legendFormat": "success"},
+        {"expr": "sum(rate(batch_runner_job_failure_total[5m]))", "legendFormat": "failure"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Job Duration p95",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(batch_runner_job_duration_ms_bucket[5m])) by (le))"
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/grafana/outcome.json
+++ b/deployment/grafana/outcome.json
@@ -1,0 +1,26 @@
+{
+  "title": "Outcome",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Outcome Mix",
+      "targets": [
+        {"expr": "sum(rate(outcome_verified[5m]))", "legendFormat": "Verified"},
+        {"expr": "sum(rate(outcome_updated[5m]))", "legendFormat": "Updated"},
+        {"expr": "sum(rate(outcome_deleted[5m]))", "legendFormat": "Deleted"},
+        {"expr": "sum(rate(outcome_nochange[5m]))", "legendFormat": "NoChange"}
+      ]
+    },
+    {
+      "type": "heatmap",
+      "title": "Ingest Latency",
+      "targets": [
+        {
+          "expr": "sum(rate(outcome_ingest_latency_ms_bucket[5m])) by (le)"
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/grafana/planner.json
+++ b/deployment/grafana/planner.json
@@ -1,0 +1,26 @@
+{
+  "title": "Planner",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Cycle Progression",
+      "targets": [
+        {
+          "expr": "sum by (step) (rate(planner_cycle_progress[5m]))",
+          "legendFormat": "step {{step}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SLA Violations",
+      "targets": [
+        {
+          "expr": "sum(rate(planner_sla_violations_total[5m]))"
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/grafana/tri_merge.json
+++ b/deployment/grafana/tri_merge.json
@@ -1,0 +1,36 @@
+{
+  "title": "Tri-Merge",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Families Processed",
+      "targets": [
+        {
+          "expr": "sum by (bureau) (rate(tri_merge_families_total[5m]))",
+          "legendFormat": "{{bureau}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Mismatches",
+      "targets": [
+        {
+          "expr": "sum by (bureau) (rate(tri_merge_mismatches_total[5m]))",
+          "legendFormat": "{{bureau}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Match Confidence p95",
+      "targets": [
+        {
+          "expr": "tri_merge_match_confidence_p95"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/observability/runbook.md
+++ b/docs/observability/runbook.md
@@ -1,0 +1,25 @@
+# Observability Runbook
+
+This runbook outlines service level objectives (SLOs) and alert thresholds for key pipelines.
+
+## SLOs
+
+### Planner
+- **SLA violations**: `planner.sla_violations_total` should remain at 0.
+  - Alert when any violation occurs over a 5m window.
+
+### Outcome
+- **Ingest latency**: 95th percentile latency below 5 minutes.
+  - Alert when p95 `outcome.ingest_latency_ms` exceeds 5m for 15m.
+
+### Tri-Merge
+- **Mismatch rate**: stay within normal baseline.
+  - Alert when `tri_merge.mismatches_total` rate is more than 2× the 1h baseline.
+
+## Alert thresholds
+
+| Metric | Threshold | Window |
+| --- | --- | --- |
+| `planner.sla_violations_total` | > 0 | 5m |
+| `outcome.ingest_latency_ms` p95 | > 5m | 15m |
+| `tri_merge.mismatches_total` | > 2× 1h baseline | 5m |


### PR DESCRIPTION
## Summary
- add Grafana dashboards for tri-merge, planner, outcome, and batch runner metrics
- introduce alert rules for SLA violations, ingest latency, and tri-merge mismatches
- document SLOs and thresholds in observability runbook

## Testing
- `scripts/run_checks.sh`

------
https://chatgpt.com/codex/tasks/task_b_68a750be0a9c832585370f090a157d5e