### PR TITLE
Implement fallback payment status detection using raw text

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -116,11 +116,13 @@ def _attach_parser_signals(
         if bureau_map:
             acc["payment_status"] = "; ".join(sorted(set(bureau_map.values())))
         else:
-            raw = payment_status_raw_by_heading.get(norm, "").lower()
-            if "charge" in raw and "off" in raw:
-                acc["payment_status"] = "charge_off"
-            elif "collection" in raw:
-                acc["payment_status"] = "collection"
+            raw = payment_status_raw_by_heading.get(norm, "")
+            acc["payment_status_raw"] = raw
+            if raw:
+                if re.search(r"\bcharge[-\s]?off\b", raw, re.I):
+                    acc["payment_status"] = "charge_off"
+                elif re.search(r"\bcollection(s)?\b", raw, re.I):
+                    acc["payment_status"] = "collection"
         acc["remarks"] = remarks_by_heading.get(norm, "")
 
 

--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -429,7 +429,7 @@ def _assign_issue_types(acc: dict) -> None:
                 if "history" in key:
                     status_parts.append(str(val or ""))
     status_text = " ".join(status_parts).lower()
-    status_clean = status_text.replace("-", " ")
+    status_clean = status_text.replace("-", " ").replace("_", " ")
 
     flags = [f.lower().replace("-", " ") for f in acc.get("flags", [])]
 

--- a/tests/report_analysis/test_parser_payment_status_precedence.py
+++ b/tests/report_analysis/test_parser_payment_status_precedence.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend.core.logic.report_analysis import analyze_report as ar
 
 
@@ -25,4 +27,41 @@ def test_parser_payment_status_precedence():
     assert acc["payment_statuses"]
     assert acc["primary_issue"] in ("collection", "charge_off")
     assert acc["issue_types"][0] == acc["primary_issue"]
+    assert "late_payment" in acc["issue_types"]
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Payment Status: Collection Account", "collection"),
+        ("Payment Status: Charge-Off", "charge_off"),
+    ],
+)
+def test_parser_payment_status_raw_fallback(raw, expected):
+    """Ensure raw payment status string triggers fallback when map is empty."""
+
+    result = {}
+    history = {"bad": {"Experian": {"30": 1}}}
+    raw_map = {"bad": "Bad Bank"}
+
+    ar._inject_missing_late_accounts(result, history, raw_map, {})
+
+    payment_statuses = {}
+    remarks = {"bad": ""}
+    payment_status_raw = {"bad": raw}
+
+    ar._attach_parser_signals(
+        result["all_accounts"],
+        payment_statuses,
+        remarks,
+        payment_status_raw,
+    )
+
+    acc = result["all_accounts"][0]
+    ar._assign_issue_types(acc)
+
+    assert acc["payment_statuses"] == {}
+    assert acc.get("payment_status") == expected
+    assert acc["primary_issue"] == expected
+    assert acc["issue_types"][0] == expected
     assert "late_payment" in acc["issue_types"]


### PR DESCRIPTION
## Summary
- Handle accounts with missing payment status map by scanning raw text for collection or charge-off keywords
- Normalize underscores in status text so flattened `payment_status` hints influence issue type detection
- Add regression tests covering raw payment status fallback

## Testing
- `pytest tests/report_analysis/test_parser_payment_status_precedence.py tests/report_analysis/test_assign_issue_types.py`


------
https://chatgpt.com/codex/tasks/task_b_68abc241deb08325a4d999ae7c97a710