### PR TITLE
Expose problem_accounts in API start_process

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -145,18 +145,24 @@ def start_process():
             timeout=300
         )
 
-        legacy = {
+        problem_accounts = result.get("problem_accounts")
+        if problem_accounts is None:
+            problem_accounts = []
+            problem_accounts.extend(result.get("disputes", []))
+            problem_accounts.extend(result.get("goodwill", []))
+
+        accounts = {
+            # Primary field
+            "problem_accounts": problem_accounts,
             # Backward compatibility fields
-            "negative_accounts": result.get(
-                "negative_accounts",
-                result.get("disputes", result.get("problem_accounts", [])),
+            "negative_accounts": problem_accounts,
+            "open_accounts_with_issues": problem_accounts,
+            "unauthorized_inquiries": result.get(
+                "unauthorized_inquiries", result.get("inquiries", [])
             ),
-            "open_accounts_with_issues": result.get(
-                "open_accounts_with_issues",
-                result.get("goodwill", result.get("problem_accounts", [])),
+            "high_utilization_accounts": result.get(
+                "high_utilization_accounts", result.get("high_utilization", [])
             ),
-            "unauthorized_inquiries": result.get("inquiries", []),
-            "high_utilization_accounts": result.get("high_utilization", []),
         }
 
         payload = {
@@ -164,10 +170,8 @@ def start_process():
             "session_id": session_id,
             "filename": unique_name,
             "original_filename": original_name,
-            "accounts": legacy,
+            "accounts": accounts,
         }
-
-        payload["accounts"]["problem_accounts"] = result.get("problem_accounts", [])
 
         logger.info("start_process payload: %s", payload)
 

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -41,6 +41,10 @@ def test_start_process_success(monkeypatch, tmp_path):
     payload = json.loads(resp.data)
     assert payload["status"] == "awaiting_user_explanations"
     assert not called.get("called")
+    accounts = payload["accounts"]
+    assert accounts["problem_accounts"] == accounts["negative_accounts"] == accounts[
+        "open_accounts_with_issues"
+    ]
 
 
 def test_start_process_missing_file():
@@ -102,7 +106,11 @@ def test_start_process_emits_enriched_fields(monkeypatch, tmp_path):
     )
     assert resp.status_code == 200
     payload_json = json.loads(resp.data)
-    acc = payload_json["accounts"]["negative_accounts"][0]
+    accounts = payload_json["accounts"]
+    assert accounts["problem_accounts"] == accounts["negative_accounts"] == accounts[
+        "open_accounts_with_issues"
+    ]
+    acc = accounts["problem_accounts"][0]
     assert acc["primary_issue"] == "charge_off"
     assert acc["account_number_last4"] == "6789"
     assert acc["original_creditor"] == "OC"


### PR DESCRIPTION
## Summary
- return `problem_accounts` as the primary accounts list
- mirror `problem_accounts` into `negative_accounts` and `open_accounts_with_issues` for legacy clients
- update start process tests for new fields

## Testing
- `pytest tests/test_start_process.py::test_start_process_success tests/test_start_process.py::test_start_process_emits_enriched_fields -q`
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_returns_models -q`


------
https://chatgpt.com/codex/tasks/task_b_68accdf111c88325a214b53cd905537f