### PR TITLE
Parse account numbers and prefer last4 identifiers

### DIFF
--- a/backend/core/logic/letters/dispute_preparation.py
+++ b/backend/core/logic/letters/dispute_preparation.py
@@ -28,7 +28,9 @@ def dedupe_disputes(
     deduped: List[dict] = []
     for d in disputes:
         name_key = normalize_creditor_name(d.get("name", "")).lower()
-        num = _sanitize(d.get("account_number"))
+        num = d.get("account_number_last4") or _sanitize(d.get("account_number"))
+        if num is None:
+            num = d.get("account_fingerprint")
         key = (name_key, num)
         if key in seen:
             log.append(f"[{bureau_name}] Skipping duplicate account '{d.get('name')}'")
@@ -80,7 +82,9 @@ def prepare_disputes_and_inquiries(
     for d in disputes:
         key = (
             normalize_creditor_name(d.get("name", "")),
-            (d.get("account_number") or "").replace("*", "").strip(),
+            d.get("account_number_last4")
+            or (d.get("account_number") or "").replace("*", "").strip()
+            or d.get("account_fingerprint", ""),
         )
         acc_type_map[key] = {
             "account_type": str(d.get("account_type") or ""),

--- a/backend/core/logic/rendering/instruction_data_preparation.py
+++ b/backend/core/logic/rendering/instruction_data_preparation.py
@@ -103,7 +103,9 @@ def prepare_instruction_data(
         for acc in strategy.get("accounts", []):
             key = (
                 normalize_creditor_name(acc.get("name", "")),
-                sanitize_number(acc.get("account_number"))[-4:],
+                acc.get("account_number_last4")
+                or sanitize_number(acc.get("account_number"))[-4:]
+                or acc.get("account_fingerprint", ""),
             )
             strategy_index[key] = acc
 
@@ -114,9 +116,17 @@ def prepare_instruction_data(
         if name1 != name2:
             return False
 
-        num1 = sanitize_number(existing.get("account_number"))
-        num2 = sanitize_number(new.get("account_number"))
-        if num1 and num2 and num1[-4:] != num2[-4:]:
+        num1 = (
+            existing.get("account_number_last4")
+            or sanitize_number(existing.get("account_number"))[-4:]
+            or existing.get("account_fingerprint")
+        )
+        num2 = (
+            new.get("account_number_last4")
+            or sanitize_number(new.get("account_number"))[-4:]
+            or new.get("account_fingerprint")
+        )
+        if num1 and num2 and num1 != num2:
             return False
         if not num1 and not num2:
             status1 = (existing.get("status") or "").lower()
@@ -132,7 +142,9 @@ def prepare_instruction_data(
             acc_copy.setdefault("categories", set(acc.get("categories", [])))
             strat_key = (
                 normalize_creditor_name(acc_copy.get("name", "")),
-                sanitize_number(acc_copy.get("account_number"))[-4:],
+                acc_copy.get("account_number_last4")
+                or sanitize_number(acc_copy.get("account_number"))[-4:]
+                or acc_copy.get("account_fingerprint", ""),
             )
             strat = strategy_index.get(strat_key)
             if strat:

--- a/backend/core/logic/report_analysis/process_accounts.py
+++ b/backend/core/logic/report_analysis/process_accounts.py
@@ -148,7 +148,12 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            key = (name_key, clean_num(account.account_number), bureau_norm)
+            identifier = (
+                account.get("account_number_last4")
+                or clean_num(account.account_number)
+                or account.get("account_fingerprint")
+            )
+            key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:
                 if is_goodwill_closed:
                     enriched_account = Account.from_dict(account.to_dict())
@@ -176,7 +181,12 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            key = (name_key, clean_num(account.account_number), bureau_norm)
+            identifier = (
+                account.get("account_number_last4")
+                or clean_num(account.account_number)
+                or account.get("account_fingerprint")
+            )
+            key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:
                 if is_goodwill:
                     enriched_account = Account.from_dict(account.to_dict())
@@ -201,7 +211,12 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            key = (name_key, clean_num(account.account_number), bureau_norm)
+            identifier = (
+                account.get("account_number_last4")
+                or clean_num(account.account_number)
+                or account.get("account_fingerprint")
+            )
+            key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:
                 output[bureau_norm]["high_utilization"].append(account)
                 seen_entries.add(key)

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -118,10 +118,35 @@ test('renders account_fingerprint when last4 missing', async () => {
     accounts: { negative_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
   const header = await screen.findByText('Account 4');
   expect(header.parentElement).toHaveTextContent('Account 4 (deadbeef) - Creditor 4');
+});
+
+test('prefers last4 over fingerprint when both provided', async () => {
+  const acc = {
+    account_id: 'acc5',
+    name: 'Account 5',
+    normalized_name: 'account 5',
+    account_number_last4: '4321',
+    account_fingerprint: 'cafebabe',
+    original_creditor: 'Creditor 5',
+    primary_issue: 'late_payment',
+    issue_types: ['late_payment'],
+  };
+  const uploadData = {
+    ...baseUploadData,
+    accounts: { negative_accounts: [acc] },
+  };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const header = await screen.findByText('Account 5');
+  expect(header.parentElement).toHaveTextContent('Account 5 ••••4321 - Creditor 5');
+  expect(header.parentElement).not.toHaveTextContent('cafebabe');
 });

--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -131,3 +131,13 @@ def test_assign_issue_types_from_payment_statuses_map():
     rp._assign_issue_types(acc)
     assert acc["primary_issue"] == "collection"
     assert acc["issue_types"] == ["collection", "charge_off", "late_payment"]
+
+
+def test_enrich_account_metadata_sets_last4_from_bureaus():
+    acc = {
+        "name": "Acme Bank",
+        "bureaus": [{"bureau": "Experian", "account_number": "123-456-7890"}],
+    }
+    rp.enrich_account_metadata(acc)
+    assert acc["account_number_last4"] == "7890"
+    assert "account_fingerprint" not in acc

--- a/tests/report_analysis/test_report_parsing.py
+++ b/tests/report_analysis/test_report_parsing.py
@@ -1,6 +1,9 @@
 import pytest
 
-from backend.core.logic.report_analysis.report_parsing import extract_payment_statuses
+from backend.core.logic.report_analysis.report_parsing import (
+    extract_payment_statuses,
+    extract_account_numbers,
+)
 from backend.core.logic.utils.names_normalization import normalize_creditor_name
 
 
@@ -20,4 +23,23 @@ Equifax     30:0 60:0 90:0
         "TransUnion": "Collection/Chargeoff",
         "Experian": "Collection/Chargeoff",
         "Equifax": "Late 120 Days",
+    }
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["Account #", "Account Number", "Acct #", "Account No."],
+)
+def test_extract_account_numbers_variants(label):
+    text = f"""
+PALISADES FU
+{label}            1234-56            7890            1357
+Balance: 0
+"""
+    numbers = extract_account_numbers(text)
+    key = normalize_creditor_name("PALISADES FU")
+    assert numbers[key] == {
+        "TransUnion": "123456",
+        "Experian": "7890",
+        "Equifax": "1357",
     }


### PR DESCRIPTION
## Summary
- extract account numbers from SmartCredit text for each bureau
- derive and use account_number_last4 for deduplication, falling back to fingerprint
- display last4 instead of fingerprint in review UI when available

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aba12924348325ba673b5eed97194b