### PR TITLE
feat: add post-confirmation dispute payload builder

### DIFF
--- a/backend/core/logic/letters/letter_generator.py
+++ b/backend/core/logic/letters/letter_generator.py
@@ -38,7 +38,7 @@ from backend.core.models.letter import LetterAccount, LetterArtifact, LetterCont
 from backend.core.services.ai_client import AIClient
 
 from .dispute_preparation import prepare_disputes_and_inquiries
-from backend.core.logic.problem_resolution import build_dispute_payload
+from backend.core.logic.post_confirmation import build_dispute_payload
 from .gpt_prompting import call_gpt_dispute_letter as _call_gpt_dispute_letter
 from .exceptions import StrategyContextMissing
 from .utils import ensure_strategy_context, populate_required_fields

--- a/backend/core/logic/post_confirmation.py
+++ b/backend/core/logic/post_confirmation.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Adapter utilities executed after user confirmation (Stage C).
+
+This module transforms the user-confirmed account selections into a structured
+``BureauPayload`` that downstream components such as the letter generator and
+tri-merge outcome ingestion can consume.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+from backend.api.config import env_bool
+from backend.core.models.bureau import BureauPayload
+from backend.core.logic.report_analysis.report_postprocessing import (
+    _assign_issue_types,
+    enrich_account_metadata,
+)
+from backend.core.orchestrators import _annotate_with_tri_merge
+
+
+@dataclass
+class _Sections:
+    """Normalized view of account sections after user selection."""
+
+    disputes: list[dict]
+    goodwill: list[dict]
+    inquiries: list[dict]
+    high_utilization: list[dict]
+
+    @classmethod
+    def from_selection(cls, data: Mapping[str, Any]) -> "_Sections":
+        return cls(
+            disputes=list(
+                data.get("disputes")
+                or data.get("negative_accounts")
+                or []
+            ),
+            goodwill=list(
+                data.get("goodwill")
+                or data.get("open_accounts_with_issues")
+                or []
+            ),
+            inquiries=list(
+                data.get("inquiries")
+                or data.get("unauthorized_inquiries")
+                or []
+            ),
+            high_utilization=list(
+                data.get("high_utilization")
+                or data.get("high_utilization_accounts")
+                or []
+            ),
+        )
+
+
+def _extract_bureaus(bureaus: Iterable[Any]) -> list[str]:
+    """Return bureau names from a heterogeneous ``bureaus`` value."""
+
+    names: list[str] = []
+    for b in bureaus:
+        if isinstance(b, str):
+            names.append(b)
+        elif isinstance(b, Mapping):
+            name = b.get("bureau") or b.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+def build_dispute_payload(
+    selected_accounts: Mapping[str, Any],
+    explanations: Mapping[str, Any] | None = None,
+) -> Dict[str, BureauPayload]:
+    """Assemble per-bureau payload from user selected accounts.
+
+    The input ``selected_accounts`` is expected to contain the user's confirmed
+    problematic accounts.  For each account we ensure ``issue_types`` are
+    populated, enrich metadata, merge any user-provided explanations, and then
+    optionally annotate with tri-merge mismatches.  Finally, accounts are grouped
+    into a ``BureauPayload`` for each bureau present.
+    """
+
+    explanations = explanations or {}
+    sections = _Sections.from_selection(selected_accounts)
+
+    all_accounts = sections.disputes + sections.goodwill + sections.high_utilization
+    for acc in all_accounts:
+        if not acc.get("issue_types"):
+            _assign_issue_types(acc)
+        enrich_account_metadata(acc)
+        acc_id = str(acc.get("account_id") or "")
+        if acc_id and acc_id in explanations and not acc.get("structured_summary"):
+            acc["structured_summary"] = explanations[acc_id]
+
+    tri_sections = {
+        "negative_accounts": sections.disputes,
+        "open_accounts_with_issues": sections.goodwill,
+        "high_utilization_accounts": sections.high_utilization,
+    }
+    if env_bool("ENABLE_TRI_MERGE", False):
+        _annotate_with_tri_merge(tri_sections)
+
+    bureau_map: Dict[str, BureauPayload] = {}
+
+    def _ensure(bureau: str) -> BureauPayload:
+        return bureau_map.setdefault(bureau, BureauPayload())
+
+    for acc in sections.disputes:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).disputes.append(acc)
+
+    for acc in sections.goodwill:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).goodwill.append(acc)
+
+    for inq in sections.inquiries:
+        bureau = inq.get("bureau") or inq.get("source")
+        if bureau:
+            _ensure(str(bureau)).inquiries.append(inq)
+
+    for acc in sections.high_utilization:
+        for bureau in _extract_bureaus(acc.get("bureaus") or []):
+            _ensure(bureau).high_utilization.append(acc)
+
+    return bureau_map
+
+
+__all__ = ["build_dispute_payload"]
+

