### PR TITLE
feat: allow disabling analysis cache

### DIFF
--- a/backend/core/logic/report_analysis/README.md
+++ b/backend/core/logic/report_analysis/README.md
@@ -45,3 +45,8 @@ yet consumed by downstream modules:
 
 These fields are optional and safely ignored by letter generation and
 instructions pipelines.
+
+## Local development
+
+Set the environment variable `ANALYSIS_DISABLE_CACHE=1` to bypass the
+in-memory analysis cache and force a fresh analysis on each run.


### PR DESCRIPTION
## Summary
- Add `USE_ANALYSIS_CACHE` flag controlled by `ANALYSIS_DISABLE_CACHE`
- Skip cache usage when caching is disabled
- Document environment variable to force fresh analyses in development

## Testing
- `python -m py_compile backend/core/logic/report_analysis/report_prompting.py`
- `pytest backend/core/logic/report_analysis`


------
https://chatgpt.com/codex/tasks/task_b_68a8a656c3e48325aae071add151dae7