### PR TITLE
Aggregate missing late accounts across bureaus

### DIFF
--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -2,7 +2,7 @@ import backend.core.logic.report_analysis.report_postprocessing as rp
 from backend.core.models.bureau import BureauAccount
 
 
-def test_inject_missing_late_accounts_per_bureau():
+def test_inject_missing_late_accounts_aggregated():
     result = {}
     history = {
         "cap_one": {
@@ -17,6 +17,7 @@ def test_inject_missing_late_accounts_per_bureau():
 
     accounts = [BureauAccount.from_dict(a) for a in result["all_accounts"]]
 
-    assert len(accounts) == 3
-    assert {a.bureau for a in accounts} == {"Experian", "Equifax", "TransUnion"}
-    assert all("bureaus" not in a for a in result["all_accounts"])
+    assert len(accounts) == 1
+    acc = accounts[0]
+    assert acc.extras["late_payments"] == history["cap_one"]
+    assert acc.extras.get("source_stage") == "parser_aggregated"

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -123,4 +123,4 @@ def test_extract_problematic_accounts_without_openai(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     payload = extract_problematic_accounts_from_report("dummy.pdf")
-    assert payload.goodwill and payload.goodwill[0].name == "Parser Bank"
+    assert payload.disputes and payload.disputes[0].name == "Parser Bank"


### PR DESCRIPTION
## Summary
- combine parser-detected late payment history into a single account entry per creditor
- mark aggregated parser accounts as delinquent and source from parser_aggregated
- adjust tests for merged late-payment records and downstream processing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7a7ed97948325805d3c747d19335e