### PR TITLE
Filter review accounts by issue types

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -25,7 +25,7 @@ export default function ReviewPage() {
   const accounts = [
     ...(uploadData.accounts?.negative_accounts ?? uploadData.accounts?.disputes ?? []),
     ...(uploadData.accounts?.open_accounts_with_issues ?? uploadData.accounts?.goodwill ?? []),
-  ];
+  ].filter((acc) => acc.issue_types && acc.issue_types.length);
 
   const dedupedAccounts = Array.from(
     accounts
@@ -43,30 +43,18 @@ export default function ReviewPage() {
   );
 
   const getProblems = (acc) => {
-    const issues = [];
-    const late = acc.late_payments;
-    if (late) {
-      Object.values(late).forEach((counts) => {
-        Object.entries(counts).forEach(([days, count]) => {
-          if (count > 0) {
-            issues.push({
-              text: `${count} ${days}-day late payment${count > 1 ? 's' : ''}`,
-              severity: 'warning',
-            });
-          }
-        });
-      });
-    }
-    if (acc.status) {
-      issues.push({
-        text: `Status: ${acc.status}`,
-        severity: /collection|chargeoff/i.test(acc.status) ? 'critical' : 'normal',
-      });
-    }
-    if (acc.balance) {
-      issues.push({ text: `Balance: ${acc.balance}`, severity: 'normal' });
-    }
-    return issues;
+    return acc.issue_types.map((type) => {
+      switch (type) {
+        case 'late_payment':
+          return { text: 'Late payments detected', severity: 'warning' };
+        case 'collection':
+          return { text: 'Account in collections', severity: 'critical' };
+        case 'charge_off':
+          return { text: 'Account charged off', severity: 'critical' };
+        default:
+          return { text: type, severity: 'normal' };
+      }
+    });
   };
 
   const handleChange = (key, value) => {

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -17,7 +17,12 @@ const baseUploadData = {
   email: 'test@example.com'
 };
 
-const account = { account_id: 'acc1', name: 'Account 1', account_number: '1234' };
+const account = {
+  account_id: 'acc1',
+  name: 'Account 1',
+  account_number: '1234',
+  issue_types: ['late_payment']
+};
 
 describe.each([
   'negative_accounts',
@@ -48,4 +53,23 @@ describe.each([
     fireEvent.click(toggle);
     expect(await screen.findByText(/bank error/i)).toBeInTheDocument();
   });
+});
+
+test('filters out accounts without issue_types', async () => {
+  const uploadData = {
+    ...baseUploadData,
+    accounts: {
+      negative_accounts: [
+        account,
+        { account_id: 'acc2', name: 'Account 2', account_number: '5678' }
+      ]
+    }
+  };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText('Account 1')).toBeInTheDocument();
+  expect(screen.queryByText('Account 2')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Only display review accounts that include issue types
- Simplify problem descriptions using issue type switch
- Test that accounts without issue types aren't rendered

## Testing
- `npm test --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7bc3966fc8325920b4dc5bc3f55df