### PR TITLE
Handle AI rate limits with parser-only fallback

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -946,6 +946,20 @@ def extract_problematic_accounts_from_report(
         run_ai=run_ai,
         request_id=session_id,
     )
+
+    force_parser = os.getenv("ANALYSIS_FORCE_PARSER_ONLY") == "1"
+    if force_parser or sections.get("ai_failed"):
+        logger.info("analysis_falling_back_to_parser_only force=%s", force_parser)
+        sections = analyze_report_logic(
+            pdf_path,
+            analyzed_json_path,
+            {},
+            ai_client=None,
+            run_ai=False,
+            request_id=session_id,
+        )
+        sections["needs_human_review"] = True
+        sections["ai_failed"] = True
     sections.setdefault("negative_accounts", [])
     sections.setdefault("open_accounts_with_issues", [])
     sections.setdefault("all_accounts", [])
@@ -1084,6 +1098,7 @@ def extract_problematic_accounts_from_report(
         len(payload.inquiries),
         len(payload.high_utilization),
     )
+    payload.needs_human_review = sections.get("needs_human_review", False)
     return payload
 
 


### PR DESCRIPTION
## Summary
- Capture OpenAI `RateLimitError` and `APIError` during report analysis and mark segments with `ai_failed`
- Orchestrator retries analysis in parser-only mode when AI fails or `ANALYSIS_FORCE_PARSER_ONLY` is set, returning `needs_human_review`
- Add regression test ensuring parser accounts are returned when AI raises 429

## Testing
- `ANALYSIS_DISABLE_CACHE=1 ANALYSIS_TRACE=1 ANALYSIS_FORCE_PARSER_ONLY=1 PIPELINE_VERSION=$RANDOM pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aba40905c0832594aa9587b8f60ceb