### PR TITLE
Handle parser payment status for aggregated accounts

### DIFF
--- a/tests/report_analysis/test_parser_payment_status_precedence.py
+++ b/tests/report_analysis/test_parser_payment_status_precedence.py
@@ -1,0 +1,28 @@
+from backend.core.logic.report_analysis import analyze_report as ar
+
+
+def test_parser_payment_status_precedence():
+    result = {}
+    history = {"bad": {"Experian": {"30": 1}}}
+    raw_map = {"bad": "Bad Bank"}
+
+    ar._inject_missing_late_accounts(result, history, raw_map, {})
+
+    payment_statuses = {"bad": {"Experian": "collection/chargeoff"}}
+    remarks = {"bad": ""}
+    payment_status_raw = {}
+
+    ar._attach_parser_signals(
+        result["all_accounts"],
+        payment_statuses,
+        remarks,
+        payment_status_raw,
+    )
+
+    acc = result["all_accounts"][0]
+    ar._assign_issue_types(acc)
+
+    assert acc["payment_statuses"]
+    assert acc["primary_issue"] in ("collection", "charge_off")
+    assert acc["issue_types"][0] == acc["primary_issue"]
+    assert "late_payment" in acc["issue_types"]


### PR DESCRIPTION
## Summary
- attach parser-extracted payment status and remarks to accounts injected from late history
- scan raw Payment Status line for charge-off/collection when bureau map missing
- test parser-only account promotes collection/charge-off over late payment

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/analyze_report.py tests/report_analysis/test_parser_payment_status_precedence.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68abbf77cf688325bb260f0534744313