### PR TITLE
Gate pre-confirm tri-merge and defer annotation

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -852,7 +852,8 @@ def run_credit_repair_process(
             ingest_outcome_report(None, bureau_data)
         except Exception:
             pass
-        _annotate_with_tri_merge(sections)
+        if os.getenv("DISABLE_TRI_MERGE_PRECONFIRM") != "1":
+            _annotate_with_tri_merge(sections)
         facts_map: dict[str, dict[str, Any]] = {}
         for key in (
             "negative_accounts",
@@ -1125,8 +1126,6 @@ def extract_problematic_accounts_from_report(
             )
             filtered.append(enriched)
         sections[cat] = filtered
-    if os.getenv("DISABLE_TRI_MERGE_PRECONFIRM", "1") != "1":
-        _annotate_with_tri_merge(sections)
     update_session(session_id, status="awaiting_user_explanations")
     _log_account_snapshot("pre_bureau_payload")
     for cat in (


### PR DESCRIPTION
## Summary
- wrap tri-merge annotation in `run_credit_repair_process` behind `DISABLE_TRI_MERGE_PRECONFIRM`
- remove pre-confirm tri-merge from report extraction so Stage C post-confirmation handles it

## Testing
- `pytest tests/test_start_process.py tests/test_tri_merge_annotations.py`

------
https://chatgpt.com/codex/tasks/task_b_68acdfcb0f248325a09e1b2f87753b4f