### PR TITLE
Enable AI categorization for problematic account extraction

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -54,6 +54,7 @@ from backend.core.logic.utils.report_sections import (
     filter_sections_by_bureau,
 )
 from backend.core.models import (
+    Account,
     BureauAccount,
     BureauPayload,
     ClientInfo,
@@ -876,9 +877,11 @@ def extract_problematic_accounts_from_report(
         analyzed_json_path,
         {},
         ai_client=ai_client,
-        run_ai=False,
+        run_ai=True,
         request_id=session_id,
     )
+    sections.setdefault("negative_accounts", [])
+    sections.setdefault("open_accounts_with_issues", [])
     update_session(session_id, status="awaiting_user_explanations")
 
     return BureauPayload(
@@ -894,6 +897,9 @@ def extract_problematic_accounts_from_report(
             for d in sections.get(
                 "unauthorized_inquiries", sections.get("inquiries", [])
             )
+        ],
+        high_utilization=[
+            Account.from_dict(d) for d in sections.get("high_utilization_accounts", [])
         ],
     )
 

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -27,6 +27,7 @@ def test_extract_problematic_accounts_returns_models(monkeypatch):
         "negative_accounts": [{"name": "Acc1"}],
         "open_accounts_with_issues": [{"name": "Acc2"}],
         "unauthorized_inquiries": [{"creditor_name": "Bank", "date": "2024-01-01"}],
+        "high_utilization_accounts": [{"name": "Acc3"}],
     }
     _mock_dependencies(monkeypatch, sections)
     payload = extract_problematic_accounts_from_report("dummy.pdf")
@@ -34,6 +35,7 @@ def test_extract_problematic_accounts_returns_models(monkeypatch):
     assert payload.disputes[0].name == "Acc1"
     assert payload.goodwill[0].name == "Acc2"
     assert payload.inquiries[0].creditor_name == "Bank"
+    assert payload.high_utilization[0].name == "Acc3"
 
 
 def test_extract_problematic_accounts_dict_adapter(monkeypatch):
@@ -41,9 +43,26 @@ def test_extract_problematic_accounts_dict_adapter(monkeypatch):
         "negative_accounts": [{"name": "Acc1"}],
         "open_accounts_with_issues": [{"name": "Acc2"}],
         "unauthorized_inquiries": [{"creditor_name": "Bank", "date": "2024-01-01"}],
+        "high_utilization_accounts": [{"name": "Acc3"}],
     }
     _mock_dependencies(monkeypatch, sections)
     with pytest.deprecated_call():
         result = extract_problematic_accounts_from_report_dict("dummy.pdf")
     assert isinstance(result, dict)
     assert result["negative_accounts"][0]["name"] == "Acc1"
+
+
+def test_payload_to_dict(monkeypatch):
+    sections = {
+        "negative_accounts": [{"name": "Acc1"}],
+        "open_accounts_with_issues": [{"name": "Acc2"}],
+        "unauthorized_inquiries": [{"creditor_name": "Bank", "date": "2024-01-01"}],
+        "high_utilization_accounts": [{"name": "Acc3"}],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    payload = extract_problematic_accounts_from_report("dummy.pdf")
+    data = payload.to_dict()
+    assert data["disputes"][0]["name"] == "Acc1"
+    assert data["goodwill"][0]["name"] == "Acc2"
+    assert data["inquiries"][0]["creditor_name"] == "Bank"
+    assert data["high_utilization"][0]["name"] == "Acc3"


### PR DESCRIPTION
## Summary
- Enable categorization when analyzing reports so sections include negative and open account issues
- Include high-utilization accounts in `BureauPayload` and ensure category keys exist
- Add tests confirming `extract_problematic_accounts_from_report` populates payload fields and `to_dict`

## Testing
- `pre-commit run --files backend/core/orchestrators.py tests/test_extract_problematic_accounts.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a772bd8eb883259551d5f6af9d7248