### PR TITLE
feat(frontend): add debug evidence drawer

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -9,6 +9,16 @@ export default function ReviewPage() {
   const [explanations, setExplanations] = useState({});
   const [summaries, setSummaries] = useState({});
   const [showSummary, setShowSummary] = useState({});
+  const debugEvidence =
+    process.env.VITE_DEBUG_EVIDENCE === '1' ||
+    (() => {
+      try {
+        // eslint-disable-next-line no-new-func
+        return new Function('return import.meta.env.VITE_DEBUG_EVIDENCE')() === '1';
+      } catch {
+        return false;
+      }
+    })();
 
   useEffect(() => {
     if (uploadData?.session_id) {
@@ -137,6 +147,14 @@ export default function ReviewPage() {
               <pre className="summary-box">
                 {JSON.stringify(summaries[acc.account_id], null, 2)}
               </pre>
+            )}
+            {debugEvidence && acc.account_trace && (
+              <details className="evidence-toggle">
+                <summary>View evidence</summary>
+                <pre className="summary-box">
+                  {JSON.stringify(acc.account_trace, null, 2)}
+                </pre>
+              </details>
             )}
           </div>
         );

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -179,3 +179,27 @@ test('dedup uses last4 before fingerprint', async () => {
   const headers = await screen.findAllByText('Account 6');
   expect(headers).toHaveLength(1);
 });
+
+test('renders evidence drawer when debug flag enabled', async () => {
+  const originalEnv = process.env.VITE_DEBUG_EVIDENCE;
+  process.env.VITE_DEBUG_EVIDENCE = '1';
+  const acc = {
+    ...account,
+    account_trace: { payment_status: 'late' }
+  };
+  const uploadData = {
+    ...baseUploadData,
+    accounts: { negative_accounts: [acc] },
+  };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const expander = await screen.findByText('View evidence');
+  const content = screen.getByText(/payment_status/i);
+  expect(content).not.toBeVisible();
+  fireEvent.click(expander);
+  expect(content).toBeVisible();
+  process.env.VITE_DEBUG_EVIDENCE = originalEnv;
+});


### PR DESCRIPTION
## Summary
- add flag-based evidence drawer on ReviewPage to inspect `account_trace`
- cover evidence drawer with unit test

## Testing
- `npm test`
- `pytest tests/test_account_trace_bug.py`


------
https://chatgpt.com/codex/tasks/task_b_68abacce44648325a2a3d81f5f5d502e