### PR TITLE
Improve heading normalization with alias and fuzzy matching

### DIFF
--- a/backend/core/logic/utils/names_normalization.py
+++ b/backend/core/logic/utils/names_normalization.py
@@ -81,6 +81,8 @@ COMMON_CREDITOR_ALIASES = {
     "aes": "aes (american education services)",
     "fedloan": "fedloan servicing",
     "credit one": "credit one bank",
+    "credit one bank": "credit one bank",
+    "creditonebnk": "credit one bank",
     "first premier": "first premier bank",
     "mission lane": "mission lane",
     "ollo": "ollo card",
@@ -97,6 +99,7 @@ COMMON_CREDITOR_ALIASES = {
     "american express national bank": "american express",
     "santander": "santander bank",
     "santander bank": "santander bank",
+    "gs bank usa": "gs",
     "bbva": "bbva usa",
     "bbva usa": "bbva usa",
     "fifth third": "fifth third bank",
@@ -109,6 +112,9 @@ COMMON_CREDITOR_ALIASES = {
     "freedom financial": "freedomplus",
     "freedom plus": "freedomplus",
     "freedomplus": "freedomplus",
+    "webbank fhut": "webbank fingerhut",
+    "webbnk fhut": "webbank fingerhut",
+    "webbank fingerhut": "webbank fingerhut",
 }
 
 

--- a/backend/core/logic/utils/norm.py
+++ b/backend/core/logic/utils/norm.py
@@ -6,28 +6,37 @@ import re
 
 from .names_normalization import COMMON_CREDITOR_ALIASES
 
-_EXTRA_ALIASES = {
-    "gs bank usa": "gs",
-}
 
-_ALIASES = {**COMMON_CREDITOR_ALIASES, **_EXTRA_ALIASES}
+def _canonicalize_base(s: str) -> str:
+    """Canonicalize *s* by stripping punctuation and normalizing case."""
+
+    name = s.upper().strip()
+    name = re.sub(r"[/-]+", " ", name)
+    name = re.sub(r"[^A-Z0-9 ]", "", name)
+    name = re.sub(r"\s+", " ", name)
+    return name.strip()
+
+
+_ALIASES = {_canonicalize_base(a): c for a, c in COMMON_CREDITOR_ALIASES.items()}
+
 
 def normalize_heading(s: str) -> str:
     """Return a normalized account heading.
 
-    The normalization is tolerant to punctuation, spacing, dashes and slashes
-    and collapses common aliases to a canonical form.
+    The normalization uppercases and strips punctuation/slashes, collapses
+    whitespace and applies :data:`COMMON_CREDITOR_ALIASES`.
     """
+
     if not s:
         return ""
-    name = s.lower().strip()
-    # Replace dashes and slashes with spaces then drop other punctuation
-    name = re.sub(r"[/-]+", " ", name)
-    name = re.sub(r"[^a-z0-9 ]", "", name)
+    name = _canonicalize_base(s)
+    alias = _ALIASES.get(name)
+    if alias:
+        return alias
+    name = re.sub(
+        r"\b(BANK|USA|NA|N\.A\.|LLC|INC|CORP|CO|COMPANY)\b",
+        "",
+        name,
+    )
     name = re.sub(r"\s+", " ", name)
-    for alias, canonical in _ALIASES.items():
-        if alias in name:
-            return canonical
-    name = re.sub(r"\b(bank|usa|na|n\.a\.|llc|inc|corp|co|company)\b", "", name)
-    name = re.sub(r"\s+", " ", name)
-    return name.strip()
+    return name.strip().lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ pyyaml
 pytest-env
 jsonschema
 croniter
+rapidfuzz==3.1.1


### PR DESCRIPTION
## Summary
- canonicalize account headings and apply extended creditor alias map
- add fuzzy matching join to attach parsed blocks to accounts
- log joined headings instead of misses and add unit tests

## Testing
- `pytest tests/test_heading_normalization.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac8c27b464832593ebcf0311479cc1