### PR TITLE
Ensure parser-only late accounts populate categories

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -170,6 +170,24 @@ def _inject_missing_late_accounts(result: dict, history: dict, raw_map: dict) ->
             "flags": ["Late Payments"],
         }
         result.setdefault("all_accounts", []).append(entry)
+
+        status_lower = entry.get("status", "").lower()
+        flags_lower = [f.lower() for f in entry.get("flags", [])]
+        negative_terms = (
+            "collection",
+            "collections",
+            "chargeoff",
+            "charge-off",
+            "charge off",
+        )
+        is_negative = any(t in status_lower for t in negative_terms) or any(
+            any(t in flag for t in negative_terms) for flag in flags_lower
+        )
+        if is_negative:
+            result.setdefault("negative_accounts", []).append(entry.copy())
+        else:
+            result.setdefault("open_accounts_with_issues", []).append(entry.copy())
+
         print(f"[WARN] Added missing account from parser: {entry['name']}")
 
 


### PR DESCRIPTION
## Summary
- categorize parser-only late accounts into negative or open-issue buckets
- keep categories populated when building BureauPayload
- test that parser-only late accounts appear in BureauPayload

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_parser_only_late_accounts_included -vv`

------
https://chatgpt.com/codex/tasks/task_b_68a778f8733c83259d2700e1e82d93e0