### PR TITLE
Sanitize extra headers in AI client

### DIFF
--- a/backend/core/services/ai_client.py
+++ b/backend/core/services/ai_client.py
@@ -43,6 +43,17 @@ class AIClient:
         """Proxy to ``chat.completions.create``."""
 
         model = model or self.config.chat_model
+
+        extra_headers = kwargs.pop("extra_headers", None)
+        if extra_headers:
+            sanitized: Dict[str, str] = {}
+            for k, v in extra_headers.items():
+                cleaned = v.encode("ascii", "ignore").decode()
+                if cleaned:
+                    sanitized[k] = cleaned
+            if sanitized:
+                kwargs["extra_headers"] = sanitized
+
         return self._client.chat.completions.create(
             model=model, messages=messages, temperature=temperature, **kwargs
         )

--- a/tests/services/test_ai_client_headers.py
+++ b/tests/services/test_ai_client_headers.py
@@ -1,0 +1,29 @@
+from backend.core.services.ai_client import AIClient, AIConfig
+
+
+def test_extra_headers_sanitized():
+    client = AIClient(AIConfig(api_key="test"))
+
+    captured = {}
+
+    class DummyCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return {"choices": []}
+
+    class DummyChat:
+        def __init__(self):
+            self.completions = DummyCompletions()
+
+    class DummyOpenAI:
+        def __init__(self):
+            self.chat = DummyChat()
+
+    client._client = DummyOpenAI()
+
+    client.chat_completion(
+        messages=[{"role": "user", "content": "hi"}],
+        extra_headers={"X-Test": "héllo"},
+    )
+
+    assert captured["extra_headers"] == {"X-Test": "hllo"}


### PR DESCRIPTION
## Summary
- Sanitize and filter non-ASCII extra headers in `AIClient.chat_completion`
- Add regression test for header sanitization in AIClient

## Testing
- `pytest tests/services/test_ai_client_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a78246f7488325bc8a8534875cd941