### PR TITLE
Backfill legacy account fields only on request

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -151,19 +151,24 @@ def start_process():
             problem_accounts.extend(result.get("disputes", []))
             problem_accounts.extend(result.get("goodwill", []))
 
+        legacy = request.args.get("legacy", "").lower() in ("1", "true", "yes")
+
         accounts = {
             # Primary field
             "problem_accounts": problem_accounts,
-            # Backward compatibility fields
-            "negative_accounts": problem_accounts,
-            "open_accounts_with_issues": problem_accounts,
-            "unauthorized_inquiries": result.get(
-                "unauthorized_inquiries", result.get("inquiries", [])
-            ),
-            "high_utilization_accounts": result.get(
-                "high_utilization_accounts", result.get("high_utilization", [])
-            ),
         }
+
+        if legacy:
+            # Backward compatibility fields for legacy clients
+            accounts["negative_accounts"] = problem_accounts
+            accounts["open_accounts_with_issues"] = problem_accounts
+
+        accounts["unauthorized_inquiries"] = result.get(
+            "unauthorized_inquiries", result.get("inquiries", [])
+        )
+        accounts["high_utilization_accounts"] = result.get(
+            "high_utilization_accounts", result.get("high_utilization", [])
+        )
 
         payload = {
             "status": "awaiting_user_explanations",

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -42,9 +42,9 @@ def test_start_process_success(monkeypatch, tmp_path):
     assert payload["status"] == "awaiting_user_explanations"
     assert not called.get("called")
     accounts = payload["accounts"]
-    assert accounts["problem_accounts"] == accounts["negative_accounts"] == accounts[
-        "open_accounts_with_issues"
-    ]
+    assert accounts["problem_accounts"] == []
+    assert "negative_accounts" not in accounts
+    assert "open_accounts_with_issues" not in accounts
 
 
 def test_start_process_missing_file():
@@ -102,7 +102,7 @@ def test_start_process_emits_enriched_fields(monkeypatch, tmp_path):
         "file": (io.BytesIO(b"%PDF-1.4"), "test.pdf"),
     }
     resp = client.post(
-        "/api/start-process", data=data, content_type="multipart/form-data"
+        "/api/start-process?legacy=1", data=data, content_type="multipart/form-data"
     )
     assert resp.status_code == 200
     payload_json = json.loads(resp.data)


### PR DESCRIPTION
## Summary
- only include `negative_accounts` and `open_accounts_with_issues` when `?legacy=1` is supplied
- adjust tests for new default account payload

## Testing
- `pytest tests/test_start_process.py -q`
- `pytest tests/test_utils_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ace332621c8325a6e293838598b25b