### PR TITLE
Derive primary account issues

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -5,6 +5,7 @@ def test_assign_issue_types_late_payment():
     acc = {"late_payments": {"Experian": {"30": 1}}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["late_payment"]
+    assert acc["primary_issue"] == "late_payment"
     assert acc["status"] == "Delinquent"
     assert acc["advisor_comment"] == "Late payments detected"
 
@@ -13,6 +14,7 @@ def test_assign_issue_types_collection_from_flags():
     acc = {"flags": ["Collection"]}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["collection"]
+    assert acc["primary_issue"] == "collection"
     assert acc["status"] == "Collection"
 
 
@@ -20,6 +22,7 @@ def test_assign_issue_types_charge_off_from_flags():
     acc = {"flags": ["Charge-Off"]}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["charge_off"]
+    assert acc["primary_issue"] == "charge_off"
     assert acc["status"] == "Charge Off"
 
 
@@ -27,6 +30,7 @@ def test_assign_issue_types_collection_overrides_late():
     acc = {"flags": ["Collection"], "late_payments": {"Experian": {"30": 2}}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["collection", "late_payment"]
+    assert acc["primary_issue"] == "collection"
     assert acc["status"] == "Collection"
     assert acc["advisor_comment"] == "Account in collection"
 
@@ -35,5 +39,6 @@ def test_assign_issue_types_charge_off_overrides_late():
     acc = {"flags": ["Charge-Off"], "late_payments": {"Equifax": {"30": 1}}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["charge_off", "late_payment"]
+    assert acc["primary_issue"] == "charge_off"
     assert acc["status"] == "Charge Off"
     assert acc["advisor_comment"] == "Account charged off"


### PR DESCRIPTION
## Summary
- add `pick_primary_issue` helper for severity ranking
- include bureau-level statuses in issue detection
- track `primary_issue` and reorder issue types accordingly
- extend tests for mixed issue signals

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_assign_issue_types.py`
- `pytest tests/report_analysis/test_assign_issue_types.py`


------
https://chatgpt.com/codex/tasks/task_b_68a88c179fbc8325bb32c93c6e1bb832