### PR TITLE
Add dispute payload builder for post-review workflow

### DIFF
--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -38,6 +38,7 @@ from backend.core.models.letter import LetterAccount, LetterArtifact, LetterCont
 from backend.core.services.ai_client import AIClient
 
 from .dispute_preparation import prepare_disputes_and_inquiries
+from backend.core.logic.problem_resolution import build_dispute_payload
 from .gpt_prompting import call_gpt_dispute_letter as _call_gpt_dispute_letter
 from .exceptions import StrategyContextMissing
 from .utils import ensure_strategy_context, populate_required_fields
@@ -361,12 +362,40 @@ def generate_all_dispute_letters_with_ai(
         )
 
 
+def generate_letters_from_selection(
+    client: ClientInfo,
+    selected_accounts: Mapping[str, Any],
+    explanations: Mapping[str, Any],
+    output_path: Path,
+    is_identity_theft: bool,
+    audit: AuditLogger | None,
+    *,
+    classification_map: Mapping[str, ClassificationRecord] | None = None,
+    ai_client: AIClient,
+    **kwargs: Any,
+):
+    """Generate dispute letters from user-selected accounts."""
+
+    bureau_map = build_dispute_payload(selected_accounts, explanations)
+    return generate_all_dispute_letters_with_ai(
+        client,
+        bureau_map,
+        output_path,
+        is_identity_theft,
+        audit,
+        classification_map=classification_map,
+        ai_client=ai_client,
+        **kwargs,
+    )
+
+
 generate_dispute_letters_for_all_bureaus = generate_all_dispute_letters_with_ai
 
 
 __all__ = [
     "generate_all_dispute_letters_with_ai",
     "generate_dispute_letters_for_all_bureaus",
+    "generate_letters_from_selection",
     "DEFAULT_DISPUTE_REASON",
     "ESCALATION_NOTE",
     "call_gpt_dispute_letter",

--- a/backend/core/logic/problem_resolution.py
+++ b/backend/core/logic/problem_resolution.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Utilities for building bureau payloads after client review."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+from backend.api.config import env_bool
+from backend.core.models.bureau import BureauPayload
+from backend.core.logic.report_analysis.report_postprocessing import _assign_issue_types
+from backend.core.orchestrators import _annotate_with_tri_merge
+
+
+@dataclass
+class _Sections:
+    disputes: list[dict]
+    goodwill: list[dict]
+    inquiries: list[dict]
+    high_utilization: list[dict]
+
+    @classmethod
+    def from_selection(cls, data: Mapping[str, Any]) -> "_Sections":
+        return cls(
+            disputes=list(
+                data.get("disputes")
+                or data.get("negative_accounts")
+                or []
+            ),
+            goodwill=list(
+                data.get("goodwill")
+                or data.get("open_accounts_with_issues")
+                or []
+            ),
+            inquiries=list(
+                data.get("inquiries")
+                or data.get("unauthorized_inquiries")
+                or []
+            ),
+            high_utilization=list(
+                data.get("high_utilization")
+                or data.get("high_utilization_accounts")
+                or []
+            ),
+        )
+
+
+def _extract_bureaus(bureaus: Iterable[Any]) -> list[str]:
+    names: list[str] = []
+    for b in bureaus:
+        if isinstance(b, str):
+            names.append(b)
+        elif isinstance(b, Mapping):
+            name = b.get("bureau") or b.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+def build_dispute_payload(
+    selected_accounts: Mapping[str, Any],
+    explanations: Mapping[str, Any] | None = None,
+) -> Dict[str, BureauPayload]:
+    """Assemble per-bureau payload from user selected accounts."""
+
+    explanations = explanations or {}
+    sections = _Sections.from_selection(selected_accounts)
+
+    all_accounts = sections.disputes + sections.goodwill + sections.high_utilization
+    for acc in all_accounts:
+        if not acc.get("issue_types"):
+            _assign_issue_types(acc)
+        acc_id = str(acc.get("account_id") or "")
+        if acc_id and acc_id in explanations and not acc.get("structured_summary"):
+            acc["structured_summary"] = explanations[acc_id]
+
+    tri_sections = {
+        "negative_accounts": sections.disputes,
+        "open_accounts_with_issues": sections.goodwill,
+        "high_utilization_accounts": sections.high_utilization,
+    }
+    if env_bool("ENABLE_TRI_MERGE", False):
+        _annotate_with_tri_merge(tri_sections)
+
+    bureau_map: Dict[str, BureauPayload] = {}
+
+    def _ensure(bureau: str) -> BureauPayload:
+        return bureau_map.setdefault(bureau, BureauPayload())
+
+    for acc in sections.disputes:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).disputes.append(acc)
+
+    for acc in sections.goodwill:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).goodwill.append(acc)
+
+    for inq in sections.inquiries:
+        bureau = inq.get("bureau") or inq.get("source")
+        if bureau:
+            _ensure(str(bureau)).inquiries.append(inq)
+
+    for acc in sections.high_utilization:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).high_utilization.append(acc)
+
+    return bureau_map
+
+
+__all__ = ["build_dispute_payload"]

--- a/services/outcome_ingestion/ingest_report.py
+++ b/services/outcome_ingestion/ingest_report.py
@@ -14,6 +14,7 @@ from backend.outcomes.models import Outcome
 from backend.analytics.analytics_tracker import emit_counter
 from backend.core.logic.report_analysis.tri_merge import normalize_and_match
 from backend.core.logic.report_analysis.tri_merge_models import Tradeline, TradelineFamily
+from backend.core.logic.problem_resolution import build_dispute_payload
 
 from . import ingest
 
@@ -187,3 +188,16 @@ def ingest_report(account_id: str | None, new_report: Mapping[str, Any]) -> List
     session_manager.update_session(session_id, tri_merge=tri_merge)
 
     return events
+
+
+def ingest_selected_accounts(
+    selected_accounts: Mapping[str, Any],
+    explanations: Mapping[str, Any] | None = None,
+) -> List[OutcomeEvent]:
+    """Ingest outcome events from user-selected accounts."""
+
+    report = {
+        b: payload.to_dict()
+        for b, payload in build_dispute_payload(selected_accounts, explanations).items()
+    }
+    return ingest_report(None, report)


### PR DESCRIPTION
## Summary
- build `build_dispute_payload` helper to classify accounts, attach explanations, and annotate tri-merge
- expose letter generator and tri-merge ingestion helpers that use the new builder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acbc47869c832598bc9812d3f2d4da