### PR TITLE
feat: tag report accounts with issue types

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -1,0 +1,23 @@
+import backend.core.logic.report_analysis.report_postprocessing as rp
+
+
+def test_assign_issue_types_late_payment():
+    acc = {"late_payments": {"Experian": {"30": 1}}}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["late_payment"]
+    assert acc["status"] == "Delinquent"
+    assert acc["advisor_comment"] == "Late payments detected"
+
+
+def test_assign_issue_types_collection_from_flags():
+    acc = {"flags": ["Collection"]}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["collection"]
+    assert acc["status"] == "Collection"
+
+
+def test_assign_issue_types_charge_off_from_flags():
+    acc = {"flags": ["Charge-Off"]}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["charge_off"]
+    assert acc["status"] == "Charge Off"

--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -21,3 +21,5 @@ def test_inject_missing_late_accounts_aggregated():
     acc = accounts[0]
     assert acc.extras["late_payments"] == history["cap_one"]
     assert acc.extras.get("source_stage") == "parser_aggregated"
+    assert acc.extras.get("issue_types") == ["late_payment"]
+    assert acc.status == "Delinquent"


### PR DESCRIPTION
## Summary
- derive issue types from late payments, collections, and charge offs
- only surface accounts with issues in negative or open issue lists
- cover issue type tagging with new unit tests

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py -q`
- `pytest tests/report_analysis -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7b73f94ec83259b32e10e7aad8525