### PR TITLE
Handle charge-off markers in late payment grids

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -53,6 +53,15 @@ def test_assign_issue_types_detects_charge_off_from_history_grid():
     assert acc["status"] == "Charge Off"
 
 
+def test_assign_issue_types_detects_charge_off_from_late_map():
+    acc = {"late_payments": {"Experian": {"CO": 1}}}
+    rp._assign_issue_types(acc)
+    assert acc["has_co_marker"] is True
+    assert acc["issue_types"] == ["charge_off", "late_payment"]
+    assert acc["primary_issue"] == "charge_off"
+    assert acc["status"] == "Charge Off"
+
+
 def test_assign_issue_types_collection_from_remarks():
     acc = {"remarks": "Account placed in collection"}
     rp._assign_issue_types(acc)


### PR DESCRIPTION
## Summary
- detect `CO` entries in late payment grids and mark accounts with `has_co_marker`
- append `Charge-Off` flag when a charge-off marker is present
- ensure charge-off grids promote account `primary_issue` to `charge_off`

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py -q`
- `pytest tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py -q`
- `pytest tests/test_start_process.py::test_start_process_emits_enriched_fields -q`

------
https://chatgpt.com/codex/tasks/task_b_68ab8d761658832587e8485dc77d1f39