### PR TITLE
Inject missing late accounts per bureau

### DIFF
--- a/backend/core/models/bureau.py
+++ b/backend/core/models/bureau.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Type
 
 from .account import Account, Inquiry
@@ -57,9 +57,12 @@ class BureauAccount(Account):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "BureauAccount":
-        base = Account.from_dict(data)
+        data = {k: v for k, v in data.items() if k not in {"bureaus"}}
+        base = Account.from_dict(
+            {k: v for k, v in data.items() if k not in {"bureau", "section"}}
+        )
         return cls(
-            **base.to_dict(),
+            **asdict(base),
             bureau=data.get("bureau"),
             section=data.get("section"),
         )

--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -1,0 +1,22 @@
+import backend.core.logic.report_analysis.report_postprocessing as rp
+from backend.core.models.bureau import BureauAccount
+
+
+def test_inject_missing_late_accounts_per_bureau():
+    result = {}
+    history = {
+        "cap_one": {
+            "Experian": {"30": 1},
+            "Equifax": {"60": 2},
+            "TransUnion": {"90": 3},
+        }
+    }
+    raw_map = {"cap_one": "Cap One"}
+
+    rp._inject_missing_late_accounts(result, history, raw_map)
+
+    accounts = [BureauAccount.from_dict(a) for a in result["all_accounts"]]
+
+    assert len(accounts) == 3
+    assert {a.bureau for a in accounts} == {"Experian", "Equifax", "TransUnion"}
+    assert all("bureaus" not in a for a in result["all_accounts"])


### PR DESCRIPTION
## Summary
- Create per-bureau entries when injecting missing late-payment accounts and categorize them by flags
- Ignore stray keys like `bureaus` in `BureauAccount.from_dict`
- Test that parser history yields separate bureau entries with distinct bureaus

## Testing
- `pre-commit run --files backend/core/models/bureau.py backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py`
- `pytest tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7830df94083258f79f6c309b89e3f