### PR TITLE
feat: prioritize charge offs over late payments

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -358,6 +358,11 @@ def _assign_issue_types(acc: dict) -> None:
         if "Charge-Off" not in flags_list:
             flags_list.append("Charge-Off")
 
+    remarks = acc.get("remarks")
+    if isinstance(remarks, str):
+        rl = remarks.lower()
+        acc["remarks_contains_co"] = ("charge" in rl and "off" in rl) or "collection" in rl
+
     # Aggregate any status-like text from the account and its bureau entries
     status_parts = [
         str(acc.get("status") or ""),
@@ -390,7 +395,8 @@ def _assign_issue_types(acc: dict) -> None:
     # Look for charge-off and collection keywords in status text and flags
     co_grid = bool(re.search(r"\bco\b", status_clean))
     has_charge_off = bool(
-        re.search(r"charge\s*off|charged\s*off|chargeoff", status_clean)
+        has_co_marker
+        or re.search(r"charge\s*off|charged\s*off|chargeoff", status_clean)
         or any("charge off" in f for f in flags)
         or co_grid
     )

--- a/backend/core/logic/report_analysis/report_prompting.py
+++ b/backend/core/logic/report_analysis/report_prompting.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import os
 import re
 import time
 from copy import deepcopy
@@ -55,7 +56,7 @@ _ANALYSIS_VALIDATOR = Draft7Validator(_ANALYSIS_SCHEMA)
 # 1: Initial version
 ANALYSIS_PROMPT_VERSION = 2
 ANALYSIS_SCHEMA_VERSION = 1
-PIPELINE_VERSION = 2  # Increment when enrichment or post-processing logic changes
+PIPELINE_VERSION = int(os.getenv("PIPELINE_VERSION", "2"))
 
 
 # Allow for odd spacing, lowercase headers, and page-break markers when

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -999,11 +999,13 @@ def extract_problematic_accounts_from_report(
             if EXCLUDE_PARSER_AGGREGATED_ACCOUNTS and norm in parser_only:
                 continue
             enriched = enrich_account_metadata(acc)
-            remarks = acc.get("remarks")
-            remarks_lower = remarks.lower() if isinstance(remarks, str) else ""
-            remarks_contains_co = (
-                "charge" in remarks_lower and "off" in remarks_lower
-            ) or "collection" in remarks_lower
+            remarks_contains_co = acc.get("remarks_contains_co")
+            if remarks_contains_co is None:
+                remarks = acc.get("remarks")
+                remarks_lower = remarks.lower() if isinstance(remarks, str) else ""
+                remarks_contains_co = (
+                    "charge" in remarks_lower and "off" in remarks_lower
+                ) or "collection" in remarks_lower
             logger.info(
                 "emitted_account name=%s primary_issue=%s status=%s "
                 "last4=%s orig_cred=%s issues=%s bureaus=%s stage=%s "
@@ -1020,7 +1022,7 @@ def extract_problematic_accounts_from_report(
                 acc.get("payment_statuses") or acc.get("payment_status"),
                 acc.get("has_co_marker"),
                 acc.get("co_bureaus"),
-                bool(remarks),
+                bool(acc.get("remarks")),
                 remarks_contains_co,
             )
             filtered.append(enriched)
@@ -1033,19 +1035,21 @@ def extract_problematic_accounts_from_report(
         for acc in sections.get("negative_accounts", []) + sections.get(
             "open_accounts_with_issues", []
         ):
-            remarks = acc.get("remarks")
-            remarks_lower = remarks.lower() if isinstance(remarks, str) else ""
-            remarks_contains_co = (
-                "charge" in remarks_lower and "off" in remarks_lower
-            ) or "collection" in remarks_lower
+            remarks_contains_co = acc.get("remarks_contains_co")
+            if remarks_contains_co is None:
+                remarks = acc.get("remarks")
+                remarks_lower = remarks.lower() if isinstance(remarks, str) else ""
+                remarks_contains_co = (
+                    "charge" in remarks_lower and "off" in remarks_lower
+                ) or "collection" in remarks_lower
             trace = {
                 "name": acc.get("normalized_name"),
                 "source_stage": acc.get("source_stage"),
                 "primary_issue": acc.get("primary_issue"),
                 "issue_types": acc.get("issue_types"),
                 "status": acc.get("status") or acc.get("account_status"),
-                "payment_statuses": acc.get("payment_statuses")
-                or acc.get("payment_status"),
+                "payment_statuses": acc.get("payment_statuses"),
+                "payment_status": acc.get("payment_status"),
                 "has_co_marker": acc.get("has_co_marker"),
                 "co_bureaus": acc.get("co_bureaus"),
                 "remarks_contains_co": remarks_contains_co,

--- a/tests/report_analysis/test_analysis_cache.py
+++ b/tests/report_analysis/test_analysis_cache.py
@@ -12,9 +12,11 @@ from tests.helpers.fake_ai_client import FakeAIClient
 def test_analysis_cache_hits_and_invalidates(tmp_path, monkeypatch):
     """Repeated calls hit cache; prompt or schema changes invalidate."""
 
+    monkeypatch.delenv("ANALYSIS_DISABLE_CACHE", raising=False)
     report_prompting = importlib.import_module(
         "backend.core.logic.report_analysis.report_prompting"
     )
+    report_prompting = importlib.reload(report_prompting)
     from backend.core.logic.report_analysis import analysis_cache
 
     analysis_cache.reset_cache()

--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -37,6 +37,14 @@ def test_assign_issue_types_collection_overrides_late():
     assert acc["advisor_comment"] == "Account in collection"
 
 
+def test_assign_issue_types_collection_from_payment_status_only():
+    acc = {"payment_status": "Account sent to collection agency"}
+    rp._assign_issue_types(acc)
+    assert acc["issue_types"] == ["collection"]
+    assert acc["primary_issue"] == "collection"
+    assert acc["status"] == "Collection"
+
+
 def test_assign_issue_types_charge_off_overrides_late():
     acc = {"flags": ["Charge-Off"], "late_payments": {"Experian": {"30": 1}}}
     rp._assign_issue_types(acc)
@@ -88,6 +96,7 @@ def test_assign_issue_types_collection_from_remarks(text):
     acc = {"remarks": text}
     rp._assign_issue_types(acc)
     assert acc["has_co_marker"] is True
+    assert acc["remarks_contains_co"] is True
     assert acc["issue_types"] == ["collection"]
     assert acc["primary_issue"] == "collection"
     assert acc["status"] == "Collection"

--- a/tests/report_analysis/test_metrics_emission.py
+++ b/tests/report_analysis/test_metrics_emission.py
@@ -7,6 +7,7 @@ def test_metrics_emission(monkeypatch, tmp_path):
     # Single segment without chunking
     monkeypatch.setattr(rp.FLAGS, "chunk_by_bureau", False)
     monkeypatch.setattr(rp.FLAGS, "max_segment_tokens", 10_000)
+    monkeypatch.setattr(rp, "USE_ANALYSIS_CACHE", True)
 
     # Fake analysis response with token usage and confidence
     def fake_analyze_bureau(*args, **kwargs):


### PR DESCRIPTION
## Summary
- ensure charge-off signals override late-payment when assigning issue types
- emit detailed account_trace logs with charge-off evidence and payment statuses
- allow PIPELINE_VERSION override via environment variable

## Testing
- `ANALYSIS_DISABLE_CACHE=1 ANALYSIS_TRACE=1 PIPELINE_VERSION=$((RANDOM)) pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab9ed68a00832593ce7a4a44f066dc