### PR TITLE
Restore human-readable creditor names in inquiry merging

### DIFF
--- a/tests/report_analysis/test_merge_parser_inquiries_preserves_name.py
+++ b/tests/report_analysis/test_merge_parser_inquiries_preserves_name.py
@@ -1,0 +1,22 @@
+import backend.core.logic.report_analysis.report_postprocessing as rp
+from backend.core.logic.utils.names_normalization import normalize_creditor_name
+
+
+def test_merge_parser_inquiries_preserves_creditor_name():
+    result = {
+        "inquiries": [
+            {"creditor_name": "cap one", "date": "01/2024", "bureau": "Experian"}
+        ]
+    }
+    parsed = [
+        {"creditor_name": "Cap One", "date": "01/2024", "bureau": "Experian"},
+        {"creditor_name": "Chase Bank", "date": "02/2024", "bureau": "TransUnion"},
+    ]
+    raw_map = {
+        normalize_creditor_name(p["creditor_name"]): p["creditor_name"] for p in parsed
+    }
+    rp._merge_parser_inquiries(result, parsed, raw_map)
+
+    names = [inq["creditor_name"] for inq in result["inquiries"]]
+    assert "Cap One" in names
+    assert "Chase Bank" in names


### PR DESCRIPTION
## Summary
- ensure `_merge_parser_inquiries` restores creditor names using parser-provided labels
- build inquiry `raw_map` in `analyze_report` and pass to merger
- test that merged inquiries retain original creditor names

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_postprocessing.py backend/core/logic/report_analysis/analyze_report.py tests/report_analysis/test_merge_parser_inquiries_preserves_name.py`
- `pytest tests/report_analysis/test_merge_parser_inquiries_preserves_name.py tests/test_report_modules.py::test_merge_parser_inquiries`

------
https://chatgpt.com/codex/tasks/task_b_68a8afe429288325886edfe7bc90e371