### PR TITLE
Log enriched account details before payload

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -951,23 +951,22 @@ def extract_problematic_accounts_from_report(
     )
 
     for cat in ["negative_accounts", "open_accounts_with_issues"]:
-        filtered: list[dict] = []
+        filtered = []
         for acc in sections.get(cat, []):
             if not acc.get("issue_types"):
                 continue
             enriched = enrich_account_metadata(acc)
-            # Keep the full enriched mapping so `BureauAccount.from_dict`
-            # preserves metadata like ``primary_issue`` and
-            # ``account_number_last4``.
             logger.info(
-                "emitted_account name=%s primary_issue=%s issue_types=%s "
-                "status=%s source_stage=%s included_in=%s",
-                enriched.get("name"),
+                "emitted_account name=%s primary_issue=%s status=%s "
+                "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s",
+                enriched.get("normalized_name"),
                 enriched.get("primary_issue"),
-                enriched.get("issue_types"),
                 enriched.get("status"),
+                enriched.get("account_number_last4"),
+                enriched.get("original_creditor"),
+                enriched.get("issue_types"),
+                list((enriched.get("bureau_statuses") or {}).keys()),
                 enriched.get("source_stage"),
-                cat,
             )
             filtered.append(enriched)
         sections[cat] = filtered

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -1,13 +1,14 @@
 import copy
 import logging
+
 import pytest
 
+from backend.core.logic.utils.names_normalization import normalize_creditor_name
 from backend.core.models import BureauPayload
 from backend.core.orchestrators import (
     extract_problematic_accounts_from_report,
     extract_problematic_accounts_from_report_dict,
 )
-from backend.core.logic.utils.names_normalization import normalize_creditor_name
 
 
 def _mock_dependencies(monkeypatch, sections):
@@ -340,11 +341,13 @@ def test_extract_problematic_accounts_logs_enriched_metadata(monkeypatch, caplog
     with caplog.at_level(logging.INFO, logger="backend.core.orchestrators"):
         extract_problematic_accounts_from_report("dummy.pdf")
     assert any(
-        r.message.startswith("emitted_account name=Acc1")
+        r.message.startswith("emitted_account name=acc1")
         and "primary_issue=" in r.message
-        and "issue_types=" in r.message
         and "status=" in r.message
-        and "source_stage=" in r.message
-        and "included_in=negative_accounts" in r.message
+        and "last4=" in r.message
+        and "orig_cred=" in r.message
+        and "issues=" in r.message
+        and "bureaus=" in r.message
+        and "stage=" in r.message
         for r in caplog.records
     )


### PR DESCRIPTION
## Summary
- log enriched account metadata (name, primary issue, status, last4, original creditor, issues, bureaus, source stage) when extracting problematic accounts
- adjust tests to expect new diagnostic fields

## Testing
- `pre-commit run --files backend/core/orchestrators.py tests/test_extract_problematic_accounts.py`
- `pytest`
- Manual invocation of `extract_problematic_accounts_from_report` to show emitted log


------
https://chatgpt.com/codex/tasks/task_b_68a89b0590548325b350aa6309d5a93b