### PR TITLE
Preserve creditor name during inquiry merge

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from uuid import uuid4
 from typing import Any, Dict, List, Mapping, Set
 
 from backend.core.logic.utils.names_normalization import (
@@ -180,8 +181,9 @@ def _merge_parser_inquiries(
         )
         if key in seen:
             continue
+        creditor_name = raw_map.get(key_name) or inq.get("creditor_name") or str(uuid4())
         entry = {
-            "creditor_name": raw_map.get(key_name, inq.get("creditor_name")),
+            "creditor_name": creditor_name,
             "date": inq.get("date"),
             "bureau": normalize_bureau_name(inq.get("bureau")),
         }
@@ -198,7 +200,8 @@ def _merge_parser_inquiries(
             normalize_bureau_name(inq.get("bureau")),
         )
         if key not in seen:
-            inq["creditor_name"] = raw_map.get(key_name, inq.get("creditor_name"))
+            creditor_name = raw_map.get(key_name) or inq.get("creditor_name") or str(uuid4())
+            inq["creditor_name"] = creditor_name
             cleaned.append(inq)
             seen.add(key)
 

--- a/tests/report_analysis/test_merge_parser_inquiries_keeps_known_name.py
+++ b/tests/report_analysis/test_merge_parser_inquiries_keeps_known_name.py
@@ -1,0 +1,14 @@
+import backend.core.logic.report_analysis.report_postprocessing as rp
+
+
+def test_merge_parser_inquiries_keeps_known_creditor_name():
+    result = {
+        "inquiries": [
+            {"creditor_name": "Local Credit Union", "date": "03/2024", "bureau": "Equifax"}
+        ]
+    }
+    parsed = []
+
+    rp._merge_parser_inquiries(result, parsed)
+
+    assert result["inquiries"][0]["creditor_name"] == "Local Credit Union"


### PR DESCRIPTION
## Summary
- ensure `_merge_parser_inquiries` only assigns a UUID when creditor names are missing
- keep existing creditor names intact during merge
- add regression test to ensure names survive merging

## Testing
- `pytest tests/report_analysis/test_merge_parser_inquiries_keeps_known_name.py tests/report_analysis/test_merge_parser_inquiries_preserves_name.py`


------
https://chatgpt.com/codex/tasks/task_b_68a8bd62ad70832591007c6f2317878b