### PR TITLE
Allow configuring Celery broker and backend via environment variables

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -20,7 +20,18 @@ from backend.core.orchestrators import (
     run_credit_repair_process,
 )
 
-app = Celery("tasks", loader="default", fixups=[])
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+
+
+app = Celery(
+    "tasks",
+    broker=CELERY_BROKER_URL,
+    backend=CELERY_RESULT_BACKEND,
+    loader="default",
+    fixups=[],
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- make Celery broker and backend configurable through `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a76c06f32883258e1c75d54b897b2c