### PR TITLE
test: cover collection/charge-off detection with late payments

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -1,5 +1,6 @@
-import backend.core.logic.report_analysis.report_postprocessing as rp
 import pytest
+
+import backend.core.logic.report_analysis.report_postprocessing as rp
 
 
 def test_assign_issue_types_detects_late_payment():
@@ -77,3 +78,24 @@ def test_assign_issue_types_collection_from_remarks(text):
     assert acc["issue_types"] == ["collection"]
     assert acc["primary_issue"] == "collection"
     assert acc["status"] == "Collection"
+
+
+def test_assign_issue_types_collection_from_payment_status_overrides_late():
+    acc = {"payment_status": "Sent to collection agency", "late_payments": {"30": 1}}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["collection", "late_payment"]
+    assert acc["primary_issue"] == "collection"
+    assert acc["status"] == "Collection"
+    assert acc["advisor_comment"] == "Account in collection"
+
+
+def test_assign_issue_types_charge_off_from_remarks_overrides_late():
+    acc = {
+        "remarks": "Account charged off as bad debt",
+        "late_payments": {"Experian": {"30": 2}},
+    }
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["charge_off", "late_payment"]
+    assert acc["primary_issue"] == "charge_off"
+    assert acc["status"] == "Charge Off"
+    assert acc["advisor_comment"] == "Account charged off"


### PR DESCRIPTION
## Summary
- test collection detection when payment_status implies collection alongside late payments
- test charge-off detection when remarks indicate charge-off alongside late payments

## Testing
- `pre-commit run --files tests/report_analysis/test_assign_issue_types.py`
- `python -m pytest tests/report_analysis/test_assign_issue_types.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab910c58fc832583909e92a7839815