### PR TITLE
Return problem accounts in detection mode

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1244,7 +1244,7 @@ def extract_problematic_accounts_from_report(
             ):
                 logger.info("account_trace_bug %s", json.dumps(trace, sort_keys=True))
             logger.info("account_trace %s", json.dumps(trace, sort_keys=True))
-    if os.getenv("PROBLEM_DETECTION_ONLY"):
+    if os.getenv("PROBLEM_DETECTION_ONLY") == "1":
         return {
             "problem_accounts": sections.get("negative_accounts", [])
             + sections.get("open_accounts_with_issues", [])
@@ -1289,6 +1289,8 @@ def extract_problematic_accounts_from_report_dict(
         stacklevel=2,
     )
     payload = extract_problematic_accounts_from_report(file_path, session_id)
+    if isinstance(payload, Mapping):
+        return payload
     return {
         "negative_accounts": [a.to_dict() for a in payload.disputes],
         "open_accounts_with_issues": [a.to_dict() for a in payload.goodwill],

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -267,6 +267,27 @@ def test_detection_mode_keeps_accounts_without_issue_types(monkeypatch):
     assert {a["name"] for a in result["problem_accounts"]} == {"Bad", "NoIssue"}
 
 
+def test_detection_mode_dict_adapter(monkeypatch):
+    sections = {
+        "negative_accounts": [
+            {"name": "Bad", "issue_types": ["late_payment"]},
+            {"name": "NoIssue"},
+        ],
+        "open_accounts_with_issues": [],
+        "unauthorized_inquiries": [],
+        "high_utilization_accounts": [],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    monkeypatch.setenv("PROBLEM_DETECTION_ONLY", "1")
+    monkeypatch.setattr(
+        "backend.core.logic.report_analysis.report_postprocessing.enrich_account_metadata",
+        lambda acc: acc,
+    )
+    with pytest.deprecated_call():
+        result = extract_problematic_accounts_from_report_dict("dummy.pdf")
+    assert {a["name"] for a in result["problem_accounts"]} == {"Bad", "NoIssue"}
+
+
 def test_accounts_without_issue_types_can_be_suppressed_with_flag(monkeypatch, caplog):
     sections = {
         "negative_accounts": [


### PR DESCRIPTION
## Summary
- Skip BureauPayload creation when `PROBLEM_DETECTION_ONLY=1`, returning `problem_accounts`
- Allow deprecated dict adapter to pass through detection-mode results
- Add regression test for dict adapter in detection-only mode

## Testing
- `pytest tests/test_extract_problematic_accounts.py`


------
https://chatgpt.com/codex/tasks/task_b_68acc9a6dc04832588c59a4175c44c78