### PR TITLE
Filter invalid account numbers and derive last4 when digits present

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -151,3 +151,16 @@ def test_enrich_account_metadata_uses_account_number_raw():
     rp.enrich_account_metadata(acc)
     assert acc["account_number_last4"] == "4321"
     assert "account_fingerprint" not in acc
+
+
+def test_enrich_account_metadata_skips_when_no_digits():
+    acc = {
+        "name": "Acme Bank",
+        "account_number_raw": "t disputed",
+        "bureaus": [{"bureau": "Experian", "account_number_raw": "N/A"}],
+    }
+    rp.enrich_account_metadata(acc)
+    assert "account_number_last4" not in acc
+    assert "account_number_raw" not in acc
+    assert all("account_number_raw" not in b for b in acc.get("bureaus", []))
+    assert "account_fingerprint" in acc

--- a/tests/report_analysis/test_report_parsing.py
+++ b/tests/report_analysis/test_report_parsing.py
@@ -1,8 +1,8 @@
 import pytest
 
 from backend.core.logic.report_analysis.report_parsing import (
-    extract_payment_statuses,
     extract_account_numbers,
+    extract_payment_statuses,
 )
 from backend.core.logic.utils.names_normalization import normalize_creditor_name
 
@@ -39,7 +39,7 @@ Balance: 0
     numbers = extract_account_numbers(text)
     key = normalize_creditor_name("PALISADES FU")
     assert numbers[key] == {
-        "TransUnion": "1234-56",
+        "TransUnion": "123456",
         "Experian": "7890",
         "Equifax": "1357",
     }
@@ -55,6 +55,17 @@ Balance: 0
     key = normalize_creditor_name("PALISADES FU")
     assert numbers[key] == {
         "TransUnion": "****1234",
-        "Experian": "12 34 56",
-        "Equifax": "1234-5678-9012",
+        "Experian": "123456",
+        "Equifax": "123456789012",
     }
+
+
+def test_extract_account_numbers_skips_non_digits():
+    text = """
+PALISADES FU
+Account #            t disputed            ****1234            N/A
+Balance: 0
+"""
+    numbers = extract_account_numbers(text)
+    key = normalize_creditor_name("PALISADES FU")
+    assert numbers[key] == {"Experian": "****1234"}


### PR DESCRIPTION
## Summary
- Normalize account number extraction to drop values without digits and strip spaces/dashes
- Sanitize account number fields during enrichment and compute last4 only when digits exist
- Cover masked, dashed, and non-digit account numbers in parser and enrichment tests

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_parsing.py backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_report_parsing.py tests/report_analysis/test_assign_issue_types.py`
- `pytest tests/report_analysis/test_report_parsing.py tests/report_analysis/test_assign_issue_types.py`


------
https://chatgpt.com/codex/tasks/task_b_68abb81e100083259d84c4c5a485bfa0