### PR TITLE
feat: add ProblemAccount model for Stage A

### DIFF
--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -1,13 +1,14 @@
 """Typed data models for the finance platform."""
 
 from .account import Account, AccountId, AccountMap, Inquiry, LateHistory
+from .account_state import AccountState, AccountStatus, StateTransition
 from .bureau import BureauAccount, BureauPayload, BureauSection
 from .client import ClientInfo, ProofDocuments
 from .letter import LetterAccount, LetterArtifact, LetterContext
+from .problem_account import ProblemAccount
 from .strategy import Recommendation, StrategyItem, StrategyPlan
+from .strategy_plan_model import Cycle, Step, StrategyPlan as StrategyPlanModel
 from .strategy_snapshot import StrategySnapshot
-from .strategy_plan_model import StrategyPlan as StrategyPlanModel, Cycle, Step
-from .account_state import AccountState, AccountStatus, StateTransition
 
 __all__ = [
     "Account",
@@ -18,6 +19,7 @@ __all__ = [
     "BureauSection",
     "BureauAccount",
     "BureauPayload",
+    "ProblemAccount",
     "StrategyPlan",
     "StrategyItem",
     "StrategySnapshot",

--- a/backend/core/models/bureau.py
+++ b/backend/core/models/bureau.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Type
 
-from .account import Account, Inquiry
+from .account import Inquiry
+from .problem_account import ProblemAccount
 
 
 @dataclass
@@ -13,20 +14,20 @@ class BureauPayload:
     Replaces the previous free-form ``dict`` layout used across the codebase.
     """
 
-    disputes: List[Account] = field(default_factory=list)
-    goodwill: List[Account] = field(default_factory=list)
+    disputes: List[ProblemAccount] = field(default_factory=list)
+    goodwill: List[ProblemAccount] = field(default_factory=list)
     inquiries: List[Inquiry] = field(default_factory=list)
-    high_utilization: List[Account] = field(default_factory=list)
+    high_utilization: List[ProblemAccount] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls: Type["BureauPayload"], data: Dict[str, Any]) -> "BureauPayload":
         return cls(
             disputes=[
-                Account.from_dict(d) if isinstance(d, dict) else d
+                BureauAccount.from_dict(d) if isinstance(d, dict) else d
                 for d in data.get("disputes", [])
             ],
             goodwill=[
-                Account.from_dict(d) if isinstance(d, dict) else d
+                BureauAccount.from_dict(d) if isinstance(d, dict) else d
                 for d in data.get("goodwill", [])
             ],
             inquiries=[
@@ -34,7 +35,7 @@ class BureauPayload:
                 for i in data.get("inquiries", [])
             ],
             high_utilization=[
-                Account.from_dict(d) if isinstance(d, dict) else d
+                ProblemAccount.from_dict(d) if isinstance(d, dict) else d
                 for d in data.get("high_utilization", [])
             ],
         )
@@ -49,7 +50,7 @@ class BureauPayload:
 
 
 @dataclass
-class BureauAccount(Account):
+class BureauAccount(ProblemAccount):
     """Account entry associated with a specific credit bureau."""
 
     bureau: Optional[str] = None
@@ -58,7 +59,7 @@ class BureauAccount(Account):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "BureauAccount":
         data = {k: v for k, v in data.items() if k not in {"bureaus"}}
-        base = Account.from_dict(
+        base = ProblemAccount.from_dict(
             {k: v for k, v in data.items() if k not in {"bureau", "section"}}
         )
         return cls(

--- a/backend/core/models/problem_account.py
+++ b/backend/core/models/problem_account.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Type
+
+
+@dataclass
+class ProblemAccount:
+    """Simplified account model used in Stage A responses."""
+
+    name: str
+    account_number_last4: Optional[str] = None
+    account_fingerprint: Optional[str] = None
+    primary_issue: str = "unknown"
+    issue_types: List[str] = field(default_factory=list)
+    late_payments: Dict[str, Any] = field(default_factory=dict)
+    payment_statuses: Dict[str, Any] = field(default_factory=dict)
+    bureau_statuses: Dict[str, Any] = field(default_factory=dict)
+    original_creditor: Optional[str] = None
+    source_stage: str = ""
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(
+        cls: Type["ProblemAccount"], data: Dict[str, Any]
+    ) -> "ProblemAccount":
+        known = {
+            "name",
+            "account_number_last4",
+            "account_fingerprint",
+            "primary_issue",
+            "issue_types",
+            "late_payments",
+            "payment_statuses",
+            "bureau_statuses",
+            "original_creditor",
+            "source_stage",
+        }
+        return cls(
+            name=data.get("name", ""),
+            account_number_last4=data.get("account_number_last4"),
+            account_fingerprint=data.get("account_fingerprint"),
+            primary_issue=data.get("primary_issue", "unknown"),
+            issue_types=list(data.get("issue_types", []) or []),
+            late_payments=dict(data.get("late_payments", {}) or {}),
+            payment_statuses=dict(data.get("payment_statuses", {}) or {}),
+            bureau_statuses=dict(data.get("bureau_statuses", {}) or {}),
+            original_creditor=data.get("original_creditor"),
+            source_stage=data.get("source_stage", ""),
+            extras={k: v for k, v in data.items() if k not in known},
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        extras = data.pop("extras", {})
+        data.update(extras)
+        return data

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -57,11 +57,11 @@ from backend.core.logic.utils.report_sections import (
     filter_sections_by_bureau,
 )
 from backend.core.models import (
-    Account,
     BureauAccount,
     BureauPayload,
     ClientInfo,
     Inquiry,
+    ProblemAccount,
     ProofDocuments,
 )
 from backend.core.services.ai_client import AIClient, _StubAIClient, get_ai_client
@@ -1267,9 +1267,7 @@ def extract_problematic_accounts_from_report(
             sections["open_accounts_with_issues"] = list(all_acc)
         neg = sections.get("negative_accounts", [])
         open_acc = sections.get("open_accounts_with_issues", [])
-        return {
-            "problem_accounts": neg + [acc for acc in open_acc if acc not in neg]
-        }
+        return {"problem_accounts": neg + [acc for acc in open_acc if acc not in neg]}
     payload = BureauPayload(
         disputes=[
             BureauAccount.from_dict(d) for d in sections.get("negative_accounts", [])
@@ -1285,7 +1283,8 @@ def extract_problematic_accounts_from_report(
             )
         ],
         high_utilization=[
-            Account.from_dict(d) for d in sections.get("high_utilization_accounts", [])
+            ProblemAccount.from_dict(d)
+            for d in sections.get("high_utilization_accounts", [])
         ],
     )
     logger.info(

--- a/docs/DATA_MODELS.md
+++ b/docs/DATA_MODELS.md
@@ -22,10 +22,25 @@ This document summarizes dataclasses under `models/` and their relationships.
 - `flags: List[str]`
 - `extras: Dict[str, object]`
 
+## problem_account.py
+
+### `ProblemAccount`
+- `name: str`
+- `account_number_last4: Optional[str]`
+- `account_fingerprint: Optional[str]`
+- `primary_issue: str`
+- `issue_types: List[str]`
+- `late_payments: Dict[str, Any]`
+- `payment_statuses: Dict[str, Any]`
+- `bureau_statuses: Dict[str, Any]`
+- `original_creditor: Optional[str]`
+- `source_stage: str`
+- `extras: Dict[str, Any]`
+
 ## bureau.py
 
 ### `BureauAccount`
-- extends `Account`
+- extends `ProblemAccount`
 - `bureau: Optional[str]`
 - `section: Optional[str]`
 
@@ -34,10 +49,10 @@ This document summarizes dataclasses under `models/` and their relationships.
 - `accounts: List[BureauAccount]`
 
 ### `BureauPayload`
-- `disputes: List[Account]`
-- `goodwill: List[Account]`
+- `disputes: List[ProblemAccount]`
+- `goodwill: List[ProblemAccount]`
 - `inquiries: List[Inquiry]`
-- `high_utilization: List[Account]`
+- `high_utilization: List[ProblemAccount]`
 - Returned by `extract_problematic_accounts_from_report` instead of a raw `dict`.
 
 ## client.py

--- a/docs/MODULE_GUIDE.md
+++ b/docs/MODULE_GUIDE.md
@@ -3,7 +3,7 @@
 | Module | Role | Public API | Key Dependencies |
 | ------ | ---- | ---------- | ---------------- |
 | `backend/core/orchestrators.py` | Coordinates the end-to-end credit repair pipeline. | `run_credit_repair_process`, `extract_problematic_accounts_from_report` → `BureauPayload` | `backend.core.logic.*`, `session_manager`, `analytics_tracker` |
-| `backend/core/models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
+| `backend/core/models/` | Dataclasses representing accounts, bureaus, letters, client metadata and strategy plans. | `Account`, `ProblemAccount`, `BureauAccount`, `BureauSection`, `BureauPayload`, `ClientInfo`, `ProofDocuments`, `LetterAccount`, `LetterContext`, `LetterArtifact`, `Recommendation`, `StrategyItem`, `StrategyPlan` | `dataclasses`, `typing` |
 | `backend/core/logic/` | Business logic: report parsing, strategy generation, compliance checks and PDF rendering. | `analyze_credit_report`, `StrategyGenerator`, `run_compliance_pipeline`, `pdf_ops.convert_txts_to_pdfs` | OpenAI API, PDF utilities |
 | `backend/core/services/` | Lightweight wrappers for external integrations. | `AIClient`, email utilities | `requests`, `smtplib` |
 | `backend/assets/templates/` | Jinja2 letter templates rendered into HTML/PDF. | N/A – consumed by letter generation code | `Jinja2`, `backend.core.logic.utils.pdf_ops` |

--- a/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
+++ b/tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py
@@ -19,10 +19,10 @@ def test_inject_missing_late_accounts_aggregated():
 
     assert len(accounts) == 1
     acc = accounts[0]
-    assert acc.extras["late_payments"] == history["cap_one"]
-    assert acc.extras.get("source_stage") == "parser_aggregated"
-    assert acc.extras.get("issue_types") == ["late_payment"]
-    assert acc.status == "Delinquent"
+    assert acc.late_payments == history["cap_one"]
+    assert acc.source_stage == "parser_aggregated"
+    assert acc.issue_types == ["late_payment"]
+    assert acc.extras.get("status") == "Delinquent"
     assert len(result.get("negative_accounts", [])) == 1
 
 
@@ -38,9 +38,9 @@ def test_inject_missing_late_accounts_detects_charge_off():
 
     assert len(accounts) == 1
     acc = accounts[0]
-    assert acc.extras["late_payments"] == history["cap_one"]
+    assert acc.late_payments == history["cap_one"]
     assert acc.extras.get("grid_history_raw") == grid_map["cap_one"]
-    assert acc.extras.get("source_stage") == "parser_aggregated"
-    assert acc.extras.get("issue_types") == ["charge_off", "late_payment"]
-    assert acc.extras.get("primary_issue") == "charge_off"
-    assert acc.status == "Charge Off"
+    assert acc.source_stage == "parser_aggregated"
+    assert acc.issue_types == ["charge_off", "late_payment"]
+    assert acc.primary_issue == "charge_off"
+    assert acc.extras.get("status") == "Charge Off"


### PR DESCRIPTION
## Summary
- add `ProblemAccount` dataclass for Stage A account info
- switch `BureauPayload` and orchestrator to use `ProblemAccount`
- document and test the new model

## Testing
- `pre-commit run --files backend/core/models/problem_account.py backend/core/models/__init__.py backend/core/models/bureau.py backend/core/orchestrators.py tests/test_start_process.py tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py docs/DATA_MODELS.md docs/MODULE_GUIDE.md`
- `pytest tests/report_analysis/test_inject_missing_late_accounts_per_bureau.py tests/test_start_process.py tests/test_extract_problematic_accounts.py`

------
https://chatgpt.com/codex/tasks/task_b_68ace641537c8325b3cddcdb3bdc33eb