### PR TITLE
Add guardrails to tri-merge to prevent account injection

### DIFF
--- a/tests/test_tri_merge_annotations.py
+++ b/tests/test_tri_merge_annotations.py
@@ -1,7 +1,9 @@
+import json
+
 from backend.core.orchestrators import _annotate_with_tri_merge
 
 
-def test_tri_merge_annotations_do_not_change_counts(monkeypatch):
+def test_tri_merge_annotations_do_not_change_counts_and_primary_issue(monkeypatch):
     sections = {
         "negative_accounts": [
             {
@@ -10,6 +12,7 @@ def test_tri_merge_annotations_do_not_change_counts(monkeypatch):
                 "account_number": "1234",
                 "bureaus": ["Experian"],
                 "issue_types": ["late_payment"],
+                "primary_issue": "late_payment",
             }
         ],
         "open_accounts_with_issues": [
@@ -19,6 +22,7 @@ def test_tri_merge_annotations_do_not_change_counts(monkeypatch):
                 "account_number": "1234",
                 "bureaus": ["Equifax"],
                 "issue_types": ["late_payment"],
+                "primary_issue": "late_payment",
             }
         ],
     }
@@ -30,3 +34,40 @@ def test_tri_merge_annotations_do_not_change_counts(monkeypatch):
     assert len(sections["open_accounts_with_issues"]) == open_before
     assert "tri_merge" in sections["negative_accounts"][0]
     assert "tri_merge" in sections["open_accounts_with_issues"][0]
+    assert sections["negative_accounts"][0]["primary_issue"] == "late_payment"
+    assert sections["open_accounts_with_issues"][0]["primary_issue"] == "late_payment"
+
+
+def test_tri_merge_violation_logged_and_reverted(monkeypatch):
+    sections = {
+        "negative_accounts": [
+            {
+                "account_id": "1",
+                "name": "Cap One",
+                "account_number": "1234",
+                "bureaus": ["Experian"],
+                "issue_types": ["late_payment"],
+                "primary_issue": "late_payment",
+            }
+        ]
+    }
+
+    def bad_compute(families):
+        sections["negative_accounts"][0]["primary_issue"] = "collection"
+        return families
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "backend.core.logic.report_analysis.tri_merge.compute_mismatches",
+        bad_compute,
+    )
+    monkeypatch.setattr(
+        "backend.audit.audit.emit_event",
+        lambda name, payload, **kw: events.append((name, json.dumps(payload))),
+    )
+    monkeypatch.setenv("ENABLE_TRI_MERGE", "1")
+    _annotate_with_tri_merge(sections)
+
+    # Primary issue should be restored and violation logged
+    assert sections["negative_accounts"][0]["primary_issue"] == "late_payment"
+    assert any(evt[0] == "trimerge_violation" for evt in events)


### PR DESCRIPTION
## Summary
- ensure tri-merge only annotates existing accounts by snapshotting account counts and primary issues
- log `trimerge_violation` and discard results if tri-merge modifies counts or primary issues
- test tri-merge guards at unit and integration levels

## Testing
- `pre-commit run --files backend/core/orchestrators.py tests/test_tri_merge_annotations.py tests/test_extract_problematic_accounts.py`
- `pytest tests/test_tri_merge_annotations.py tests/test_extract_problematic_accounts.py::test_tri_merge_toggle_does_not_change_counts_or_primary_issue`


------
https://chatgpt.com/codex/tasks/task_b_68abaae5c6648325b3fdd1415d3c6de4