### PR TITLE
Stage A parser-only problem detection

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -142,12 +142,16 @@ def _split_account_buckets(accounts: list[dict]) -> tuple[list[dict], list[dict]
                 bucket = "negative"
                 negatives.append(acc)
 
-        logger.debug(
-            "bucket_decision %s",
-            json.dumps(
-                {"name": acc.get("name"), "bucket": bucket, "evidence": evidence}
-            ),
-        )
+        if not (
+            os.getenv("PROBLEM_DETECTION_ONLY") == "1"
+            or os.getenv("DEFER_ASSIGN_ISSUE_TYPES") == "1"
+        ):
+            logger.debug(
+                "bucket_decision %s",
+                json.dumps(
+                    {"name": acc.get("name"), "bucket": bucket, "evidence": evidence}
+                ),
+            )
 
     return negatives, open_issues
 
@@ -762,6 +766,8 @@ def analyze_credit_report(
             for acc in result.get("all_accounts", []):
                 acc["primary_issue"] = "unknown"
                 acc["issue_types"] = []
+                if acc.get("status") in (None, "", "Delinquent"):
+                    acc["status"] = "Unknown"
             result["negative_accounts"] = []
             result["open_accounts_with_issues"] = []
             result["positive_accounts"] = []

--- a/backend/core/logic/report_analysis/problem_detection.py
+++ b/backend/core/logic/report_analysis/problem_detection.py
@@ -1,0 +1,113 @@
+import logging
+from typing import Any, Dict, List, Mapping, Tuple
+
+from backend.core.logic.utils.names_normalization import normalize_creditor_name
+
+logger = logging.getLogger(__name__)
+
+COLLECTOR_WHITELIST = {
+    "palisades fu",
+    "midland",
+    "midland credit management",
+    "portfolio recovery",
+    "lvnv funding",
+    "enhanced recovery",
+    "cmre financial",
+    "allied interstate",
+    "portfolio rcvy",
+    "asset acceptance",
+    "transworld systems",
+    "iqor",
+    "ccs",
+    "americollect",
+    "cavalry",
+    "firstsource",
+    "national credit systems",
+}
+
+KEYWORDS = [
+    "collection",
+    "placed for collection",
+    "charge off",
+    "charged off",
+    "derogatory",
+    "repossession",
+    "foreclosure",
+    "collection agency",
+    "collections",
+    "bankruptcy",
+    "judgment",
+    "lien",
+]
+
+
+def _sum_late_payments(late_payments: Any) -> int:
+    total = 0
+    if isinstance(late_payments, Mapping):
+        for bureau_vals in late_payments.values():
+            if isinstance(bureau_vals, Mapping):
+                for v in bureau_vals.values():
+                    try:
+                        total += int(v) or 0
+                    except Exception:
+                        continue
+            else:
+                try:
+                    total += int(bureau_vals) or 0
+                except Exception:
+                    continue
+    return total
+
+
+def is_problematic(
+    acc: Mapping[str, Any]
+) -> Tuple[bool, List[str], str, Dict[str, Any]]:
+    """Determine if an account is problematic based on simple evidence heuristics.
+
+    Returns a tuple ``(is_problem, reasons, inferred_issue, context)``.
+    ``context`` includes diagnostic info such as ``late_sum`` and ``keywords_hit``.
+    """
+
+    reasons: List[str] = []
+    late_sum = _sum_late_payments(acc.get("late_payments"))
+    if late_sum > 0:
+        reasons.append(f"late_payment_sum:{late_sum}")
+
+    text_slots = " ".join(
+        str(acc.get(field, "") or "")
+        for field in ["remarks", "status", "bureau_statuses", "account_status"]
+    ).lower()
+    keywords_hit = [kw for kw in KEYWORDS if kw in text_slots]
+    if keywords_hit:
+        reasons.extend([f"keyword:{kw}" for kw in keywords_hit])
+
+    norm_name = acc.get("normalized_name") or normalize_creditor_name(
+        acc.get("name", "")
+    )
+    is_collector = norm_name in COLLECTOR_WHITELIST
+    if is_collector:
+        reasons.append("name_matches_collector")
+
+    inferred_issue = "unknown"
+    if is_collector or any(
+        kw
+        in {
+            "collection",
+            "placed for collection",
+            "charge off",
+            "charged off",
+            "collection agency",
+            "collections",
+        }
+        for kw in keywords_hit
+    ):
+        inferred_issue = "collection"
+    elif late_sum > 0:
+        inferred_issue = "late_payment"
+
+    context = {
+        "late_sum": late_sum,
+        "keywords_hit": keywords_hit,
+        "is_collector": is_collector,
+    }
+    return bool(reasons), reasons, inferred_issue, context

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -44,7 +44,7 @@ export default function ReviewPage() {
   if (accounts[0]) {
     console.debug('review-card-props', {
       primary_issue: accounts[0].primary_issue,
-      issue_types: accounts[0].issue_types,
+      problem_reasons: accounts[0].problem_reasons,
       last4: accounts[0].account_number_last4,
       original_creditor: accounts[0].original_creditor,
     });
@@ -106,12 +106,11 @@ export default function ReviewPage() {
     <div className="container">
       <h2>Explain Your Situation</h2>
       {dedupedAccounts.map((acc, idx) => {
-        const issues = acc.issue_types ?? [];
+        const reasons = acc.problem_reasons ?? [];
         const primary = acc.primary_issue;
         const idLast4 = acc.account_number_last4 ?? null;
         const fingerprint = acc.account_fingerprint ?? null;
         const displayId = idLast4 ? `••••${idLast4}` : fingerprint ?? '';
-        const secondaryIssues = issues.filter((t) => t !== primary);
         return (
           <div key={idx} className="account-block">
             <p>
@@ -121,10 +120,8 @@ export default function ReviewPage() {
             </p>
             <div className="issue-badges">
               <span className="badge">{primary ? formatIssueType(primary) : 'Unknown'}</span>
-              {secondaryIssues.map((type, i) => (
-                <span key={i} className="chip">
-                  {formatIssueType(type)}
-                </span>
+              {reasons.map((reason, i) => (
+                <span key={i} className="chip">{reason}</span>
               ))}
             </div>
             <textarea

--- a/frontend/src/pages/ReviewPage.test.jsx
+++ b/frontend/src/pages/ReviewPage.test.jsx
@@ -24,7 +24,7 @@ const account = {
   account_number_last4: '1234',
   original_creditor: 'Creditor 1',
   primary_issue: 'late_payment',
-  issue_types: ['late_payment']
+  problem_reasons: ['late_payment_eqf_30']
 };
 
 describe('ReviewPage', () => {
@@ -53,12 +53,12 @@ describe('ReviewPage', () => {
   });
 });
 
-test('renders accounts with empty issue_types and no primary_issue', async () => {
+test('renders accounts with empty reasons and no primary_issue', async () => {
   const uploadData = {
     ...baseUploadData,
     accounts: {
       problem_accounts: [
-        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678', issue_types: [] }
+        { account_id: 'acc2', name: 'Account 2', account_number_last4: '5678', problem_reasons: [] }
       ]
     }
   };
@@ -79,7 +79,7 @@ test('renders primary badge from primary_issue and secondary chips with identifi
     account_number_last4: '7890',
     original_creditor: 'Bank A',
     primary_issue: 'charge_off',
-    issue_types: ['collection', 'charge_off', 'late_payment'],
+    problem_reasons: ['keyword:collection', 'late_payment_eqf_30'],
   };
   const uploadData = {
     ...baseUploadData,
@@ -93,8 +93,8 @@ test('renders primary badge from primary_issue and secondary chips with identifi
   const header = await screen.findByText('Account 3');
   expect(header.parentElement).toHaveTextContent('Account 3 ••••7890 - Bank A');
   expect(screen.getByText('Charge-Off')).toHaveClass('badge');
-  expect(screen.getByText('Collection')).toHaveClass('chip');
-  expect(screen.getByText('Late Payment')).toHaveClass('chip');
+  expect(screen.getByText('keyword:collection')).toHaveClass('chip');
+  expect(screen.getByText('late_payment_eqf_30')).toHaveClass('chip');
 });
 
 test('renders account_fingerprint when last4 missing', async () => {
@@ -104,15 +104,15 @@ test('renders account_fingerprint when last4 missing', async () => {
     normalized_name: 'account 4',
     account_fingerprint: 'deadbeef',
     original_creditor: 'Creditor 4',
-    primary_issue: 'late_payment',
-    issue_types: ['late_payment'],
+  primary_issue: 'late_payment',
+  problem_reasons: ['late_payment_eqf_30'],
   };
   const uploadData = {
     ...baseUploadData,
     accounts: { problem_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
@@ -129,14 +129,14 @@ test('prefers last4 over fingerprint when both provided', async () => {
     account_fingerprint: 'cafebabe',
     original_creditor: 'Creditor 5',
     primary_issue: 'late_payment',
-    issue_types: ['late_payment'],
+    problem_reasons: ['late_payment_eqf_30'],
   };
   const uploadData = {
     ...baseUploadData,
     accounts: { problem_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
@@ -153,7 +153,7 @@ test('dedup uses last4 before fingerprint', async () => {
     account_number_last4: '9999',
     account_fingerprint: 'aaaa',
     primary_issue: 'late_payment',
-    issue_types: ['late_payment'],
+    problem_reasons: ['late_payment_eqf_30'],
   };
   const acc2 = {
     ...acc1,
@@ -165,7 +165,7 @@ test('dedup uses last4 before fingerprint', async () => {
     accounts: { problem_accounts: [acc1, acc2] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
@@ -180,21 +180,21 @@ test('handles missing payment maps and late payments with identifier fallback', 
     name: 'Account 8',
     normalized_name: 'account 8',
     account_number_last4: '1234',
-    issue_types: ['late_payment'],
+    problem_reasons: ['late_payment_eqf_30'],
   };
   const acc2 = {
     account_id: 'acc9',
     name: 'Account 9',
     normalized_name: 'account 9',
     account_fingerprint: 'ff99',
-    issue_types: ['late_payment'],
+    problem_reasons: ['late_payment_eqf_30'],
   };
   const uploadData = {
     ...baseUploadData,
     accounts: { problem_accounts: [acc1, acc2] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );
@@ -217,7 +217,7 @@ test('renders evidence drawer when debug flag enabled', async () => {
     accounts: { problem_accounts: [acc] },
   };
   render(
-    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}>
       <ReviewPage />
     </MemoryRouter>
   );


### PR DESCRIPTION
## Summary
- add `is_problematic` helper and collector whitelist for parser-only evidence checks
- filter `all_accounts` using evidence and log `problem_selection`/`problem_reject`
- surface `problem_reasons` in ReviewPage and show only Stage A problem accounts

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/problem_detection.py backend/core/orchestrators.py backend/core/logic/report_analysis/analyze_report.py frontend/src/pages/ReviewPage.jsx frontend/src/pages/ReviewPage.test.jsx tests/test_extract_problematic_accounts.py`
- `pytest tests/test_extract_problematic_accounts.py`
- `npm test --prefix frontend -- src/pages/ReviewPage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_b_68adc2d36cac8325bd8f25bcbf4a5f09