### PR TITLE
Add heading normalization util and join diagnostics

### DIFF
--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -84,10 +84,8 @@ def scan_page_markers(page_texts: Sequence[str]) -> dict[str, Any]:
     }
 
 
-from backend.core.logic.utils.names_normalization import (  # noqa: E402
-    normalize_bureau_name,
-    normalize_creditor_name,
-)
+from backend.core.logic.utils.names_normalization import normalize_bureau_name  # noqa: E402
+from backend.core.logic.utils.norm import normalize_heading  # noqa: E402
 from backend.core.logic.utils.text_parsing import extract_account_blocks  # noqa: E402
 from backend.core.models.bureau import BureauAccount  # noqa: E402
 
@@ -187,7 +185,7 @@ def extract_three_column_fields(
                 heading_text = " ".join(
                     sp.get("text", "") for sp in heading_line.get("spans", [])
                 ).strip()
-                acc_norm = normalize_creditor_name(heading_text)
+                acc_norm = normalize_heading(heading_text)
                 ranges: dict[str, tuple[float, float]] | None = None
                 for line in lines[1:]:
                     spans = line.get("spans", [])
@@ -352,7 +350,7 @@ def extract_payment_statuses(
         if not block:
             continue
         heading = block[0].strip()
-        acc_norm = normalize_creditor_name(heading)
+        acc_norm = normalize_heading(heading)
 
         bureau_order = _find_boundaries(block[1:])
         ps_line: str | None = None
@@ -429,7 +427,7 @@ def extract_account_numbers(text: str) -> dict[str, dict[str, str]]:
         if not block:
             continue
         heading = block[0].strip()
-        acc_norm = normalize_creditor_name(heading)
+        acc_norm = normalize_heading(heading)
 
         block_text = "\n".join(block[1:])
         row = ACCOUNT_NUMBER_ROW_RE.search(block_text)
@@ -490,7 +488,7 @@ def extract_creditor_remarks(text: str) -> dict[str, dict[str, str]]:
         if not block:
             continue
         heading = block[0].strip()
-        acc_norm = normalize_creditor_name(heading)
+        acc_norm = normalize_heading(heading)
         current_bureau: str | None = None
         for line in block[1:]:
             clean = line.strip()

--- a/backend/core/logic/utils/norm.py
+++ b/backend/core/logic/utils/norm.py
@@ -1,0 +1,33 @@
+"""Heading normalization utilities."""
+
+from __future__ import annotations
+
+import re
+
+from .names_normalization import COMMON_CREDITOR_ALIASES
+
+_EXTRA_ALIASES = {
+    "gs bank usa": "gs",
+}
+
+_ALIASES = {**COMMON_CREDITOR_ALIASES, **_EXTRA_ALIASES}
+
+def normalize_heading(s: str) -> str:
+    """Return a normalized account heading.
+
+    The normalization is tolerant to punctuation, spacing, dashes and slashes
+    and collapses common aliases to a canonical form.
+    """
+    if not s:
+        return ""
+    name = s.lower().strip()
+    # Replace dashes and slashes with spaces then drop other punctuation
+    name = re.sub(r"[/-]+", " ", name)
+    name = re.sub(r"[^a-z0-9 ]", "", name)
+    name = re.sub(r"\s+", " ", name)
+    for alias, canonical in _ALIASES.items():
+        if alias in name:
+            return canonical
+    name = re.sub(r"\b(bank|usa|na|n\.a\.|llc|inc|corp|co|company)\b", "", name)
+    name = re.sub(r"\s+", " ", name)
+    return name.strip()

--- a/backend/core/logic/utils/text_parsing.py
+++ b/backend/core/logic/utils/text_parsing.py
@@ -209,7 +209,7 @@ def extract_account_headings(text: str) -> list[tuple[str, str]]:
 
     The function leverages :func:`extract_account_blocks` to locate candidate
     account sections and then normalizes their headings using
-    :func:`names_normalization.normalize_creditor_name`.  Only the first
+    :func:`norm.normalize_heading`.  Only the first
     occurrence of each normalized name is retained in the returned list.
 
     Parameters
@@ -223,7 +223,7 @@ def extract_account_headings(text: str) -> list[tuple[str, str]]:
         Tuples of ``(normalized_name, raw_heading)``.
     """
 
-    from .names_normalization import normalize_creditor_name
+    from .norm import normalize_heading
 
     headings: list[tuple[str, str]] = []
     seen: set[str] = set()
@@ -231,7 +231,7 @@ def extract_account_headings(text: str) -> list[tuple[str, str]]:
         if not block:
             continue
         raw = block[0].strip()
-        norm = normalize_creditor_name(raw)
+        norm = normalize_heading(raw)
         if norm and norm not in seen:
             headings.append((norm, raw))
             seen.add(norm)
@@ -298,9 +298,9 @@ def extract_late_history_blocks(
     grid_map: dict[str, dict[str, str]] = {}
 
     def norm(name: str) -> str:
-        from .names_normalization import normalize_creditor_name
+        from .norm import normalize_heading
 
-        return normalize_creditor_name(name)
+        return normalize_heading(name)
 
     normalized_accounts = {norm(n): n for n in known_accounts or []}
 

--- a/tests/test_heading_normalization.py
+++ b/tests/test_heading_normalization.py
@@ -1,0 +1,18 @@
+import logging
+
+from backend.core.logic.report_analysis.analyze_report import _log_heading_join_misses
+from backend.core.logic.utils.norm import normalize_heading
+
+
+def test_normalize_heading_alias():
+    assert normalize_heading("AMEX") == "american express"
+    assert normalize_heading("GS Bank USA") == "gs"
+
+
+def test_heading_join_miss_logged(caplog):
+    existing = {normalize_heading("GS")}
+    heading_map = {normalize_heading("AMEX"): "AMEX"}
+    paymap = {normalize_heading("AMEX"): {"Experian": "OK"}}
+    with caplog.at_level(logging.INFO):
+        _log_heading_join_misses(paymap, "payment_statuses", existing, heading_map)
+    assert any("heading_join_miss" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add `normalize_heading` utility with extra alias handling
- normalize headings when parsing accounts and building bureau maps
- log `heading_join_miss` diagnostics when map keys fail to match accounts

## Testing
- `pytest tests/test_heading_normalization.py -q`
- `pytest tests/report_analysis/test_report_parsing.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac793866e08325a53522246807e1df