### PR TITLE
Gate pre-confirm tri-merge behind env flag

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1109,9 +1109,8 @@ def extract_problematic_accounts_from_report(
             )
             filtered.append(enriched)
         sections[cat] = filtered
-    if os.getenv("DISABLE_TRI_MERGE_PRECONFIRM") == "1":
-        return sections
-    _annotate_with_tri_merge(sections)
+    if os.getenv("DISABLE_TRI_MERGE_PRECONFIRM", "1") != "1":
+        _annotate_with_tri_merge(sections)
     update_session(session_id, status="awaiting_user_explanations")
     _log_account_snapshot("pre_bureau_payload")
     for cat in (


### PR DESCRIPTION
## Summary
- Skip costly tri-merge annotations before user confirmation unless `DISABLE_TRI_MERGE_PRECONFIRM=0`
- Adjust tests to expect `BureauPayload` return and to enable tri-merge explicitly when desired

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68acc82f5eb48325a45e3efdad2e58b2