### PR TITLE
feat(frontend): allow empty issues in review

### DIFF
--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -1,3 +1,4 @@
+/* global process, jest, describe, test, expect */
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ReviewPage from './ReviewPage';
@@ -58,7 +59,7 @@ describe.each([
   });
 });
 
-test('filters out accounts without issue_types', async () => {
+test('filters out accounts without issue_types when flag disabled', async () => {
   const uploadData = {
     ...baseUploadData,
     accounts: {
@@ -75,6 +76,27 @@ test('filters out accounts without issue_types', async () => {
   );
   expect(await screen.findByText('Account 1')).toBeInTheDocument();
   expect(screen.queryByText('Account 2')).not.toBeInTheDocument();
+});
+
+test('shows accounts without issue_types when flag enabled', async () => {
+  const originalEnv = process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI;
+  process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI = '1';
+  const uploadData = {
+    ...baseUploadData,
+    accounts: {
+      negative_accounts: [
+        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678' }
+      ]
+    }
+  };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText('Account 2')).toBeInTheDocument();
+  expect(screen.getByText('Unknown')).toHaveClass('badge');
+  process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI = originalEnv;
 });
 
 test('renders primary badge from primary_issue and secondary chips with identifiers', async () => {


### PR DESCRIPTION
## Summary
- make ReviewPage respect `ALLOW_EMPTY_ISSUES_IN_UI` feature flag
- show `Unknown` badge when an account lacks a primary issue
- test flag behavior for accounts without issue types

## Testing
- `npm test`
- `npx eslint src/pages/ReviewPage.jsx src/pages/ReviewPage.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68acb869bf888325a736182e5117e93a