### PR TITLE
feat: flag accounts with late payments

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -1,13 +1,13 @@
 import backend.core.logic.report_analysis.report_postprocessing as rp
 
 
-def test_assign_issue_types_no_auto_late_payment():
+def test_assign_issue_types_detects_late_payment():
     acc = {"late_payments": {"Experian": {"30": 1}}}
     rp._assign_issue_types(acc)
-    assert "issue_types" not in acc
-    assert acc["primary_issue"] == "unknown"
-    assert acc.get("status") is None
-    assert acc.get("advisor_comment") is None
+    assert acc["issue_types"] == ["late_payment"]
+    assert acc["primary_issue"] == "late_payment"
+    assert acc["status"] == "Delinquent"
+    assert acc["advisor_comment"] == "Late payments detected"
 
 
 def test_assign_issue_types_collection_from_flags():
@@ -29,7 +29,7 @@ def test_assign_issue_types_charge_off_from_flags():
 def test_assign_issue_types_collection_overrides_late():
     acc = {"flags": ["Collection"], "late_payments": {"Experian": {"30": 2}}}
     rp._assign_issue_types(acc)
-    assert acc["issue_types"] == ["collection"]
+    assert acc["issue_types"] == ["collection", "late_payment"]
     assert acc["primary_issue"] == "collection"
     assert acc["status"] == "Collection"
     assert acc["advisor_comment"] == "Account in collection"
@@ -38,7 +38,7 @@ def test_assign_issue_types_collection_overrides_late():
 def test_assign_issue_types_charge_off_overrides_late():
     acc = {"flags": ["Charge-Off"], "late_payments": {"Equifax": {"30": 1}}}
     rp._assign_issue_types(acc)
-    assert acc["issue_types"] == ["charge_off"]
+    assert acc["issue_types"] == ["charge_off", "late_payment"]
     assert acc["primary_issue"] == "charge_off"
     assert acc["status"] == "Charge Off"
     assert acc["advisor_comment"] == "Account charged off"


### PR DESCRIPTION
## Summary
- flag late payments as an issue type when any bureau reports them
- update issue-type tests to reflect automatic late payment detection

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_assign_issue_types.py`
- `pytest tests/report_analysis/test_assign_issue_types.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_68a8acbb23248325aea864eda62529cd