### PR TITLE
feat: prioritize bureau detail charge-offs

### DIFF
--- a/tests/report_analysis/test_assign_issue_types.py
+++ b/tests/report_analysis/test_assign_issue_types.py
@@ -170,6 +170,43 @@ def test_assign_issue_types_charge_off_from_status_texts_only():
     assert acc["issue_types"] == ["charge_off"]
 
 
+def test_assign_issue_types_from_bureau_details_status_only():
+    acc = {
+        "bureau_details": {
+            "Experian": {
+                "account_status": "Collection/Charge-Off/Bad Debt",
+                "past_due_amount": 50,
+            }
+        }
+    }
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "collection"
+    assert acc["issue_types"] == ["collection", "charge_off"]
+    assert acc["co_bureaus"] == ["Experian"]
+
+
+def test_assign_issue_types_from_bureau_details_past_due_only():
+    acc = {"bureau_details": {"Experian": {"past_due_amount": 25}}}
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "late_payment"
+    assert acc["issue_types"] == ["late_payment"]
+
+
+def test_assign_issue_types_bureau_details_mixed_late():
+    acc = {
+        "bureau_details": {
+            "Experian": {
+                "account_status": "Collection",
+                "past_due_amount": 100,
+            }
+        },
+        "late_payments": {"30": 1},
+    }
+    rp._assign_issue_types(acc)
+    assert acc["primary_issue"] == "collection"
+    assert acc["issue_types"] == ["collection", "late_payment"]
+
+
 def test_enrich_account_metadata_sets_last4_from_bureaus():
     acc = {
         "name": "Acme Bank",


### PR DESCRIPTION
## Summary
- detect charge-off/collection keywords in bureau detail lines and prioritize those issues
- include past-due-based late payment when no charge-off/collection evidence
- log bureau-driven charge-offs in account trace

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_postprocessing.py tests/report_analysis/test_assign_issue_types.py tests/test_extract_problematic_accounts.py`
- `pytest tests/report_analysis/test_assign_issue_types.py::test_assign_issue_types_from_bureau_details_status_only tests/report_analysis/test_assign_issue_types.py::test_assign_issue_types_from_bureau_details_past_due_only tests/report_analysis/test_assign_issue_types.py::test_assign_issue_types_bureau_details_mixed_late tests/test_extract_problematic_accounts.py::test_account_trace_logs_co_bureaus_from_details -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac940a2b74832590b98e3624fc713d