### PR TITLE
Parse creditor remarks and flag collections

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -1,4 +1,5 @@
 import backend.core.logic.report_analysis.report_postprocessing as rp
+import pytest
 
 
 def test_assign_issue_types_detects_late_payment():
@@ -62,8 +63,15 @@ def test_assign_issue_types_detects_charge_off_from_late_map():
     assert acc["status"] == "Charge Off"
 
 
-def test_assign_issue_types_collection_from_remarks():
-    acc = {"remarks": "Account placed in collection"}
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Account placed in collection",
+        "Account transferred to collection agency",
+    ],
+)
+def test_assign_issue_types_collection_from_remarks(text):
+    acc = {"remarks": text}
     rp._assign_issue_types(acc)
     assert acc["has_co_marker"] is True
     assert acc["issue_types"] == ["collection"]


### PR DESCRIPTION
## Summary
- extract bureau-specific Creditor Remarks from SmartCredit text
- merge parsed remarks into accounts during report analysis
- ensure collection phrasing in remarks triggers collection issue types

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab8f475f688325be4c063b6daae73e