### PR TITLE
Use primary_issue for ReviewPage badges

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -79,8 +79,8 @@ export default function ReviewPage() {
     <div className="container">
       <h2>Explain Your Situation</h2>
       {dedupedAccounts.map((acc, idx) => {
-        const primaryIssue = acc.issue_types[0];
-        const secondaryIssues = acc.issue_types.slice(1);
+        const primaryIssue = acc.primary_issue || acc.issue_types[0];
+        const secondaryIssues = acc.issue_types.filter((t) => t !== primaryIssue);
         return (
           <div key={idx} className="account-block">
             <p>

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -23,6 +23,7 @@ const account = {
   normalized_name: 'account 1',
   account_number_last4: '1234',
   original_creditor: 'Creditor 1',
+  primary_issue: 'late_payment',
   issue_types: ['late_payment']
 };
 
@@ -36,7 +37,7 @@ describe.each([
 
   test('renders helper text', async () => {
     render(
-      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
         <ReviewPage />
       </MemoryRouter>
     );
@@ -47,7 +48,7 @@ describe.each([
 
   test('shows summary box when toggle active', async () => {
     render(
-      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
         <ReviewPage />
       </MemoryRouter>
     );
@@ -68,7 +69,7 @@ test('filters out accounts without issue_types', async () => {
     }
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
@@ -76,21 +77,22 @@ test('filters out accounts without issue_types', async () => {
   expect(screen.queryByText('Account 2')).not.toBeInTheDocument();
 });
 
-test('renders primary badge and secondary chips with identifiers', async () => {
+test('renders primary badge from primary_issue and secondary chips with identifiers', async () => {
   const acc = {
     account_id: 'acc3',
     name: 'Account 3',
     normalized_name: 'account 3',
     account_number_last4: '7890',
     original_creditor: 'Bank A',
-    issue_types: ['charge_off', 'collection', 'late_payment'],
+    primary_issue: 'charge_off',
+    issue_types: ['collection', 'charge_off', 'late_payment'],
   };
   const uploadData = {
     ...baseUploadData,
     accounts: { negative_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );


### PR DESCRIPTION
## Summary
- Derive badge from `primary_issue` and filter remaining issue types
- Ensure review headers render account number last4 and original creditor
- Verify identifiers and `primary_issue` badges via updated tests

## Testing
- `pre-commit run --files frontend/src/pages/ReviewPage.jsx frontend/src/pages/ReviewPage.test.jsx`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a895861e20832581dd4dbc7b6a8207