### PR TITLE
Parse & propagate Payment Status per bureau (SmartCredit)

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -354,6 +354,8 @@ def _assign_issue_types(acc: dict) -> None:
         str(acc.get("payment_status") or ""),
         str(acc.get("remarks") or ""),
     ]
+    for val in (acc.get("payment_statuses") or {}).values():
+        status_parts.append(str(val or ""))
     for key, val in acc.items():
         if "history" in key:
             status_parts.append(str(val or ""))
@@ -401,7 +403,10 @@ def _assign_issue_types(acc: dict) -> None:
     if "foreclosure" in status_clean or any("foreclosure" in f for f in flags):
         issue_types.add("foreclosure")
 
-    primary = pick_primary_issue(issue_types)
+    if "collection" in issue_types and "charge_off" in issue_types:
+        primary = "collection"
+    else:
+        primary = pick_primary_issue(issue_types)
     acc["primary_issue"] = primary
 
     severity_index = {t: i for i, t in enumerate(ISSUE_SEVERITY)}

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -55,7 +55,7 @@ _ANALYSIS_VALIDATOR = Draft7Validator(_ANALYSIS_SCHEMA)
 # 1: Initial version
 ANALYSIS_PROMPT_VERSION = 2
 ANALYSIS_SCHEMA_VERSION = 1
-PIPELINE_VERSION = 1  # Increment when enrichment or post-processing logic changes
+PIPELINE_VERSION = 2  # Increment when enrichment or post-processing logic changes
 
 
 # Allow for odd spacing, lowercase headers, and page-break markers when

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1006,7 +1006,7 @@ def extract_problematic_accounts_from_report(
             logger.info(
                 "emitted_account name=%s primary_issue=%s status=%s "
                 "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s "
-                "payment_status=%s has_co_marker=%s has_remarks=%s "
+                "payment_statuses=%s has_co_marker=%s has_remarks=%s "
                 "remarks_contains_co=%s",
                 enriched.get("normalized_name"),
                 enriched.get("primary_issue"),
@@ -1016,7 +1016,7 @@ def extract_problematic_accounts_from_report(
                 enriched.get("issue_types"),
                 list((enriched.get("bureau_statuses") or {}).keys()),
                 enriched.get("source_stage"),
-                acc.get("payment_status"),
+                acc.get("payment_statuses") or acc.get("payment_status"),
                 acc.get("has_co_marker"),
                 bool(remarks),
                 remarks_contains_co,

--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -99,3 +99,13 @@ def test_assign_issue_types_charge_off_from_remarks_overrides_late():
     assert acc["primary_issue"] == "charge_off"
     assert acc["status"] == "Charge Off"
     assert acc["advisor_comment"] == "Account charged off"
+
+
+def test_assign_issue_types_from_payment_statuses_map():
+    acc = {
+        "payment_statuses": {"TransUnion": "Collection/Chargeoff"},
+        "late_payments": {"TransUnion": {"30": 1}},
+    }
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "collection"
+    assert acc["issue_types"] == ["collection", "charge_off", "late_payment"]

--- a/tests/report_analysis/test_report_parsing.py
+++ b/tests/report_analysis/test_report_parsing.py
@@ -1,0 +1,23 @@
+import pytest
+
+from backend.core.logic.report_analysis.report_parsing import extract_payment_statuses
+from backend.core.logic.utils.names_normalization import normalize_creditor_name
+
+
+def test_extract_payment_statuses_smartcredit_table():
+    text = """
+PALISADES FU
+Account #            123             123             123
+Account Status:      Open            Open            Open
+Payment Status:      Collection/Chargeoff  Collection/Chargeoff  Late 120 Days
+TransUnion  30:0 60:0 90:0
+Experian    30:0 60:0 90:0
+Equifax     30:0 60:0 90:0
+"""
+    statuses = extract_payment_statuses(text)
+    key = normalize_creditor_name("PALISADES FU")
+    assert statuses[key] == {
+        "TransUnion": "Collection/Chargeoff",
+        "Experian": "Collection/Chargeoff",
+        "Equifax": "Late 120 Days",
+    }

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -387,7 +387,7 @@ def test_extract_problematic_accounts_logs_enriched_metadata(monkeypatch, caplog
         and "issues=" in r.message
         and "bureaus=" in r.message
         and "stage=" in r.message
-        and "payment_status=current" in r.message
+        and "payment_statuses=current" in r.message
         and "has_co_marker=False" in r.message
         and "has_remarks=True" in r.message
         for r in caplog.records


### PR DESCRIPTION
## Summary
- Capture "Payment Status" rows for each bureau in SmartCredit account tables.
- Surface per-bureau payment_statuses on accounts and emit them in logs.
- Teach issue-type assignment to use payment_statuses, preferring collection over charge-off when both appear.

## Testing
- `pytest tests/report_analysis/test_report_parsing.py tests/report_analysis/test_assign_issue_types.py tests/test_start_process.py tests/test_extract_problematic_accounts.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab96cf5ea08325a398a11746eff447