### PR TITLE
Log low recall without halting bureau merge

### DIFF
--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -878,7 +878,9 @@ def call_ai_analysis(
                                             "validation_errors": ["LOW_RECALL"],
                                         },
                                     )
-                                    error_code = "LOW_RECALL"
+                                    # Attach warning but do not flag an error so other
+                                    # bureau results are still processed.
+                                    data.setdefault("warnings", []).append("LOW_RECALL")
                         if not error_code and USE_ANALYSIS_CACHE:
                             store_cached_analysis(
                                 doc_fingerprint,

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -198,7 +198,7 @@ def test_call_ai_analysis_retries_and_succeeds(tmp_path, caplog):
     assert any(r.__dict__.get("attempt") == 2 for r in attempts)
 
 
-def test_call_ai_analysis_retries_on_low_recall(tmp_path, caplog, monkeypatch):
+def test_call_ai_analysis_logs_low_recall(tmp_path, caplog, monkeypatch):
     utils_pkg = types.ModuleType("backend.core.logic.utils")
     utils_pkg.__path__ = [
         str(
@@ -257,11 +257,12 @@ def test_call_ai_analysis_retries_on_low_recall(tmp_path, caplog, monkeypatch):
     assert len(data["all_accounts"]) == 2
     attempts = [r for r in caplog.records if r.__dict__.get("bureau")]
     assert any(r.__dict__.get("attempt") == 1 for r in attempts)
-    assert any(r.__dict__.get("attempt") == 2 for r in attempts)
+    assert not any(r.__dict__.get("attempt") == 2 for r in attempts)
     assert any(
         "LOW_RECALL" in (r.__dict__.get("validation_errors") or [])
         for r in caplog.records
     )
+    assert data["bureau_sections"][0].get("warnings") == ["LOW_RECALL"]
     assert any(
         "Chase" in (r.__dict__.get("unmatched_headings") or []) for r in caplog.records
     )


### PR DESCRIPTION
## Summary
- do not raise LOW_RECALL error during bureau analysis; log warning and keep merging results
- track LOW_RECALL in per-bureau warnings
- update tests for new low recall behaviour

## Testing
- `pytest tests/test_report_modules.py::test_call_ai_analysis_logs_low_recall -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8ade71c388325a308a721e878d24c