### PR TITLE
Add analytics view export utility

### DIFF
--- a/backend/analytics/view_exporter.py
+++ b/backend/analytics/view_exporter.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Mapping, Sequence
+
+EXPORT_COLUMNS = [
+    "session_id",
+    "family_id",
+    "action_tag",
+    "cycle_id",
+    "outcome",
+    "planner_status",
+    "last_sent_at",
+    "next_eligible_at",
+]
+
+
+@dataclass(frozen=True)
+class ExportFilters:
+    """Filter options for analytics exports."""
+
+    action_tags: Sequence[str] | None = None
+    family_ids: Sequence[str] | None = None
+    cycle_range: tuple[int, int] | None = None
+    start_ts: str | None = None
+    end_ts: str | None = None
+
+
+def _build_where(filters: ExportFilters) -> tuple[str, list[object]]:
+    clauses: list[str] = []
+    params: list[object] = []
+    if filters.action_tags:
+        placeholders = ",".join("?" for _ in filters.action_tags)
+        clauses.append(f"action_tag IN ({placeholders})")
+        params.extend(filters.action_tags)
+    if filters.family_ids:
+        placeholders = ",".join("?" for _ in filters.family_ids)
+        clauses.append(f"family_id IN ({placeholders})")
+        params.extend(filters.family_ids)
+    if filters.cycle_range:
+        clauses.append("cycle_id BETWEEN ? AND ?")
+        params.extend(filters.cycle_range)
+    if filters.start_ts:
+        clauses.append("last_sent_at >= ?")
+        params.append(filters.start_ts)
+    if filters.end_ts:
+        clauses.append("last_sent_at <= ?")
+        params.append(filters.end_ts)
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    return where, params
+
+
+def fetch_joined(
+    conn: sqlite3.Connection,
+    filters: ExportFilters,
+    *,
+    view_name: str = "analytics_planner_outcomes",
+) -> Iterator[Mapping[str, object]]:
+    """Yield joined planner/outcome rows from ``view_name`` applying ``filters``."""
+
+    where, params = _build_where(filters)
+    query = (
+        "SELECT session_id, family_id, action_tag, cycle_id, outcome, "
+        "planner_status, last_sent_at, next_eligible_at "
+        f"FROM {view_name}{where}"
+    )
+    cur = conn.execute(query, params)
+    cols = [c[0] for c in cur.description]
+    for row in cur:
+        yield dict(zip(cols, row))
+
+
+def stream_csv(rows: Iterable[Mapping[str, object]]) -> Iterator[str]:
+    """Yield CSV lines for ``rows`` with an ``export_version`` header."""
+
+    yield "export_version=1\n"
+    yield ",".join(EXPORT_COLUMNS) + "\n"
+    for row in rows:
+        yield ",".join(str(row.get(col, "")) for col in EXPORT_COLUMNS) + "\n"
+
+
+def stream_json(rows: Iterable[Mapping[str, object]]) -> Iterator[str]:
+    """Yield JSON chunks for ``rows`` with an ``export_version`` header."""
+
+    yield "{\"export_version\":1,\"rows\":[\n"
+    first = True
+    for row in rows:
+        if not first:
+            yield ",\n"
+        else:
+            first = False
+        yield json.dumps(row, separators=(",", ":"))
+    yield "\n]}"

