### PR TITLE
Add analytics views and schema documentation

### DIFF
--- a/backend/analytics/views.py
+++ b/backend/analytics/views.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+def create_tri_merge_view(conn: sqlite3.Connection) -> None:
+    """Create ``analytics_tri_merge_view`` if it doesn't exist."""
+    conn.execute(
+        """
+        CREATE VIEW IF NOT EXISTS analytics_tri_merge_view AS
+        SELECT
+            session_id,
+            account_id,
+            family_id,
+            cycle_id,
+            tri_merge_snapshot_id,
+            NULL AS plan_id,
+            NULL AS step_id,
+            NULL AS outcome_id
+        FROM tri_merge
+        """
+    )
+
+
+def create_planner_view(conn: sqlite3.Connection) -> None:
+    """Create ``analytics_planner_view`` if it doesn't exist."""
+    conn.execute(
+        """
+        CREATE VIEW IF NOT EXISTS analytics_planner_view AS
+        SELECT
+            session_id,
+            account_id,
+            family_id,
+            cycle_id,
+            tri_merge_snapshot_id,
+            plan_id,
+            step_id,
+            NULL AS outcome_id
+        FROM planner
+        """
+    )
+
+
+def create_outcome_view(conn: sqlite3.Connection) -> None:
+    """Create ``analytics_outcome_view`` if it doesn't exist."""
+    conn.execute(
+        """
+        CREATE VIEW IF NOT EXISTS analytics_outcome_view AS
+        SELECT
+            session_id,
+            account_id,
+            family_id,
+            cycle_id,
+            tri_merge_snapshot_id,
+            plan_id,
+            step_id,
+            outcome_id
+        FROM outcome
+        """
+    )
+
+
+def create_views(conn: sqlite3.Connection) -> None:
+    """Create all analytics views on ``conn``."""
+    create_tri_merge_view(conn)
+    create_planner_view(conn)
+    create_outcome_view(conn)

--- a/docs/analytics/views.md
+++ b/docs/analytics/views.md
@@ -1,0 +1,72 @@
+# Analytics Views
+
+This document records the schemas for analytics views and their version history.
+
+## analytics.tri_merge_view
+
+### v1
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+
+### v2
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+| tri_merge_snapshot_id | TEXT | Snapshot provenance identifier |
+| plan_id | TEXT | Planner provenance identifier |
+| step_id | TEXT | Planner step provenance identifier |
+| outcome_id | TEXT | Outcome provenance identifier |
+
+## analytics.planner_view
+
+### v1
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+| plan_id | TEXT | Planner provenance identifier |
+| step_id | TEXT | Planner step provenance identifier |
+
+### v2
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+| tri_merge_snapshot_id | TEXT | Snapshot provenance identifier |
+| plan_id | TEXT | Planner provenance identifier |
+| step_id | TEXT | Planner step provenance identifier |
+| outcome_id | TEXT | Outcome provenance identifier |
+
+## analytics.outcome_view
+
+### v1
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+| outcome_id | TEXT | Outcome provenance identifier |
+
+### v2
+| column | type | description |
+| --- | --- | --- |
+| session_id | TEXT | Session identifier |
+| account_id | TEXT | Account identifier |
+| family_id | TEXT | Family identifier |
+| cycle_id | INTEGER | Cycle identifier |
+| tri_merge_snapshot_id | TEXT | Snapshot provenance identifier |
+| plan_id | TEXT | Planner provenance identifier |
+| step_id | TEXT | Planner step provenance identifier |
+| outcome_id | TEXT | Outcome provenance identifier |

--- a/tests/analytics/test_views.py
+++ b/tests/analytics/test_views.py
@@ -1,0 +1,77 @@
+import sqlite3
+
+from backend.analytics import views
+
+
+def setup_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE tri_merge (
+            session_id TEXT,
+            account_id TEXT,
+            family_id TEXT,
+            cycle_id INTEGER,
+            tri_merge_snapshot_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE planner (
+            session_id TEXT,
+            account_id TEXT,
+            family_id TEXT,
+            cycle_id INTEGER,
+            tri_merge_snapshot_id TEXT,
+            plan_id TEXT,
+            step_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE outcome (
+            session_id TEXT,
+            account_id TEXT,
+            family_id TEXT,
+            cycle_id INTEGER,
+            tri_merge_snapshot_id TEXT,
+            plan_id TEXT,
+            step_id TEXT,
+            outcome_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO tri_merge VALUES (?,?,?,?,?)",
+        ("s1", "a1", "f1", 1, "snap1"),
+    )
+    conn.execute(
+        "INSERT INTO planner VALUES (?,?,?,?,?,?,?)",
+        ("s1", "a1", "f1", 1, "snap1", "plan1", "step1"),
+    )
+    conn.execute(
+        "INSERT INTO outcome VALUES (?,?,?,?,?,?,?,?)",
+        ("s1", "a1", "f1", 1, "snap1", "plan1", "step1", "out1"),
+    )
+    views.create_views(conn)
+    return conn
+
+
+def test_tri_merge_view() -> None:
+    conn = setup_db()
+    row = conn.execute("SELECT * FROM analytics_tri_merge_view").fetchone()
+    assert row == ("s1", "a1", "f1", 1, "snap1", None, None, None)
+
+
+def test_planner_view() -> None:
+    conn = setup_db()
+    row = conn.execute("SELECT * FROM analytics_planner_view").fetchone()
+    assert row == ("s1", "a1", "f1", 1, "snap1", "plan1", "step1", None)
+
+
+def test_outcome_view() -> None:
+    conn = setup_db()
+    row = conn.execute("SELECT * FROM analytics_outcome_view").fetchone()
+    assert row == ("s1", "a1", "f1", 1, "snap1", "plan1", "step1", "out1")


### PR DESCRIPTION
## Summary
- add SQL helpers to create analytics tri-merge, planner, and outcome views with shared provenance keys
- document view schemas for versions v1 and v2
- test view creation and data projection

## Testing
- `pytest tests/analytics/test_views.py`


------
https://chatgpt.com/codex/tasks/task_b_68a75bd817848325bc598e0912e1e40a