### PR TITLE
Enhance fingerprint generation with creditor and balance

### DIFF
--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -152,9 +152,14 @@ def enrich_account_metadata(acc: dict[str, Any]) -> dict[str, Any]:
 
     # Derive a stable fingerprint when no account number is available
     if "account_number_last4" not in acc:
-        acc["account_fingerprint"] = sha1(
-            f"{acc['normalized_name']}|{acc.get('date_opened')}|{','.join(sorted((acc.get('late_payments') or {}).keys()))}".encode()
-        ).hexdigest()[:8]
+        late = acc.get("late_payments") or {}
+        seed = (
+            f"{acc['normalized_name']}|{acc.get('date_opened')}|"
+            f"{','.join(sorted(late.keys()))}"
+        )
+        if not acc.get("date_opened") and not late:
+            seed += f"|{acc.get('original_creditor')}|{acc.get('balance')}"
+        acc["account_fingerprint"] = sha1(seed.encode()).hexdigest()[:8]
 
     # Build a distilled status per bureau when bureau level info is available
     statuses: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- include `original_creditor` and `balance` in account fingerprint seed when `date_opened` and `late_payments` are empty
- add regression test for new fingerprint seeding logic

## Testing
- `pytest`
- `pytest tests/test_extract_problematic_accounts.py::test_account_fingerprint_uses_original_creditor_and_balance -v`


------
https://chatgpt.com/codex/tasks/task_b_68acbb54289c8325b58474546283d1a0