### PR TITLE
Handle masked account numbers and prefer last4

### DIFF
--- a/backend/core/logic/report_analysis/process_accounts.py
+++ b/backend/core/logic/report_analysis/process_accounts.py
@@ -133,11 +133,6 @@ def process_analyzed_report(
         for bureau in BUREAUS
     }
 
-    def clean_num(n: str | None) -> str:
-        import re
-
-        return re.sub(r"\D", "", n or "")
-
     seen_entries = set()
 
     # 1. Negative Accounts
@@ -148,10 +143,8 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            identifier = (
-                account.get("account_number_last4")
-                or clean_num(account.account_number)
-                or account.get("account_fingerprint")
+            identifier = account.get("account_number_last4") or account.get(
+                "account_fingerprint"
             )
             key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:
@@ -181,10 +174,8 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            identifier = (
-                account.get("account_number_last4")
-                or clean_num(account.account_number)
-                or account.get("account_fingerprint")
+            identifier = account.get("account_number_last4") or account.get(
+                "account_fingerprint"
             )
             key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:
@@ -211,10 +202,8 @@ def process_analyzed_report(
         name_key = normalize_creditor_name(account.name)
         for bureau in account.bureaus:
             bureau_norm = normalize_bureau_name(bureau)
-            identifier = (
-                account.get("account_number_last4")
-                or clean_num(account.account_number)
-                or account.get("account_fingerprint")
+            identifier = account.get("account_number_last4") or account.get(
+                "account_fingerprint"
             )
             key = (name_key, identifier, bureau_norm)
             if bureau_norm in output and key not in seen_entries:

--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -155,9 +155,9 @@ def extract_account_numbers(text: str) -> dict[str, dict[str, str]]:
         block_text = "\n".join(block[1:])
         row = ACCOUNT_NUMBER_ROW_RE.search(block_text)
         if row:
-            tu = re.sub(r"\D", "", row.group("tu"))
-            ex = re.sub(r"\D", "", row.group("ex"))
-            eq = re.sub(r"\D", "", row.group("eq"))
+            tu = row.group("tu").strip()
+            ex = row.group("ex").strip()
+            eq = row.group("eq").strip()
             if tu:
                 numbers.setdefault(acc_norm, {})[
                     normalize_bureau_name("TransUnion")
@@ -180,17 +180,17 @@ def extract_account_numbers(text: str) -> dict[str, dict[str, str]]:
                 # Bureau line itself might contain the account number
                 inline = ACCOUNT_NUMBER_LINE_RE.search(clean)
                 if inline:
-                    digits = re.sub(r"\D", "", inline.group(1))
-                    if digits:
-                        numbers.setdefault(acc_norm, {})[current_bureau] = digits
+                    value = inline.group(1).strip()
+                    if value:
+                        numbers.setdefault(acc_norm, {})[current_bureau] = value
                 continue
 
             if current_bureau:
                 m = ACCOUNT_NUMBER_LINE_RE.match(clean)
                 if m:
-                    digits = re.sub(r"\D", "", m.group(1))
-                    if digits:
-                        numbers.setdefault(acc_norm, {})[current_bureau] = digits
+                    value = m.group(1).strip()
+                    if value:
+                        numbers.setdefault(acc_norm, {})[current_bureau] = value
 
     return numbers
 

--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -59,12 +59,20 @@ def enrich_account_metadata(acc: dict[str, Any]) -> dict[str, Any]:
     acc["normalized_name"] = normalize_creditor_name(name)
 
     # Derive a last4 account number from any available account number field
-    acct_num = acc.get("account_number") or acc.get("account_number_masked")
+    acct_num = (
+        acc.get("account_number")
+        or acc.get("account_number_masked")
+        or acc.get("account_number_raw")
+    )
     if not acct_num:
         for info in acc.get("bureaus", []) or []:
             if not isinstance(info, dict):
                 continue
-            acct_num = info.get("account_number") or info.get("account_number_masked")
+            acct_num = (
+                info.get("account_number")
+                or info.get("account_number_masked")
+                or info.get("account_number_raw")
+            )
             if acct_num:
                 break
     if isinstance(acct_num, str):

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -40,9 +40,11 @@ export default function ReviewPage() {
   const dedupedAccounts = Array.from(
     accounts
       .reduce((map, acc) => {
+        const identifier =
+          acc.account_number_last4 || acc.account_fingerprint || '';
         const key = `${
           acc.normalized_name ?? acc.name?.toLowerCase() ?? ''
-        }|${acc.account_number_last4 ?? acc.account_fingerprint ?? ''}`;
+        }|${identifier}`;
         const existing = map.get(key);
         if (existing) {
           existing.late_payments = { ...existing.late_payments, ...acc.late_payments };

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -142,11 +142,40 @@ test('prefers last4 over fingerprint when both provided', async () => {
     accounts: { negative_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
       <ReviewPage />
     </MemoryRouter>
   );
   const header = await screen.findByText('Account 5');
   expect(header.parentElement).toHaveTextContent('Account 5 ••••4321 - Creditor 5');
   expect(header.parentElement).not.toHaveTextContent('cafebabe');
+});
+
+test('dedup uses last4 before fingerprint', async () => {
+  const acc1 = {
+    account_id: 'acc6',
+    name: 'Account 6',
+    normalized_name: 'account 6',
+    account_number_last4: '9999',
+    account_fingerprint: 'aaaa',
+    primary_issue: 'late_payment',
+    issue_types: ['late_payment'],
+  };
+  const acc2 = {
+    ...acc1,
+    account_id: 'acc7',
+    account_fingerprint: 'bbbb',
+  };
+  const uploadData = {
+    ...baseUploadData,
+    accounts: { negative_accounts: [acc1, acc2] },
+  };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  // Only one card should render despite differing fingerprints
+  const headers = await screen.findAllByText('Account 6');
+  expect(headers).toHaveLength(1);
 });

--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -141,3 +141,13 @@ def test_enrich_account_metadata_sets_last4_from_bureaus():
     rp.enrich_account_metadata(acc)
     assert acc["account_number_last4"] == "7890"
     assert "account_fingerprint" not in acc
+
+
+def test_enrich_account_metadata_uses_account_number_raw():
+    acc = {
+        "name": "Acme Bank",
+        "bureaus": [{"bureau": "TransUnion", "account_number_raw": "****4321"}],
+    }
+    rp.enrich_account_metadata(acc)
+    assert acc["account_number_last4"] == "4321"
+    assert "account_fingerprint" not in acc

--- a/tests/report_analysis/test_report_parsing.py
+++ b/tests/report_analysis/test_report_parsing.py
@@ -39,7 +39,22 @@ Balance: 0
     numbers = extract_account_numbers(text)
     key = normalize_creditor_name("PALISADES FU")
     assert numbers[key] == {
-        "TransUnion": "123456",
+        "TransUnion": "1234-56",
         "Experian": "7890",
         "Equifax": "1357",
+    }
+
+
+def test_extract_account_numbers_masked_forms():
+    text = """
+PALISADES FU
+Account #            ****1234            12 34 56            1234-5678-9012
+Balance: 0
+"""
+    numbers = extract_account_numbers(text)
+    key = normalize_creditor_name("PALISADES FU")
+    assert numbers[key] == {
+        "TransUnion": "****1234",
+        "Experian": "12 34 56",
+        "Equifax": "1234-5678-9012",
     }


### PR DESCRIPTION
## Summary
- parse account numbers from variant labels and masked/dashed forms, storing per-bureau raw values
- derive last-4 digits from any account number and fall back to fingerprint only when absent
- show last-4 in review UI and dedupe accounts by name + last4

## Testing
- `pytest tests/report_analysis/test_report_parsing.py tests/report_analysis/test_assign_issue_types.py tests/test_extract_problematic_accounts.py`
- `npm test --prefix frontend frontend/src/pages/ReviewPage.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68aba7dac2448325bab5a22d5fa1e2c1