### PR TITLE
Populate problem accounts in detection mode

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1245,9 +1245,15 @@ def extract_problematic_accounts_from_report(
                 logger.info("account_trace_bug %s", json.dumps(trace, sort_keys=True))
             logger.info("account_trace %s", json.dumps(trace, sort_keys=True))
     if os.getenv("PROBLEM_DETECTION_ONLY") == "1":
+        all_acc = sections.get("all_accounts") or []
+        if not sections.get("negative_accounts"):
+            sections["negative_accounts"] = list(all_acc)
+        if not sections.get("open_accounts_with_issues"):
+            sections["open_accounts_with_issues"] = list(all_acc)
+        neg = sections.get("negative_accounts", [])
+        open_acc = sections.get("open_accounts_with_issues", [])
         return {
-            "problem_accounts": sections.get("negative_accounts", [])
-            + sections.get("open_accounts_with_issues", [])
+            "problem_accounts": neg + [acc for acc in open_acc if acc not in neg]
         }
     payload = BureauPayload(
         disputes=[

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -288,6 +288,23 @@ def test_detection_mode_dict_adapter(monkeypatch):
     assert {a["name"] for a in result["problem_accounts"]} == {"Bad", "NoIssue"}
 
 
+def test_detection_mode_populates_from_all_accounts(monkeypatch):
+    sections = {
+        "negative_accounts": [],
+        "open_accounts_with_issues": [],
+        "all_accounts": [{"name": "A1"}, {"name": "A2"}],
+    }
+    _mock_dependencies(monkeypatch, sections)
+    monkeypatch.setenv("PROBLEM_DETECTION_ONLY", "1")
+    monkeypatch.setattr(
+        "backend.core.logic.report_analysis.report_postprocessing.enrich_account_metadata",
+        lambda acc: acc,
+    )
+    result = extract_problematic_accounts_from_report("dummy.pdf")
+    assert {a["name"] for a in result["problem_accounts"]} == {"A1", "A2"}
+    assert len(result["problem_accounts"]) == 2
+
+
 def test_accounts_without_issue_types_can_be_suppressed_with_flag(monkeypatch, caplog):
     sections = {
         "negative_accounts": [


### PR DESCRIPTION
## Summary
- ensure `extract_problematic_accounts_from_report` fills problem lists from `all_accounts` when detection mode defers classification
- add regression test for detection mode using `all_accounts`

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_detection_mode_populates_from_all_accounts tests/test_extract_problematic_accounts.py::test_detection_mode_keeps_accounts_without_issue_types tests/test_extract_problematic_accounts.py::test_detection_mode_dict_adapter -vv`


------
https://chatgpt.com/codex/tasks/task_b_68acdd14d8208325b1ef61dfc15c7ff4