### PR TITLE
Propagate raw grid histories and flag CO markers

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -255,7 +255,7 @@ def analyze_credit_report(
                     if status_text == "closed":
                         acc["goodwill_on_closed"] = True
             if norm in grid_map:
-                acc["late_payment_history"] = grid_map[norm]
+                acc["grid_history_raw"] = grid_map[norm]
 
         for section in [
             "negative_accounts",
@@ -287,7 +287,7 @@ def analyze_credit_report(
                         if status_text == "closed":
                             acc["goodwill_on_closed"] = True
                 if norm in grid_map:
-                    acc["late_payment_history"] = grid_map[norm]
+                    acc["grid_history_raw"] = grid_map[norm]
 
         for raw_norm, bureaus in history_all.items():
             linked = raw_norm in history

--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -387,8 +387,8 @@ def _assign_issue_types(acc: dict) -> None:
                 except (TypeError, ValueError):
                     continue
 
-    for bureau, hist in (acc.get("late_payment_history") or {}).items():
-        if isinstance(hist, str) and "CO" in hist.upper():
+    for bureau, hist in (acc.get("grid_history_raw") or {}).items():
+        if isinstance(hist, str) and re.search(r"\bCO\b", hist, re.I):
             has_co_marker = True
             co_bureaus.add(bureau)
 
@@ -507,7 +507,7 @@ def _inject_missing_late_accounts(
         co_bureaus = [
             b
             for b, txt in histories.items()
-            if isinstance(txt, str) and "CO" in txt.upper()
+            if isinstance(txt, str) and re.search(r"\bCO\b", txt, re.I)
         ]
         if co_bureaus:
             flags.append("Charge-Off")
@@ -521,7 +521,7 @@ def _inject_missing_late_accounts(
             "source_stage": "parser_aggregated",
         }
         if histories:
-            entry["late_payment_history"] = histories
+            entry["grid_history_raw"] = histories
         if co_bureaus:
             entry["co_bureaus"] = sorted(co_bureaus)
         _assign_issue_types(entry)

--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -39,7 +39,7 @@ def test_inject_missing_late_accounts_detects_charge_off():
     assert len(accounts) == 1
     acc = accounts[0]
     assert acc.extras["late_payments"] == history["cap_one"]
-    assert acc.extras.get("late_payment_history") == grid_map["cap_one"]
+    assert acc.extras.get("grid_history_raw") == grid_map["cap_one"]
     assert acc.extras.get("source_stage") == "parser_aggregated"
     assert acc.extras.get("issue_types") == ["charge_off", "late_payment"]
     assert acc.extras.get("primary_issue") == "charge_off"

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -144,7 +144,7 @@ def test_emitted_account_logs_co_marker(monkeypatch, caplog):
             {
                 "name": "Acc1",
                 "late_payments": {"Experian": {"30": 1}},
-                "late_payment_history": {"Experian": "OK CO"},
+                "grid_history_raw": {"Experian": "OK CO"},
             }
         ]
     }


### PR DESCRIPTION
## Summary
- attach raw 24-month late-payment grids to accounts as `grid_history_raw`
- detect CO tokens in grids to set `has_co_marker`, `co_bureaus`, and prioritize `charge_off`
- support parser-only accounts with grid histories and updated issue-type assignment

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py tests/test_start_process.py`


------
https://chatgpt.com/codex/tasks/task_b_68abc1259f3483258f198455ffc4bb68