### PR TITLE
Enrich account metadata for AI and parser paths

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -35,6 +35,7 @@ from .report_postprocessing import (
     _reconcile_account_headings,
     _assign_issue_types,
     validate_analysis_sanity,
+    enrich_account_metadata,
 )
 from .report_prompting import (
     ANALYSIS_PROMPT_VERSION,
@@ -286,6 +287,15 @@ def analyze_credit_report(
         )
         issues.append(msg)
         print(msg)
+
+    for section in [
+        "all_accounts",
+        "negative_accounts",
+        "open_accounts_with_issues",
+        "positive_accounts",
+        "high_utilization_accounts",
+    ]:
+        result[section] = [enrich_account_metadata(acc) for acc in result.get(section, [])]
 
     Path(output_json_path).parent.mkdir(parents=True, exist_ok=True)
     with open(output_json_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Populate account_number_last4, creditor details, balances, dates, and per-bureau statuses in `enrich_account_metadata`
- Ensure parser-only analysis also enriches accounts before emitting results
- Add tests verifying enriched fields in BureauPayload for AI and parser-only runs

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_enriched_metadata_present_ai tests/test_extract_problematic_accounts.py::test_enriched_metadata_present_parser_only -q`
- `pytest tests/test_extract_problematic_accounts.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a88d87cd348325970e3652a96b4864