### PR TITLE
Defer issue-type assignment with env flag

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -689,9 +689,10 @@ def analyze_credit_report(
             for acc in result.get(section, []):
                 enforce_collection_status(acc)
 
-        if os.getenv("DEFER_ASSIGN_ISSUE_TYPES"):
+        if os.getenv("DEFER_ASSIGN_ISSUE_TYPES") == "1":
             for acc in result.get("all_accounts", []):
-                acc.setdefault("primary_issue", "unknown")
+                acc["primary_issue"] = "unknown"
+                acc["issue_types"] = []
             result["negative_accounts"] = []
             result["open_accounts_with_issues"] = []
             result["positive_accounts"] = []


### PR DESCRIPTION
## Summary
- Skip issue-type assignment and account bucketing when `DEFER_ASSIGN_ISSUE_TYPES=1`
- Populate each account with `primary_issue="unknown"` and an empty `issue_types` list in deferred mode

## Testing
- `pytest tests/report_analysis/test_bucket_split.py`
- `pytest tests/test_report_modules.py::test_analyze_report_wrapper`


------
https://chatgpt.com/codex/tasks/task_b_68accb71e8808325bd1ed4dafaf2c79d