--- a/scripts/export_analytics_view.py
+++ b/scripts/export_analytics_view.py
@@ -1,0 +1,49 @@
+import argparse
+import sqlite3
+import sys
+
+from backend.analytics.view_exporter import (
+    ExportFilters,
+    fetch_joined,
+    stream_csv,
+    stream_json,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export analytics planner view")
+    parser.add_argument("--db", required=True, help="Path to analytics database")
+    parser.add_argument("--format", choices=["csv", "json"], default="csv")
+    parser.add_argument("--tag", action="append", dest="action_tags")
+    parser.add_argument("--family", action="append", dest="family_ids")
+    parser.add_argument("--cycle-min", type=int)
+    parser.add_argument("--cycle-max", type=int)
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--view-name", default="analytics_planner_outcomes")
+    args = parser.parse_args()
+
+    cycle_range = None
+    if args.cycle_min is not None and args.cycle_max is not None:
+        cycle_range = (args.cycle_min, args.cycle_max)
+
+    filters = ExportFilters(
+        action_tags=args.action_tags,
+        family_ids=args.family_ids,
+        cycle_range=cycle_range,
+        start_ts=args.start,
+        end_ts=args.end,
+    )
+
+    conn = sqlite3.connect(args.db)
+    try:
+        rows = fetch_joined(conn, filters, view_name=args.view_name)
+        streamer = stream_csv if args.format == "csv" else stream_json
+        for chunk in streamer(rows):
+            sys.stdout.write(chunk)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_view_exporter.py
+++ b/tests/test_view_exporter.py
@@ -1,0 +1,102 @@
+import sqlite3
+
+from backend.analytics.view_exporter import (
+    ExportFilters,
+    fetch_joined,
+    stream_csv,
+    stream_json,
+)
+
+
+def setup_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE tri_merge (session_id TEXT, family_id TEXT, action_tag TEXT)")
+    conn.execute(
+        """
+        CREATE TABLE planner (
+            session_id TEXT,
+            family_id TEXT,
+            action_tag TEXT,
+            cycle_id INTEGER,
+            status TEXT,
+            last_sent_at TEXT,
+            next_eligible_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE outcome (
+            session_id TEXT,
+            family_id TEXT,
+            action_tag TEXT,
+            cycle_id INTEGER,
+            outcome TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO tri_merge VALUES (?,?,?)",
+        [("s1", "f1", "t1"), ("s2", "f2", "t2")],
+    )
+    conn.executemany(
+        "INSERT INTO planner VALUES (?,?,?,?,?,?,?)",
+        [
+            ("s1", "f1", "t1", 1, "planned", "2023-01-01", "2023-02-01"),
+            ("s2", "f2", "t2", 2, "planned", "2023-03-01", "2023-04-01"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO outcome VALUES (?,?,?,?,?)",
+        [
+            ("s1", "f1", "t1", 1, "ok"),
+            ("s2", "f2", "t2", 2, "fail"),
+        ],
+    )
+    conn.execute(
+        """
+        CREATE VIEW analytics_planner_outcomes AS
+        SELECT tm.session_id, tm.family_id, tm.action_tag,
+               p.cycle_id, o.outcome, p.status AS planner_status,
+               p.last_sent_at, p.next_eligible_at
+        FROM tri_merge tm
+        JOIN planner p ON tm.session_id=p.session_id AND tm.family_id=p.family_id AND tm.action_tag=p.action_tag
+        LEFT JOIN outcome o ON (
+            tm.session_id=o.session_id AND tm.family_id=o.family_id AND tm.action_tag=o.action_tag AND p.cycle_id=o.cycle_id
+        )
+        """
+    )
+    return conn
+
+
+def test_fetch_joined_and_streaming() -> None:
+    conn = setup_db()
+    filters = ExportFilters(
+        action_tags=["t1"],
+        cycle_range=(1, 1),
+        start_ts="2023-01-01",
+        end_ts="2023-02-01",
+    )
+    rows = list(fetch_joined(conn, filters))
+    assert rows == [
+        {
+            "session_id": "s1",
+            "family_id": "f1",
+            "action_tag": "t1",
+            "cycle_id": 1,
+            "outcome": "ok",
+            "planner_status": "planned",
+            "last_sent_at": "2023-01-01",
+            "next_eligible_at": "2023-02-01",
+        }
+    ]
+
+    csv_text = "".join(stream_csv(iter(rows)))
+    lines = csv_text.strip().splitlines()
+    assert lines[0] == "export_version=1"
+    assert lines[1].startswith("session_id")
+    assert lines[2].startswith("s1,f1,t1,1,ok,planned,2023-01-01,2023-02-01")
+
+    json_text = "".join(stream_json(iter(rows)))
+    assert json_text.startswith("{\"export_version\":1")
+    assert "\"session_id\":\"s1\"" in json_text


### PR DESCRIPTION
## Summary
- expose `ExportFilters` and `fetch_joined` to query analytics materialized views with optional tag, family, cycle, and time filters
- provide streaming CSV/JSON exporters that include `export_version=1`
- add CLI script for exporting planner/outcome data and accompanying tests

## Testing
- `python -m pytest tests/test_view_exporter.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7543e3a1c8325bc429e09bba7d300