### PR TITLE
Log payment and remarks info for accounts

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1000,7 +1000,8 @@ def extract_problematic_accounts_from_report(
             enriched = enrich_account_metadata(acc)
             logger.info(
                 "emitted_account name=%s primary_issue=%s status=%s "
-                "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s",
+                "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s "
+                "payment_status=%s has_co_marker=%s has_remarks=%s",
                 enriched.get("normalized_name"),
                 enriched.get("primary_issue"),
                 enriched.get("status"),
@@ -1009,6 +1010,9 @@ def extract_problematic_accounts_from_report(
                 enriched.get("issue_types"),
                 list((enriched.get("bureau_statuses") or {}).keys()),
                 enriched.get("source_stage"),
+                acc.get("payment_status"),
+                acc.get("has_co_marker"),
+                bool(acc.get("remarks")),
             )
             filtered.append(enriched)
         sections[cat] = filtered


### PR DESCRIPTION
## Summary
- log payment status, co-maker flag, and remark presence for each emitted account
- test logging metadata for accounts including payment and co-maker fields

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_logs_enriched_metadata -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab73b1bbc4832585cc86816a489e8d