### PR TITLE
fix: forward problematic account dict

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -78,13 +78,13 @@ def extract_problematic_accounts(self, file_path: str, session_id: str | None = 
     try:
         logger.info("Extracting accounts from %s", file_path)
         _ensure_file(file_path)
-        payload = extract_problematic_accounts_from_report(file_path, session_id)
+        result = extract_problematic_accounts_from_report(file_path, session_id)
         warnings.warn(
             "extract_problematic_accounts task will return BureauPayload in the future; current dict output is deprecated",
             DeprecationWarning,
             stacklevel=2,
         )
-        return payload.to_dict()
+        return result
     except Exception as exc:
         logger.exception("[ERROR] Error extracting accounts")
         raise exc


### PR DESCRIPTION
## Summary
- forward `extract_problematic_accounts_from_report` result directly in Celery task

## Testing
- `ruff check backend/api/tasks.py`
- `pytest tests/test_start_process.py::test_start_process_success -q`
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_returns_models -q`
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_dict_adapter -q`


------
https://chatgpt.com/codex/tasks/task_b_68acca8e3b74832586de1583fcb5265b