### PR TITLE
Lower log levels for noisy report logging

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -142,7 +142,7 @@ def _split_account_buckets(accounts: list[dict]) -> tuple[list[dict], list[dict]
                 bucket = "negative"
                 negatives.append(acc)
 
-        logger.info(
+        logger.debug(
             "bucket_decision %s",
             json.dumps(
                 {"name": acc.get("name"), "bucket": bucket, "evidence": evidence}

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -11,7 +11,6 @@ import logging
 import os
 import random
 import time
-import warnings
 from datetime import datetime
 from pathlib import Path
 from shutil import copyfile
@@ -1287,7 +1286,7 @@ def extract_problematic_accounts_from_report(
             for d in sections.get("high_utilization_accounts", [])
         ],
     )
-    logger.info(
+    logger.debug(
         "constructed_bureau_payload disputes=%d goodwill=%d inquiries=%d high_utilization=%d",
         len(payload.disputes),
         len(payload.goodwill),
@@ -1302,11 +1301,8 @@ def extract_problematic_accounts_from_report_dict(
     file_path: str, session_id: str | None = None
 ) -> Mapping[str, Any]:
     """Deprecated adapter returning ``dict`` for old clients."""
-    warnings.warn(
-        "extract_problematic_accounts_from_report_dict is deprecated;"
-        " use extract_problematic_accounts_from_report instead",
-        DeprecationWarning,
-        stacklevel=2,
+    logger.debug(
+        "extract_problematic_accounts_from_report_dict is deprecated; use extract_problematic_accounts_from_report instead"
     )
     payload = extract_problematic_accounts_from_report(file_path, session_id)
     if isinstance(payload, Mapping):

--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -58,8 +58,7 @@ def test_extract_problematic_accounts_dict_adapter(monkeypatch):
         "high_utilization_accounts": [{"name": "Acc3"}],
     }
     _mock_dependencies(monkeypatch, sections)
-    with pytest.deprecated_call():
-        result = extract_problematic_accounts_from_report_dict("dummy.pdf")
+    result = extract_problematic_accounts_from_report_dict("dummy.pdf")
     assert isinstance(result, dict)
     assert result["negative_accounts"][0]["name"] == "Acc1"
 
@@ -283,8 +282,7 @@ def test_detection_mode_dict_adapter(monkeypatch):
         "backend.core.logic.report_analysis.report_postprocessing.enrich_account_metadata",
         lambda acc: acc,
     )
-    with pytest.deprecated_call():
-        result = extract_problematic_accounts_from_report_dict("dummy.pdf")
+    result = extract_problematic_accounts_from_report_dict("dummy.pdf")
     assert {a["name"] for a in result["problem_accounts"]} == {"Bad", "NoIssue"}
 
 


### PR DESCRIPTION
## Summary
- tone down bucket allocation logging to debug
- quiet bureau payload construction and deprecation warnings
- adjust tests for removed deprecation warnings

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_dict_adapter tests/test_extract_problematic_accounts.py::test_detection_mode_dict_adapter -q`
- `pytest -q` *(fails: test_warning_on_missing_summary, test_unrecognized_dispute_type_fallback)*

------
https://chatgpt.com/codex/tasks/task_b_68ace8502dfc8325ba04904220aa3a56