### PR TITLE
feat: show unclassified problem accounts

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,7 +15,7 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node, ...globals.jest },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -1,4 +1,3 @@
-/* global process */
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { submitExplanations, getSummaries } from '../api';
@@ -15,17 +14,6 @@ export default function ReviewPage() {
       return (
         process.env.VITE_DEBUG_EVIDENCE === '1' ||
         new Function('return import.meta.env?.VITE_DEBUG_EVIDENCE')() === '1'
-      );
-    } catch {
-      return false;
-    }
-  })();
-
-  const allowEmptyIssues = (() => {
-    try {
-      return (
-        process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI === '1' ||
-        new Function('return import.meta.env?.VITE_ALLOW_EMPTY_ISSUES_IN_UI')() === '1'
       );
     } catch {
       return false;
@@ -50,14 +38,15 @@ export default function ReviewPage() {
     return <p>No upload data available.</p>;
   }
 
-  const allAccounts = [
-    ...(uploadData.accounts?.negative_accounts ?? uploadData.accounts?.disputes ?? []),
-    ...(uploadData.accounts?.open_accounts_with_issues ?? uploadData.accounts?.goodwill ?? []),
-  ];
-
-  const accounts = allowEmptyIssues
-    ? allAccounts
-    : allAccounts.filter((acc) => (acc.issue_types ?? []).length);
+  const accounts =
+    uploadData.accounts?.problem_accounts ?? [
+      ...(uploadData.accounts?.negative_accounts ??
+        uploadData.accounts?.disputes ??
+        []),
+      ...(uploadData.accounts?.open_accounts_with_issues ??
+        uploadData.accounts?.goodwill ??
+        []),
+    ];
 
   // Debug: log first card's props
   if (accounts[0]) {
@@ -99,7 +88,7 @@ export default function ReviewPage() {
       case 'charge_off':
         return 'Charge-Off';
       default:
-        return type;
+        return type ? type.charAt(0).toUpperCase() + type.slice(1) : type;
     }
   };
 

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -1,4 +1,3 @@
-/* global process, jest, describe, test, expect */
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ReviewPage from './ReviewPage';
@@ -29,6 +28,7 @@ const account = {
 };
 
 describe.each([
+  'problem_accounts',
   'negative_accounts',
   'disputes',
   'open_accounts_with_issues',
@@ -59,44 +59,22 @@ describe.each([
   });
 });
 
-test('filters out accounts without issue_types when flag disabled', async () => {
+test('renders accounts without issue_types', async () => {
   const uploadData = {
     ...baseUploadData,
     accounts: {
-      negative_accounts: [
-        account,
-        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678' }
+      problem_accounts: [
+        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678', primary_issue: 'unknown' }
       ]
     }
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
-      <ReviewPage />
-    </MemoryRouter>
-  );
-  expect(await screen.findByText('Account 1')).toBeInTheDocument();
-  expect(screen.queryByText('Account 2')).not.toBeInTheDocument();
-});
-
-test('shows accounts without issue_types when flag enabled', async () => {
-  const originalEnv = process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI;
-  process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI = '1';
-  const uploadData = {
-    ...baseUploadData,
-    accounts: {
-      negative_accounts: [
-        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678' }
-      ]
-    }
-  };
-  render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
       <ReviewPage />
     </MemoryRouter>
   );
   expect(await screen.findByText('Account 2')).toBeInTheDocument();
   expect(screen.getByText('Unknown')).toHaveClass('badge');
-  process.env.VITE_ALLOW_EMPTY_ISSUES_IN_UI = originalEnv;
 });
 
 test('renders primary badge from primary_issue and secondary chips with identifiers', async () => {


### PR DESCRIPTION
## Summary
- read `problem_accounts` in ReviewPage with legacy fallback
- display accounts even without issue types and handle `unknown` issues
- allow ESLint to recognize Node and Jest globals

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68accefa2d88832583246d9b4ecc07d4