### PR TITLE
Decouple Stage A keyword handling and add candidate token logging

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,27 +1,46 @@
+import json
 import os
+from pathlib import Path
+from typing import Any, Tuple
 
-UTILIZATION_PROBLEM_THRESHOLD = float(os.getenv("UTILIZATION_PROBLEM_THRESHOLD", "0.90"))
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.lower() in {"1", "true", "yes", "on"}
+
+
+def _load_keyword_lists() -> Tuple[dict, dict, dict]:
+    """Load tiered keyword dictionaries from JSON/YAML config.
+
+    Returns empty dictionaries when the config file is missing or malformed.
+    """
+
+    path = os.getenv("KEYWORDS_CONFIG_PATH", Path(__file__).with_name("keywords.json"))
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data: Any = json.load(f)
+    except Exception:
+        data = {}
+    t1 = data.get("tier1") or data.get("TIER1_KEYWORDS") or {}
+    t2 = data.get("tier2") or data.get("TIER2_KEYWORDS") or {}
+    t3 = data.get("tier3") or data.get("TIER3_KEYWORDS") or {}
+    return t1, t2, t3
+
+
+UTILIZATION_PROBLEM_THRESHOLD = float(
+    os.getenv("UTILIZATION_PROBLEM_THRESHOLD", "0.90")
+)
 SERIOUS_DELINQUENCY_MIN_DPD = int(os.getenv("SERIOUS_DELINQUENCY_MIN_DPD", "60"))
 
-TIER1_KEYWORDS = {
-    "bankruptcy": ["bankruptcy"],
-    "foreclosure": ["foreclosure"],
-    "judgment": ["judgment"],
-    "tax_lien": ["tax lien", "tax-lien"],
-    "charge_off": ["charge off", "charge-off", "charged off", "chargeoff"],
-    "collection": ["collection", "placed for collection", "collections"],
-}
+ENABLE_TIER1_KEYWORDS = _env_bool("ENABLE_TIER1_KEYWORDS", False)
+ENABLE_TIER2_KEYWORDS = _env_bool("ENABLE_TIER2_KEYWORDS", False)
+ENABLE_TIER3_KEYWORDS = _env_bool("ENABLE_TIER3_KEYWORDS", False)
+ENABLE_TIER2_NUMERIC = _env_bool("ENABLE_TIER2_NUMERIC", True)
 
-TIER2_KEYWORDS = {
-    "serious_delinquency": [
-        "60 days past due",
-        "90 days past due",
-        "120 days past due",
-        "120+ days",
-        "derogatory",
-    ]
-}
+_raw_t1, _raw_t2, _raw_t3 = _load_keyword_lists()
 
-TIER3_KEYWORDS = {
-    "potential_derogatory": ["derogatory", "collection", "charge-off"]
-}
+TIER1_KEYWORDS = _raw_t1 if ENABLE_TIER1_KEYWORDS else {}
+TIER2_KEYWORDS = _raw_t2 if ENABLE_TIER2_KEYWORDS else {}
+TIER3_KEYWORDS = _raw_t3 if ENABLE_TIER3_KEYWORDS else {}

--- a/backend/core/logic/report_analysis/candidate_logger.py
+++ b/backend/core/logic/report_analysis/candidate_logger.py
@@ -1,0 +1,45 @@
+"""Collect raw SmartCredit field values for dictionary building.
+
+The logger stores unique field values across accounts and writes them to a
+JSON file. This allows offline analysis to build comprehensive keyword
+dictionaries without impacting Stage A logic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Set
+
+
+class CandidateTokenLogger:
+    """Accumulates raw field values and persists them to disk."""
+
+    def __init__(self) -> None:
+        self._tokens: Dict[str, Set[str]] = {
+            "account_status": set(),
+            "payment_status": set(),
+            "account_description": set(),
+            "creditor_remarks": set(),
+        }
+
+    def collect(self, account: Dict[str, object]) -> None:
+        for field in list(self._tokens.keys()):
+            val = account.get(field)
+            if isinstance(val, dict):
+                for v in val.values():
+                    if v:
+                        self._tokens[field].add(str(v))
+            elif val:
+                self._tokens[field].add(str(val))
+
+    def save(self, folder: Path) -> None:
+        """Write collected tokens to ``folder/candidate_tokens.json``."""
+
+        data = {k: sorted(v) for k, v in self._tokens.items() if v}
+        if not data:
+            return
+        folder.mkdir(parents=True, exist_ok=True)
+        path = folder / "candidate_tokens.json"
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)

--- a/backend/keywords.json
+++ b/backend/keywords.json
@@ -1,0 +1,22 @@
+{
+  "tier1": {
+    "bankruptcy": ["bankruptcy"],
+    "foreclosure": ["foreclosure"],
+    "judgment": ["judgment"],
+    "tax_lien": ["tax lien", "tax-lien"],
+    "charge_off": ["charge off", "charge-off", "charged off", "chargeoff"],
+    "collection": ["collection", "placed for collection", "collections"]
+  },
+  "tier2": {
+    "serious_delinquency": [
+      "60 days past due",
+      "90 days past due",
+      "120 days past due",
+      "120+ days",
+      "derogatory"
+    ]
+  },
+  "tier3": {
+    "potential_derogatory": ["derogatory", "collection", "charge-off"]
+  }
+}

--- a/tests/test_candidate_logger.py
+++ b/tests/test_candidate_logger.py
@@ -1,0 +1,20 @@
+import json
+
+from backend.core.logic.report_analysis.candidate_logger import CandidateTokenLogger
+
+
+def test_candidate_tokens_written(tmp_path):
+    logger = CandidateTokenLogger()
+    acc = {
+        "account_status": "Open",
+        "payment_status": "Current",
+        "account_description": "Credit Card",
+        "creditor_remarks": "Test remark",
+    }
+    logger.collect(acc)
+    logger.save(tmp_path)
+    path = tmp_path / "candidate_tokens.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["account_status"] == ["Open"]
+    assert data["creditor_remarks"] == ["Test remark"]


### PR DESCRIPTION
## Summary
- Load tiered keyword lists from optional external JSON with feature flags to enable tiers
- Add fallback problem detection for numeric late payments and explicit collection/charge-off statuses
- Collect raw SmartCredit field values and write candidate_tokens.json per session

## Testing
- `pre-commit run --files backend/config.py backend/core/logic/report_analysis/problem_detection.py backend/core/logic/report_analysis/analyze_report.py backend/core/logic/report_analysis/candidate_logger.py backend/keywords.json tests/test_problem_detection.py tests/test_candidate_logger.py`
- `pytest tests/test_problem_detection.py tests/test_candidate_logger.py tests/report_analysis/test_bucket_split.py`

------
https://chatgpt.com/codex/tasks/task_b_68adf072cea48325959defa2007cc0ac