### PR TITLE
Handle account status text when tagging issues

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -146,6 +146,30 @@ def test_assign_issue_types_from_payment_statuses_map():
     assert acc["issue_types"] == ["collection", "charge_off", "late_payment"]
 
 
+def test_assign_issue_types_from_status_texts_map():
+    acc = {"status_texts": {"TransUnion": "Collection/Chargeoff"}}
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "collection"
+    assert acc["issue_types"] == ["collection", "charge_off"]
+
+
+def test_assign_issue_types_status_texts_override_late():
+    acc = {
+        "status_texts": {"Experian": "Collection/Chargeoff"},
+        "late_payments": {"Experian": {"30": 2}},
+    }
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "collection"
+    assert acc["issue_types"] == ["collection", "charge_off", "late_payment"]
+
+
+def test_assign_issue_types_charge_off_from_status_texts_only():
+    acc = {"status_texts": {"Equifax": "Account charged off"}}
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "charge_off"
+    assert acc["issue_types"] == ["charge_off"]
+
+
 def test_enrich_account_metadata_sets_last4_from_bureaus():
     acc = {
         "name": "Acme Bank",


### PR DESCRIPTION
## Summary
- detect charge offs and collections from `status_texts`
- track which bureaus flagged charge off/collection in `evidence.status_text_hits`
- add tests ensuring status text detection and precedence over late payments

## Testing
- `pytest tests/report_analysis/test_assign_issue_types.py -q`
- `pytest tests/report_analysis/test_parser_payment_status_precedence.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac77f207b08325acdebdd0f4fc3321