### PR TITLE
Map legacy account keys in start_process response

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -141,15 +141,24 @@ def start_process():
             timeout=300
         )
 
-        return jsonify(
-            {
-                "status": "awaiting_user_explanations",
-                "session_id": session_id,
-                "filename": unique_name,
-                "original_filename": original_name,
-                "accounts": accounts,
-            }
-        )
+        legacy = {
+            "negative_accounts": accounts.get("disputes", []),
+            "open_accounts_with_issues": accounts.get("goodwill", []),
+            "unauthorized_inquiries": accounts.get("inquiries", []),
+            "high_utilization_accounts": accounts.get("high_utilization", []),
+        }
+
+        payload = {
+            "status": "awaiting_user_explanations",
+            "session_id": session_id,
+            "filename": unique_name,
+            "original_filename": original_name,
+            "accounts": legacy,
+        }
+
+        logger.info("start_process payload: %s", payload)
+
+        return jsonify(payload)
 
     except Exception as e:
         print("Exception occurred:", str(e))


### PR DESCRIPTION
## Summary
- Map new extract_problematic_accounts keys to legacy names for start-process
- Return mapped accounts in response and log final payload

## Testing
- `pytest tests/test_start_process.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a79542245c832594f0451139fdc9b2