### PR TITLE
Improve fuzzy matching for inquiries and headings

### DIFF
--- a/tests/report_analysis/test_merge_parser_inquiries_fuzzy.py
+++ b/tests/report_analysis/test_merge_parser_inquiries_fuzzy.py
@@ -1,0 +1,18 @@
+import backend.core.logic.report_analysis.report_postprocessing as rp
+from backend.core.logic.utils.norm import normalize_heading
+
+
+def test_merge_parser_inquiries_fuzzy_match():
+    result = {
+        "inquiries": [
+            {"creditor_name": "Capital One", "date": "01/2024", "bureau": "Experian"}
+        ]
+    }
+    parsed = [
+        {"creditor_name": "CAPTL ONE", "date": "01/2024", "bureau": "Experian"}
+    ]
+    raw_map = {normalize_heading(p["creditor_name"]): p["creditor_name"] for p in parsed}
+    rp._merge_parser_inquiries(result, parsed, raw_map)
+    assert result["inquiries"] == [
+        {"creditor_name": "CAPTL ONE", "date": "01/2024", "bureau": "Experian"}
+    ]

--- a/tests/report_analysis/test_merge_parser_inquiries_preserves_name.py
+++ b/tests/report_analysis/test_merge_parser_inquiries_preserves_name.py
@@ -1,5 +1,5 @@
 import backend.core.logic.report_analysis.report_postprocessing as rp
-from backend.core.logic.utils.names_normalization import normalize_creditor_name
+from backend.core.logic.utils.norm import normalize_heading
 
 
 def test_merge_parser_inquiries_preserves_creditor_name():
@@ -13,7 +13,7 @@ def test_merge_parser_inquiries_preserves_creditor_name():
         {"creditor_name": "Chase Bank", "date": "02/2024", "bureau": "TransUnion"},
     ]
     raw_map = {
-        normalize_creditor_name(p["creditor_name"]): p["creditor_name"] for p in parsed
+        normalize_heading(p["creditor_name"]): p["creditor_name"] for p in parsed
     }
     rp._merge_parser_inquiries(result, parsed, raw_map)
 


### PR DESCRIPTION
## Summary
- reuse heading-based fuzzy matching when merging parser inquiries, avoiding UUID fallbacks
- apply same fuzzy matching to section heading reconciliation
- add unit test covering inquiry fuzzy matching

## Testing
- `pytest tests/report_analysis/test_merge_parser_inquiries_preserves_name.py tests/report_analysis/test_merge_parser_inquiries_keeps_known_name.py tests/report_analysis/test_merge_parser_inquiries_fuzzy.py tests/test_heading_normalization.py tests/test_names_normalization.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac9940817883258023ed9eddcf5808