### PR TITLE
Log suppression reasons and heading join links

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -23,8 +23,8 @@ from typing import Any, Mapping
 from rapidfuzz import fuzz
 
 from backend.core.logic.utils.inquiries import extract_inquiries
-from backend.core.logic.utils.norm import normalize_heading
 from backend.core.logic.utils.names_normalization import normalize_creditor_name
+from backend.core.logic.utils.norm import normalize_heading
 from backend.core.logic.utils.text_parsing import (
     enforce_collection_status,
     extract_account_headings,
@@ -279,7 +279,7 @@ def _join_heading_map(
         if field_name is None:
             if method:
                 logger.info(
-                    "joined_heading %s",
+                    "heading_join_linked %s",
                     json.dumps(
                         {"raw_key": raw, "normalized_target": norm, "method": method},
                         sort_keys=True,
@@ -316,7 +316,7 @@ def _join_heading_map(
 
         if method:
             logger.info(
-                "joined_heading %s",
+                "heading_join_linked %s",
                 json.dumps(
                     {"raw_key": raw, "normalized_target": norm, "method": method},
                     sort_keys=True,

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1062,14 +1062,22 @@ def extract_problematic_accounts_from_report(
             if not skip_issue_check and not acc.get("issue_types"):
                 logger.info(
                     "suppressed_account %s",
-                    {"reason": "missing_issue_types", "name": acc.get("name"), "category": cat},
+                    {
+                        "suppression_reason": "missing_issue_types",
+                        "name": acc.get("name"),
+                        "category": cat,
+                    },
                 )
                 continue
             norm = normalize_creditor_name(acc.get("name", ""))
             if EXCLUDE_PARSER_AGGREGATED_ACCOUNTS and norm in parser_only:
                 logger.info(
                     "suppressed_account %s",
-                    {"reason": "parser_aggregated_only", "name": acc.get("name"), "category": cat},
+                    {
+                        "suppression_reason": "parser_aggregated_only",
+                        "name": acc.get("name"),
+                        "category": cat,
+                    },
                 )
                 continue
             enriched = enrich_account_metadata(acc)

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -282,7 +282,9 @@ def test_logs_suppressed_accounts(monkeypatch, caplog):
         payload = extract_problematic_accounts_from_report("dummy.pdf")
     assert [a.name for a in payload.disputes] == ["Bad"]
     assert any(
-        "suppressed_account" in r.message and "missing_issue_types" in r.message
+        "suppressed_account" in r.message
+        and "suppression_reason" in r.message
+        and "missing_issue_types" in r.message
         for r in caplog.records
     )
 

--- a/tests/test_heading_normalization.py
+++ b/tests/test_heading_normalization.py
@@ -30,6 +30,6 @@ def test_fuzzy_heading_join(caplog):
         )
     assert accounts[0]["payment_statuses"]["Experian"] == "OK"
     assert any(
-        "joined_heading" in r.message and '"method": "fuzzy"' in r.message
+        "heading_join_linked" in r.message and '"method": "fuzzy"' in r.message
         for r in caplog.records
     )


### PR DESCRIPTION
## Summary
- log suppression_reason when dropping accounts
- emit heading_join_linked when heading joins succeed after normalization
- update tests for new logging

## Testing
- `pre-commit run --files backend/core/orchestrators.py backend/core/logic/report_analysis/analyze_report.py tests/test_heading_normalization.py tests/test_extract_problematic_accounts.py`
- `pytest tests/test_heading_normalization.py tests/test_extract_problematic_accounts.py`


------
https://chatgpt.com/codex/tasks/task_b_68acbfd4f8188325957deb82454c310e