### PR TITLE
Improve issue type assignment for collections and late payments

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -2,7 +2,7 @@ import backend.core.logic.report_analysis.report_postprocessing as rp
 
 
 def test_assign_issue_types_detects_late_payment():
-    acc = {"late_payments": {"Experian": {"30": 1}}}
+    acc = {"late_payments": {"30": 1}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["late_payment"]
     assert acc["primary_issue"] == "late_payment"
@@ -10,8 +10,8 @@ def test_assign_issue_types_detects_late_payment():
     assert acc["advisor_comment"] == "Late payments detected"
 
 
-def test_assign_issue_types_collection_from_flags():
-    acc = {"flags": ["Collection"]}
+def test_assign_issue_types_collection_from_status():
+    acc = {"status": "Sent to collections"}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["collection"]
     assert acc["primary_issue"] == "collection"
@@ -27,7 +27,7 @@ def test_assign_issue_types_charge_off_from_flags():
 
 
 def test_assign_issue_types_collection_overrides_late():
-    acc = {"flags": ["Collection"], "late_payments": {"Experian": {"30": 2}}}
+    acc = {"status": "Sent to collections", "late_payments": {"30": 2}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["collection", "late_payment"]
     assert acc["primary_issue"] == "collection"
@@ -36,7 +36,7 @@ def test_assign_issue_types_collection_overrides_late():
 
 
 def test_assign_issue_types_charge_off_overrides_late():
-    acc = {"flags": ["Charge-Off"], "late_payments": {"Equifax": {"30": 1}}}
+    acc = {"flags": ["Charge-Off"], "late_payments": {"Experian": {"30": 1}}}
     rp._assign_issue_types(acc)
     assert acc["issue_types"] == ["charge_off", "late_payment"]
     assert acc["primary_issue"] == "charge_off"


### PR DESCRIPTION
## Summary
- Detect late payments from any `late_payments` map structure
- Parse status fields for collection/charge-off indicators and prioritize severity
- Always populate ordered `issue_types` and `primary_issue`
- Add tests for late-only, collection-only, and mixed scenarios

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py`

------
https://chatgpt.com/codex/tasks/task_b_68a8b94b868083259089b5131849c377