### PR TITLE
Prioritize account issue severity

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -21,3 +21,19 @@ def test_assign_issue_types_charge_off_from_flags():
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["charge_off"]
     assert acc["status"] == "Charge Off"
+
+
+def test_assign_issue_types_collection_overrides_late():
+    acc = {"flags": ["Collection"], "late_payments": {"Experian": {"30": 2}}}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["collection", "late_payment"]
+    assert acc["status"] == "Collection"
+    assert acc["advisor_comment"] == "Account in collection"
+
+
+def test_assign_issue_types_charge_off_overrides_late():
+    acc = {"flags": ["Charge-Off"], "late_payments": {"Equifax": {"30": 1}}}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["charge_off", "late_payment"]
+    assert acc["status"] == "Charge Off"
+    assert acc["advisor_comment"] == "Account charged off"


### PR DESCRIPTION
## Summary
- order report issue types by severity for consistent prioritization
- override account status and comment based on highest-severity issue
- test mixed issue combinations to ensure primary issue selection

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_assign_issue_types.py`
- `pytest tests/report_analysis/test_assign_issue_types.py`

------
https://chatgpt.com/codex/tasks/task_b_68a87fc626f48325b3c3373f76132a32