### PR TITLE
Log summaries payload at debug level

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -215,6 +215,7 @@ def get_summaries(session_id: str):
     elif isinstance(raw, dict):
         for key, item in raw.items():
             cleaned[key] = {k: item.get(k) for k in allowed if k in item}
+    logger.debug("summaries payload for %s: %s", session_id, cleaned)
     return jsonify({"status": "ok", "summaries": cleaned})
 
 


### PR DESCRIPTION
## Summary
- add debug logging for summary payloads in `get_summaries`

## Testing
- `pre-commit run --files backend/api/app.py`
- `LOG_LEVEL=DEBUG PYTHONPATH=backend/api pytest tests/test_api_summaries.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7992cfabc8325bfa39ef2709f479b