### PR TITLE
Detect charge-off markers from history grids

### DIFF
--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -265,7 +265,7 @@ def _generate_prompt(
     else:
         heading_summary = ""
 
-    late_blocks, late_raw_map = extract_late_history_blocks(
+    late_blocks, late_raw_map, _ = extract_late_history_blocks(
         segment_text, return_raw_map=True
     )
     if late_blocks:

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -978,7 +978,7 @@ def extract_problematic_accounts_from_report(
         )
 
     _log_account_snapshot("post_analyze_report")
-    _inject_missing_late_accounts(sections, {}, {})
+    _inject_missing_late_accounts(sections, {}, {}, {})
     _log_account_snapshot("post_inject_missing_late_accounts")
 
     from backend.core.logic.utils.names_normalization import normalize_creditor_name
@@ -1006,7 +1006,7 @@ def extract_problematic_accounts_from_report(
             logger.info(
                 "emitted_account name=%s primary_issue=%s status=%s "
                 "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s "
-                "payment_statuses=%s has_co_marker=%s has_remarks=%s "
+                "payment_statuses=%s has_co_marker=%s co_bureaus=%s has_remarks=%s "
                 "remarks_contains_co=%s",
                 enriched.get("normalized_name"),
                 enriched.get("primary_issue"),
@@ -1018,6 +1018,7 @@ def extract_problematic_accounts_from_report(
                 enriched.get("source_stage"),
                 acc.get("payment_statuses") or acc.get("payment_status"),
                 acc.get("has_co_marker"),
+                acc.get("co_bureaus"),
                 bool(remarks),
                 remarks_contains_co,
             )

--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -64,6 +64,19 @@ def test_assign_issue_types_detects_charge_off_from_late_map():
     assert acc["status"] == "Charge Off"
 
 
+def test_assign_issue_types_co_grid_with_late_counts():
+    acc = {
+        "late_payments": {"Experian": {"30": 1}},
+        "late_payment_history": {"Experian": "OK OK CO"},
+    }
+    rp._assign_issue_types(acc)
+    assert acc["has_co_marker"] is True
+    assert acc["issue_types"] == ["charge_off", "late_payment"]
+    assert acc["primary_issue"] == "charge_off"
+    assert acc["status"] == "Charge Off"
+    assert acc.get("co_bureaus") == ["Experian"]
+
+
 @pytest.mark.parametrize(
     "text",
     [

--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -13,7 +13,7 @@ def test_inject_missing_late_accounts_aggregated():
     }
     raw_map = {"cap_one": "Cap One"}
 
-    rp._inject_missing_late_accounts(result, history, raw_map)
+    rp._inject_missing_late_accounts(result, history, raw_map, {})
 
     accounts = [BureauAccount.from_dict(a) for a in result["all_accounts"]]
 
@@ -28,16 +28,18 @@ def test_inject_missing_late_accounts_aggregated():
 
 def test_inject_missing_late_accounts_detects_charge_off():
     result = {}
-    history = {"cap_one": {"Experian": {"CO": 1}}}
+    history = {"cap_one": {"Experian": {"30": 1}}}
     raw_map = {"cap_one": "Cap One"}
+    grid_map = {"cap_one": {"Experian": "OK CO"}}
 
-    rp._inject_missing_late_accounts(result, history, raw_map)
+    rp._inject_missing_late_accounts(result, history, raw_map, grid_map)
 
     accounts = [BureauAccount.from_dict(a) for a in result["all_accounts"]]
 
     assert len(accounts) == 1
     acc = accounts[0]
     assert acc.extras["late_payments"] == history["cap_one"]
+    assert acc.extras.get("late_payment_history") == grid_map["cap_one"]
     assert acc.extras.get("source_stage") == "parser_aggregated"
     assert acc.extras.get("issue_types") == ["charge_off", "late_payment"]
     assert acc.extras.get("primary_issue") == "charge_off"

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -93,7 +93,7 @@ def test_parser_only_late_accounts_excluded_when_flag_set(monkeypatch):
     }
     history = {"parser bank": {"Experian": {"30": 1}}}
     raw_map = {"parser bank": "Parser Bank"}
-    _inject_missing_late_accounts(result, history, raw_map)
+    _inject_missing_late_accounts(result, history, raw_map, {})
     for sec in ["negative_accounts", "open_accounts_with_issues"]:
         for acc in result.get(sec, []):
             for key in list(acc.keys()):
@@ -131,7 +131,7 @@ def test_extract_problematic_accounts_without_openai(monkeypatch):
         }
         history = {"parser bank": {"Experian": {"30": 1}}}
         raw_map = {"parser bank": "Parser Bank"}
-        _inject_missing_late_accounts(result, history, raw_map)
+        _inject_missing_late_accounts(result, history, raw_map, {})
         return result
 
     monkeypatch.setattr(

--- a/tests/test_report_modules.py
+++ b/tests/test_report_modules.py
@@ -231,7 +231,7 @@ def test_call_ai_analysis_logs_low_recall(tmp_path, caplog, monkeypatch):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
     monkeypatch.setattr(
@@ -300,7 +300,7 @@ def test_low_recall_does_not_clear_other_bureaus(tmp_path, monkeypatch):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
     monkeypatch.setattr(
@@ -398,7 +398,7 @@ def test_call_ai_analysis_adds_confidence_and_flags(tmp_path, monkeypatch):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
     monkeypatch.setattr(
@@ -460,7 +460,7 @@ def test_call_ai_analysis_remediates_missing_account(tmp_path, monkeypatch):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
     monkeypatch.setattr(
@@ -522,7 +522,7 @@ def test_call_ai_analysis_remediates_merged_account(tmp_path, monkeypatch):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
     monkeypatch.setattr(
@@ -636,7 +636,7 @@ def test_analyze_report_wrapper(monkeypatch, tmp_path, identity_theft):
     monkeypatch.setattr(
         report_prompting,
         "extract_late_history_blocks",
-        lambda text, return_raw_map=False: ({}, {}) if return_raw_map else {},
+        lambda text, return_raw_map=False: ({}, {}, {}) if return_raw_map else {},
     )
     monkeypatch.setattr(report_prompting, "extract_inquiries", lambda text: [])
 


### PR DESCRIPTION
## Summary
- capture raw 24-month payment history per bureau and scan for `CO`
- tag accounts with `has_co_marker`, track `co_bureaus`, and prioritize charge offs
- log charge-off markers and involved bureaus in emitted account entries

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py -q`
- `pytest tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py -q`
- `pytest tests/test_start_process.py -q`
- `pytest tests/test_report_modules.py -q`
- `pytest tests/test_logic_fixes.py::test_extract_late_history_blocks tests/test_logic_fixes.py::test_extract_late_history_no_header tests/test_logic_fixes.py::test_skip_placeholder_heading -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab9b0f7cd083259edbaa0395afb90b