### PR TITLE
Track pipeline version in report analysis

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -40,6 +40,7 @@ from .report_postprocessing import (
 from .report_prompting import (
     ANALYSIS_PROMPT_VERSION,
     ANALYSIS_SCHEMA_VERSION,
+    PIPELINE_VERSION,
     call_ai_analysis,
 )
 
@@ -80,7 +81,7 @@ def analyze_credit_report(
 
     is_identity_theft = client_info.get("is_identity_theft", False)
     doc_fingerprint = hashlib.sha256(
-        f"{text}|{ANALYSIS_PROMPT_VERSION}|{ANALYSIS_SCHEMA_VERSION}".encode(
+        f"{text}|{ANALYSIS_PROMPT_VERSION}|{ANALYSIS_SCHEMA_VERSION}|{PIPELINE_VERSION}".encode(
             "utf-8"
         )
     ).hexdigest()

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -54,6 +54,7 @@ _ANALYSIS_VALIDATOR = Draft7Validator(_ANALYSIS_SCHEMA)
 # 1: Initial version
 ANALYSIS_PROMPT_VERSION = 2
 ANALYSIS_SCHEMA_VERSION = 1
+PIPELINE_VERSION = 1  # Increment when enrichment or post-processing logic changes
 
 
 # Allow for odd spacing, lowercase headers, and page-break markers when


### PR DESCRIPTION
## Summary
- Add a `PIPELINE_VERSION` constant to report analysis prompting to version enrichment or post-processing updates
- Incorporate `PIPELINE_VERSION` into `analyze_report` fingerprinting and import

## Testing
- `pytest tests/report_analysis -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8a78cb12483259a76a3b1b2052289