### PR TITLE
feat: robust SmartCredit payment status parsing

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -193,7 +193,7 @@ def analyze_credit_report(
             text, account_names, return_raw_map=True
         )
         _sanitize_late_counts(history)
-        payment_status_map = extract_payment_statuses(text)
+        payment_status_map, _payment_status_raw_map = extract_payment_statuses(text)
         remarks_map = extract_creditor_remarks(text)
         account_number_map = extract_account_numbers(text)
 


### PR DESCRIPTION
## Summary
- parse SmartCredit `Payment Status` rows using bureau header positions and normalize per-bureau values
- expose raw payment status line alongside normalized map
- test parsing for aligned, irregular, and mixed-case inputs

## Testing
- `pytest tests/report_analysis/test_report_parsing.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68abbd4c48748325bea22e0ee17a2fd7