### PR TITLE
Support dual account keys on review page

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -23,8 +23,8 @@ export default function ReviewPage() {
   }
 
   const accounts = [
-    ...(uploadData.accounts?.negative_accounts || []),
-    ...(uploadData.accounts?.open_accounts_with_issues || []),
+    ...(uploadData.accounts?.negative_accounts ?? uploadData.accounts?.disputes ?? []),
+    ...(uploadData.accounts?.open_accounts_with_issues ?? uploadData.accounts?.goodwill ?? []),
   ];
 
   const getProblems = (acc) => {

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -11,21 +11,25 @@ jest.mock('../api', () => ({
   })
 }));
 
-const uploadData = {
+const baseUploadData = {
   session_id: 'sess1',
   filename: 'file.pdf',
-  email: 'test@example.com',
-  accounts: {
-    negative_accounts: [
-      { account_id: 'acc1', name: 'Account 1', account_number: '1234' }
-    ]
-  }
+  email: 'test@example.com'
 };
 
-describe('ReviewPage', () => {
+const account = { account_id: 'acc1', name: 'Account 1', account_number: '1234' };
+
+describe.each([
+  'negative_accounts',
+  'disputes',
+  'open_accounts_with_issues',
+  'goodwill'
+])('ReviewPage with %s', (key) => {
+  const uploadData = { ...baseUploadData, accounts: { [key]: [account] } };
+
   test('renders helper text', async () => {
     render(
-      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
         <ReviewPage />
       </MemoryRouter>
     );
@@ -36,7 +40,7 @@ describe('ReviewPage', () => {
 
   test('shows summary box when toggle active', async () => {
     render(
-      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
         <ReviewPage />
       </MemoryRouter>
     );


### PR DESCRIPTION
## Summary
- Merge legacy and new account key names when listing accounts on ReviewPage
- Expand ReviewPage tests to cover negative/dispute and goodwill account keys

## Testing
- `npm test`
- `pytest` *(fails: Unknown config option: env; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68a795d31c448325a35ac7ad6b1bd219