### PR TITLE
Backfill evidence defaults across account categories

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1010,6 +1010,7 @@ def extract_problematic_accounts_from_report(
     sections.setdefault("negative_accounts", [])
     sections.setdefault("open_accounts_with_issues", [])
     sections.setdefault("all_accounts", [])
+    sections.setdefault("high_utilization_accounts", [])
     from backend.core.logic.report_analysis.report_postprocessing import (
         _inject_missing_late_accounts,
         enrich_account_metadata,
@@ -1092,22 +1093,26 @@ def extract_problematic_accounts_from_report(
     _annotate_with_tri_merge(sections)
     update_session(session_id, status="awaiting_user_explanations")
     _log_account_snapshot("pre_bureau_payload")
-    for acc in sections.get("negative_accounts", []) + sections.get(
-        "open_accounts_with_issues", []
+    for cat in (
+        "negative_accounts",
+        "open_accounts_with_issues",
+        "high_utilization_accounts",
     ):
-        acc.setdefault("primary_issue", "unknown")
-        acc.setdefault("issue_types", [])
-        acc.setdefault("status", acc.get("account_status") or "")
-        acc.setdefault("late_payments", {})
-        acc.setdefault("payment_statuses", {})
-        acc.setdefault("has_co_marker", False)
-        acc.setdefault("co_bureaus", [])
-        acc.setdefault("remarks_contains_co", False)
-        acc.setdefault("bureau_statuses", {})
-        acc.setdefault("account_number_last4", None)
-        acc.setdefault("account_fingerprint", None)
-        acc.setdefault("original_creditor", None)
-        acc.setdefault("source_stage", acc.get("source_stage") or "")
+        for acc in sections.get(cat, []):
+            acc.setdefault("primary_issue", "unknown")
+            acc.setdefault("issue_types", [])
+            acc.setdefault("status", acc.get("account_status") or "")
+            acc.setdefault("late_payments", {})
+            acc.setdefault("payment_statuses", {})
+            acc.setdefault("has_co_marker", False)
+            acc.setdefault("co_bureaus", [])
+            acc.setdefault("remarks_contains_co", False)
+            acc.setdefault("bureau_statuses", {})
+            acc.setdefault("account_number_last4", None)
+            acc.setdefault("account_fingerprint", None)
+            acc.setdefault("original_creditor", None)
+            acc.setdefault("source_stage", acc.get("source_stage") or "")
+            acc.setdefault("bureau_details", {})
     if os.getenv("ANALYSIS_TRACE"):
         for acc in sections.get("negative_accounts", []) + sections.get(
             "open_accounts_with_issues", []

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -111,12 +111,47 @@ def test_backfills_default_fields(monkeypatch):
         "account_fingerprint": None,
         "original_creditor": None,
         "source_stage": "",
+        "bureau_details": {},
     }
     neg = payload.disputes[0].to_dict()
     good = payload.goodwill[0].to_dict()
     for acc in (neg, good):
         for key, val in expected.items():
             assert acc.get(key) == val
+
+
+def test_high_utilization_backfills_default_fields(monkeypatch):
+    sections = {
+        "negative_accounts": [],
+        "open_accounts_with_issues": [],
+        "unauthorized_inquiries": [],
+        "high_utilization_accounts": [{"name": "Acc3"}],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    monkeypatch.setattr(
+        "backend.core.logic.report_analysis.report_postprocessing.enrich_account_metadata",
+        lambda acc: acc,
+    )
+    payload = extract_problematic_accounts_from_report("dummy.pdf")
+    expected = {
+        "primary_issue": "unknown",
+        "issue_types": [],
+        "status": "",
+        "late_payments": {},
+        "payment_statuses": {},
+        "has_co_marker": False,
+        "co_bureaus": [],
+        "remarks_contains_co": False,
+        "bureau_statuses": {},
+        "account_number_last4": None,
+        "account_fingerprint": None,
+        "original_creditor": None,
+        "source_stage": "",
+        "bureau_details": {},
+    }
+    high = payload.high_utilization[0].to_dict()
+    for key, val in expected.items():
+        assert high.get(key) == val
 
 
 def test_parser_only_late_accounts_excluded_when_flag_set(monkeypatch):


### PR DESCRIPTION
## Summary
- extend evidence default backfilling to high-utilization accounts and other emitted lists
- default account schema now includes bureau_details and other fields when missing
- add tests ensuring defaults are populated for disputes, goodwill, and high-utilization categories

## Testing
- `pre-commit run --files backend/core/orchestrators.py tests/test_extract_problematic_accounts.py`
- `pytest tests/test_extract_problematic_accounts.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac8fd450cc8325aa8565d2b44a4f39