### PR TITLE
Refactor batch runner with job management

### DIFF
--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -1,17 +1,38 @@
 import json
+import sqlite3
 from pathlib import Path
 
-from backend.analytics.batch_runner import run_staging_batch
+from backend.analytics.batch_runner import BatchFilters, BatchRunner
 
 
-def test_run_staging_batch(tmp_path):
+def test_batch_runner_run(tmp_path):
     samples = Path(__file__).parent / "helpers" / "batch_samples.json"
-    report = run_staging_batch(samples, limit=2, output_dir=tmp_path)
-    assert "finalization_pass_rate" in report
-    assert "sanitizer" in report
-    json_files = list(tmp_path.glob("*.json"))
-    csv_files = list(tmp_path.glob("*.csv"))
-    assert len(json_files) == 1
-    assert len(csv_files) == 1
-    data = json.loads(json_files[0].read_text())
+
+    def fake_fetch(self, filters):
+        return json.loads(samples.read_text())
+
+    runner = BatchRunner(job_store=tmp_path / "jobs.sqlite", output_dir=tmp_path)
+    runner._fetch_samples = fake_fetch.__get__(runner, BatchRunner)
+
+    filters = BatchFilters(action_tags=["fraud_dispute"])
+    job_id = runner.run(filters, format="json")
+
+    json_path = tmp_path / f"{job_id}.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text())
     assert "missing_fields" in data
+
+    # idempotent run
+    job_id2 = runner.run(filters, format="json")
+    assert job_id2 == job_id
+
+    with sqlite3.connect(tmp_path / "jobs.sqlite") as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM batch_jobs")
+        assert cur.fetchone()[0] == 1
+
+    # retry should reprocess and keep single record
+    runner.retry(job_id)
+    with sqlite3.connect(tmp_path / "jobs.sqlite") as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM batch_jobs")
+        assert cur.fetchone()[0] == 1
+


### PR DESCRIPTION
## Summary
- refactor analytics batch runner into `BatchRunner` class and `BatchFilters` dataclass
- add idempotent job persistence, scheduling and retry helpers
- test batch job execution and idempotent job recording

## Testing
- `pytest tests/test_batch_runner.py::test_batch_runner_run -q`

------
https://chatgpt.com/codex/tasks/task_b_68a7532386a083259fc76442ef9ffd11