### PR TITLE
feat: enhance join logging and fingerprint stability

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -626,10 +626,34 @@ def analyze_credit_report(
                 norm = acc.get("normalized_name") or normalize_creditor_name(
                     acc.get("name", "")
                 )
+                raw_name = acc.get("name", "")
                 acc["normalized_name"] = norm
                 values_map = field_map.get(norm)
                 if not values_map:
+                    logger.info(
+                        "heading_join_miss %s",
+                        json.dumps(
+                            {
+                                "raw_key": raw_name,
+                                "normalized": norm,
+                                "target_present": False,
+                                "map": "account_number",
+                            },
+                            sort_keys=True,
+                        ),
+                    )
                     continue
+                logger.info(
+                    "heading_join_linked %s",
+                    json.dumps(
+                        {
+                            "raw_key": raw_name,
+                            "normalized_target": norm,
+                            "method": "canonical",
+                        },
+                        sort_keys=True,
+                    ),
+                )
                 acc.setdefault("bureaus", [])
                 raw_unique: set[str] = set()
                 digit_unique: set[str] = set()
@@ -661,10 +685,34 @@ def analyze_credit_report(
                 norm = acc.get("normalized_name") or normalize_creditor_name(
                     acc.get("name", "")
                 )
+                raw_name = acc.get("name", "")
                 acc["normalized_name"] = norm
                 values_map = detail_map.get(norm)
                 if not values_map:
+                    logger.info(
+                        "heading_join_miss %s",
+                        json.dumps(
+                            {
+                                "raw_key": raw_name,
+                                "normalized": norm,
+                                "target_present": False,
+                                "map": "bureau_details",
+                            },
+                            sort_keys=True,
+                        ),
+                    )
                     continue
+                logger.info(
+                    "heading_join_linked %s",
+                    json.dumps(
+                        {
+                            "raw_key": raw_name,
+                            "normalized_target": norm,
+                            "method": "canonical",
+                        },
+                        sort_keys=True,
+                    ),
+                )
                 bd = acc.setdefault("bureau_details", {})
                 for bureau, fields in values_map.items():
                     bd.setdefault(bureau, {}).update(fields)

--- a/backend/core/logic/report_analysis/process_accounts.py
+++ b/backend/core/logic/report_analysis/process_accounts.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, cast
@@ -13,6 +14,8 @@ from backend.core.logic.utils.names_normalization import (
 from backend.core.logic.utils.text_parsing import enforce_collection_status
 
 BUREAUS = ["Experian", "Equifax", "TransUnion"]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -159,10 +162,19 @@ def process_analyzed_report(
                 else:
                     output[bureau_norm]["disputes"].append(account)
                 seen_entries.add(key)
-            elif bureau_norm in output and log_list is not None:
-                log_list.append(
-                    f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+            elif bureau_norm in output:
+                logger.info(
+                    "suppressed_account %s",
+                    {
+                        "suppression_reason": "duplicate_entry",
+                        "name": account.name,
+                        "bureau": bureau_norm,
+                    },
                 )
+                if log_list is not None:
+                    log_list.append(
+                        f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+                    )
 
     # 2. Open Accounts with Issues
     for account_data in data.get("open_accounts_with_issues", []):
@@ -190,10 +202,19 @@ def process_analyzed_report(
                 else:
                     output[bureau_norm]["disputes"].append(account)
                 seen_entries.add(key)
-            elif bureau_norm in output and log_list is not None:
-                log_list.append(
-                    f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+            elif bureau_norm in output:
+                logger.info(
+                    "suppressed_account %s",
+                    {
+                        "suppression_reason": "duplicate_entry",
+                        "name": account.name,
+                        "bureau": bureau_norm,
+                    },
                 )
+                if log_list is not None:
+                    log_list.append(
+                        f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+                    )
 
     # 3. High Utilization Accounts - NOT sent to disputes
     for account_data in data.get("high_utilization_accounts", []):
@@ -209,10 +230,19 @@ def process_analyzed_report(
             if bureau_norm in output and key not in seen_entries:
                 output[bureau_norm]["high_utilization"].append(account)
                 seen_entries.add(key)
-            elif bureau_norm in output and log_list is not None:
-                log_list.append(
-                    f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+            elif bureau_norm in output:
+                logger.info(
+                    "suppressed_account %s",
+                    {
+                        "suppression_reason": "duplicate_entry",
+                        "name": account.name,
+                        "bureau": bureau_norm,
+                    },
                 )
+                if log_list is not None:
+                    log_list.append(
+                        f"[{bureau_norm}] Duplicate entry skipped for '{account.name}'"
+                    )
 
     # 4. Inquiries (exclude matched)
     def norm(name: str | None) -> str:

--- a/backend/core/logic/report_analysis/report_postprocessing.py
+++ b/backend/core/logic/report_analysis/report_postprocessing.py
@@ -153,12 +153,15 @@ def enrich_account_metadata(acc: dict[str, Any]) -> dict[str, Any]:
     # Derive a stable fingerprint when no account number is available
     if "account_number_last4" not in acc:
         late = acc.get("late_payments") or {}
-        seed = (
-            f"{acc['normalized_name']}|{acc.get('date_opened')}|"
-            f"{','.join(sorted(late.keys()))}"
-        )
-        if not acc.get("date_opened") and not late:
-            seed += f"|{acc.get('original_creditor')}|{acc.get('balance')}"
+        seed_parts = [
+            acc["normalized_name"],
+            acc.get("date_opened") or "",
+            ",".join(sorted(late.keys())),
+        ]
+        if acc.get("original_creditor") not in (None, "") or acc.get("balance") not in (None, ""):
+            seed_parts.append(str(acc.get("original_creditor")))
+            seed_parts.append(str(acc.get("balance")))
+        seed = "|".join(seed_parts)
         acc["account_fingerprint"] = sha1(seed.encode()).hexdigest()[:8]
 
     # Build a distilled status per bureau when bureau level info is available

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -421,7 +421,7 @@ def test_account_fingerprint_uses_original_creditor_and_balance(monkeypatch):
     acc = payload.to_dict()["disputes"][0]
     assert acc["account_number_last4"] is None
     expected_seed = (
-        f"{normalize_creditor_name('Acme Bank')}|{acc.get('date_opened')}|"
+        f"{normalize_creditor_name('Acme Bank')}|{acc.get('date_opened') or ''}|"
         f"{','.join(sorted((acc.get('late_payments') or {}).keys()))}"
         f"|{acc.get('original_creditor')}|{acc.get('balance')}"
     )


### PR DESCRIPTION
## Summary
- log heading join successes and misses after account canonicalization
- record suppression_reason when duplicate accounts are dropped
- expand fingerprint seeds to keep account IDs deterministic

## Testing
- `pytest tests/test_heading_normalization.py tests/test_extract_problematic_accounts.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68acd5da84d48325ac7b89838dbea2e1