--- a/backend/core/logic/problem_resolution.py
+++ b/backend/core/logic/problem_resolution.py
@@ -1,109 +1,12 @@
-from __future__ import annotations
+"""Deprecated shim for backward compatibility.
 
-"""Utilities for building bureau payloads after client review."""
+This module previously housed :func:`build_dispute_payload` but has been
+superseded by :mod:`backend.core.logic.post_confirmation`.  Importing from this
+module continues to work, but new code should use the ``post_confirmation``
+module directly.
+"""
 
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Mapping
-
-from backend.api.config import env_bool
-from backend.core.models.bureau import BureauPayload
-from backend.core.logic.report_analysis.report_postprocessing import _assign_issue_types
-from backend.core.orchestrators import _annotate_with_tri_merge
-
-
-@dataclass
-class _Sections:
-    disputes: list[dict]
-    goodwill: list[dict]
-    inquiries: list[dict]
-    high_utilization: list[dict]
-
-    @classmethod
-    def from_selection(cls, data: Mapping[str, Any]) -> "_Sections":
-        return cls(
-            disputes=list(
-                data.get("disputes")
-                or data.get("negative_accounts")
-                or []
-            ),
-            goodwill=list(
-                data.get("goodwill")
-                or data.get("open_accounts_with_issues")
-                or []
-            ),
-            inquiries=list(
-                data.get("inquiries")
-                or data.get("unauthorized_inquiries")
-                or []
-            ),
-            high_utilization=list(
-                data.get("high_utilization")
-                or data.get("high_utilization_accounts")
-                or []
-            ),
-        )
-
-
-def _extract_bureaus(bureaus: Iterable[Any]) -> list[str]:
-    names: list[str] = []
-    for b in bureaus:
-        if isinstance(b, str):
-            names.append(b)
-        elif isinstance(b, Mapping):
-            name = b.get("bureau") or b.get("name")
-            if isinstance(name, str):
-                names.append(name)
-    return names
-
-
-def build_dispute_payload(
-    selected_accounts: Mapping[str, Any],
-    explanations: Mapping[str, Any] | None = None,
-) -> Dict[str, BureauPayload]:
-    """Assemble per-bureau payload from user selected accounts."""
-
-    explanations = explanations or {}
-    sections = _Sections.from_selection(selected_accounts)
-
-    all_accounts = sections.disputes + sections.goodwill + sections.high_utilization
-    for acc in all_accounts:
-        if not acc.get("issue_types"):
-            _assign_issue_types(acc)
-        acc_id = str(acc.get("account_id") or "")
-        if acc_id and acc_id in explanations and not acc.get("structured_summary"):
-            acc["structured_summary"] = explanations[acc_id]
-
-    tri_sections = {
-        "negative_accounts": sections.disputes,
-        "open_accounts_with_issues": sections.goodwill,
-        "high_utilization_accounts": sections.high_utilization,
-    }
-    if env_bool("ENABLE_TRI_MERGE", False):
-        _annotate_with_tri_merge(tri_sections)
-
-    bureau_map: Dict[str, BureauPayload] = {}
-
-    def _ensure(bureau: str) -> BureauPayload:
-        return bureau_map.setdefault(bureau, BureauPayload())
-
-    for acc in sections.disputes:
-        for bureau in _extract_bureaus(acc.get("bureaus") or []):
-            _ensure(bureau).disputes.append(acc)
-
-    for acc in sections.goodwill:
-        for bureau in _extract_bureaus(acc.get("bureaus") or []):
-            _ensure(bureau).goodwill.append(acc)
-
-    for inq in sections.inquiries:
-        bureau = inq.get("bureau") or inq.get("source")
-        if bureau:
-            _ensure(str(bureau)).inquiries.append(inq)
-
-    for acc in sections.high_utilization:
-        for bureau in _extract_bureaus(acc.get("bureaus") or []):
-            _ensure(bureau).high_utilization.append(acc)
-
-    return bureau_map
-
+from .post_confirmation import build_dispute_payload
 
 __all__ = ["build_dispute_payload"]
+

--- a/services/outcome_ingestion/ingest_report.py
+++ b/services/outcome_ingestion/ingest_report.py
@@ -14,7 +14,7 @@ from backend.outcomes.models import Outcome
 from backend.analytics.analytics_tracker import emit_counter
 from backend.core.logic.report_analysis.tri_merge import normalize_and_match
 from backend.core.logic.report_analysis.tri_merge_models import Tradeline, TradelineFamily
-from backend.core.logic.problem_resolution import build_dispute_payload
+from backend.core.logic.post_confirmation import build_dispute_payload
 
 from . import ingest
 


### PR DESCRIPTION
## Summary
- add Stage C post-confirmation adapter to build BureauPayloads after user review
- wire letters and outcome ingestion to consume post-confirmation payloads
- retain deprecated problem_resolution shim for compatibility

## Testing
- `pytest tests/test_start_process.py::test_start_process_success tests/test_start_process.py::test_start_process_missing_file tests/test_local_workflow.py::test_minimal_workflow -q`


------
https://chatgpt.com/codex/tasks/task_b_68acd46078cc8325af993fc832ad4beb