### PR TITLE
Add Stage A telemetry and decision visibility

### DIFF
--- a/backend/core/logic/report_analysis/candidate_logger.py
+++ b/backend/core/logic/report_analysis/candidate_logger.py
@@ -12,7 +12,6 @@ import re
 from pathlib import Path
 from typing import Dict, Set
 
-
 _FIELDS = [
     "balance_owed",
     "account_rating",
@@ -74,3 +73,26 @@ class CandidateTokenLogger:
         path = folder / "candidate_tokens.json"
         with path.open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Stage A trace logging
+# ---------------------------------------------------------------------------
+
+
+class StageATraceLogger:
+    """Append per-account Stage A decisions to a JSONL trace file."""
+
+    def __init__(self, session_id: str, base_folder: Path | None = None) -> None:
+        base = base_folder or Path("uploads")
+        self.path = base / session_id / "stageA_trace.jsonl"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, row: Dict[str, object]) -> None:
+        from datetime import datetime
+
+        data = dict(row)
+        data["ts"] = datetime.utcnow().isoformat() + "Z"
+        with self.path.open("a", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+            f.write("\n")

--- a/backend/core/logic/report_analysis/problem_detection.py
+++ b/backend/core/logic/report_analysis/problem_detection.py
@@ -1,19 +1,25 @@
+"""Rule/AI hybrid problem detection for Stage A."""
+
 from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+from backend.api.internal_ai import adjudicate as ai_adjudicate
+from backend.config import AI_MIN_CONFIDENCE, ENABLE_AI_ADJUDICATOR
+
+from .redaction import redact_account_for_ai
 
 
 def evaluate_account_problem(acct: Dict[str, Any]) -> Dict[str, Any]:
-    """Detect potential problems on a credit account without classification.
+    """Evaluate an account for potential problems.
 
-    The function only surfaces accounts that show evidence of issues such as
-    late payments or past-due amounts. It does not attempt to categorize the
-    account or assign issue types. All accounts flagged here will therefore
-    carry a neutral ``primary_issue`` of ``"unknown"``.
+    The function applies lightweight rule-based checks and optionally consults
+    the AI adjudicator.  It returns a unified decision dictionary and mutates
+    ``acct`` in-place so the decision fields are available to later stages.
     """
 
     reasons: List[str] = []
-    supporting: Dict[str, Any] = {}
-
-    # Late payment history
     late = acct.get("late_payments") or {}
     for bureau, buckets in late.items():
         for days, count in (buckets or {}).items():
@@ -23,43 +29,75 @@ def evaluate_account_problem(acct: Dict[str, Any]) -> Dict[str, Any]:
             except Exception:
                 continue
             if c > 0:
-                reasons.append(f"late_payment: {c}\u00d7{d} on {bureau}")
-    if late:
-        supporting["late_payments"] = late
-
-    # Past due amount
+                reasons.append(f"late_payment: {c}x{d} on {bureau}")
     if acct.get("past_due_amount") is not None:
-        supporting["past_due_amount"] = acct["past_due_amount"]
         try:
             if float(acct["past_due_amount"]) > 0:
                 reasons.append("past_due_amount")
         except Exception:
             pass
 
+    decision: Dict[str, Any] = {
+        "primary_issue": "unknown",
+        "issue_types": [],
+        "problem_reasons": list(reasons),
+        "tier": 0,
+        "confidence": 0.0,
+        "decision_source": "rules",
+        "adjudicator_version": "rules-v1",
+        "debug": {
+            "ai_latency_ms": 0,
+            "ai_tokens_in": 0,
+            "ai_tokens_out": 0,
+            "ai_error": None,
+        },
     }
 
+    is_problem = bool(reasons)
+
     if ENABLE_AI_ADJUDICATOR:
-        redacted = redact_account_for_ai(acct)
-        ai_resp = ai_adjudicate("stageA", "v1", redacted)
-        result["debug"]["ai_response"] = {
-            "primary_issue": ai_resp.get("primary_issue"),
-            "confidence": ai_resp.get("confidence"),
-            "tier": ai_resp.get("tier"),
-            "error": ai_resp.get("error"),
-        }
-        if (
-            ai_resp.get("confidence", 0) >= AI_MIN_CONFIDENCE
-            and ai_resp.get("primary_issue") != "unknown"
-        ):
-            result.update(
+        start = time.perf_counter()
+        try:
+            redacted = redact_account_for_ai(acct)
+            ai_resp = ai_adjudicate("stageA", "v1", redacted)
+            decision["debug"].update(
                 {
-                    "primary_issue": ai_resp.get("primary_issue", "unknown"),
-                    "issue_types": ai_resp.get("issue_types", []),
-                    "problem_reasons": ai_resp.get("problem_reasons", []),
-                    "confidence": ai_resp.get("confidence", 0.0),
-                    "tier": ai_resp.get("tier", 0),
-                    "decision_source": "ai",
+                    "ai_latency_ms": int((time.perf_counter() - start) * 1000),
+                    "ai_tokens_in": ai_resp.get("tokens_in", 0),
+                    "ai_tokens_out": ai_resp.get("tokens_out", 0),
+                    "ai_error": ai_resp.get("error"),
                 }
             )
+            if ai_resp.get("error"):
+                decision["decision_source"] = "fallback_ai_error"
+            elif (
+                ai_resp.get("confidence", 0.0) >= AI_MIN_CONFIDENCE
+                and ai_resp.get("primary_issue") != "unknown"
+            ):
+                decision.update(
+                    {
+                        "primary_issue": ai_resp.get("primary_issue", "unknown"),
+                        "issue_types": ai_resp.get("issue_types", []),
+                        "problem_reasons": ai_resp.get("problem_reasons", []),
+                        "confidence": ai_resp.get("confidence", 0.0),
+                        "tier": ai_resp.get("tier", 0),
+                        "decision_source": "ai",
+                        "adjudicator_version": ai_resp.get(
+                            "adjudicator_version", "ai-v1"
+                        ),
+                    }
+                )
+                is_problem = True
+            else:
+                decision["decision_source"] = "fallback_ai_low_conf"
+        except Exception as exc:  # pragma: no cover - defensive
+            decision["decision_source"] = "fallback_ai_error"
+            decision["debug"]["ai_error"] = str(exc)
+            decision["debug"]["ai_latency_ms"] = int(
+                (time.perf_counter() - start) * 1000
+            )
 
-    return result
+    acct.update({k: v for k, v in decision.items() if k != "debug"})
+    acct["debug"] = decision["debug"]
+    acct["_detector_is_problem"] = bool(is_problem)
+    return decision

--- a/backend/core/telemetry/emit.py
+++ b/backend/core/telemetry/emit.py
@@ -1,0 +1,21 @@
+import json
+import logging
+from datetime import datetime
+from typing import Any, Mapping
+
+logger = logging.getLogger("telemetry")
+
+
+def emit(event: str, payload: Mapping[str, Any] | None = None) -> None:
+    """Emit a structured telemetry event.
+
+    Events are logged as a single JSON line with an ISO timestamp. Failures to
+    serialize are logged but otherwise ignored to avoid interrupting the caller.
+    """
+    record = {"event": event, "ts": datetime.utcnow().isoformat() + "Z"}
+    if payload:
+        record.update(dict(payload))
+    try:
+        logger.info(json.dumps(record, sort_keys=True))
+    except Exception:
+        logger.exception("telemetry_emit_failed")

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -119,6 +119,26 @@ export default function ReviewPage() {
               {displayId && ` ${displayId}`}
               {acc.original_creditor && ` - ${acc.original_creditor}`}
             </p>
+            <div className="decision-row">
+              <span
+                className="decision-badge"
+                title={
+                  acc.decision_source === 'ai'
+                    ? `AI confidence: ${Number(acc.confidence).toFixed(2)}`
+                    : undefined
+                }
+              >
+                {acc.decision_source === 'ai'
+                  ? 'AI decision'
+                  : acc.decision_source === 'rules'
+                  ? 'Rule-based decision'
+                  : acc.decision_source === 'fallback_ai_low_conf' ||
+                    acc.decision_source === 'fallback_ai_error'
+                  ? 'AI fallback (rules)'
+                  : 'Unknown'}
+              </span>
+              {acc.tier > 0 && <span className="tier-label">Tier {acc.tier}</span>}
+            </div>
             <div className="issue-badges">
               <span className="badge">{primary ? formatIssueType(primary) : 'Unknown'}</span>
               {secondaryIssues.map((type, i) => (
@@ -127,6 +147,20 @@ export default function ReviewPage() {
                 </span>
               ))}
             </div>
+            {acc.problem_reasons && acc.problem_reasons.length > 0 && (
+              <div className="reason-chips">
+                {acc.problem_reasons.slice(0, 3).map((reason, i) => (
+                  <span key={i} className="chip">
+                    {reason}
+                  </span>
+                ))}
+                {acc.problem_reasons.length > 3 && (
+                  <span className="chip" title={acc.problem_reasons.join(', ')}>
+                    …
+                  </span>
+                )}
+              </div>
+            )}
             <textarea
               value={explanations[acc.name] || ''}
               onChange={(e) => handleChange(acc.name, e.target.value)}

--- a/tests/test_orchestrator_stageA_ai.py
+++ b/tests/test_orchestrator_stageA_ai.py
@@ -1,58 +1,39 @@
-import json
-from importlib import reload
-
-import backend.core.orchestrators as orch
+from backend.core import orchestrators as orch
 
 
-def test_problem_accounts_only(monkeypatch, caplog):
-    sections = {
-        "problem_accounts": [
+def test_emit_called_for_problem_accounts(monkeypatch):
+    events = []
+
+    def fake_emit(event, payload):
+        events.append((event, payload))
+
+    monkeypatch.setattr(orch, "emit", fake_emit)
+
+    accounts = [
+        {
+            "normalized_name": "palisades fu",
+            "account_number_last4": "1234",
+            "decision_source": "ai",
+            "primary_issue": "collection",
+            "confidence": 0.83,
+            "tier": 1,
+            "problem_reasons": ["remarks"],
+        }
+    ]
+
+    orch._emit_stageA_events("sess1", accounts)
+    assert events == [
+        (
+            "stageA_problem_decision",
             {
-                "normalized_name": "acc1",
-                "primary_issue": "collection",
-                "issue_types": ["collection"],
-                "problem_reasons": ["status"],
-                "confidence": 0.9,
-                "tier": 1,
+                "session_id": "sess1",
+                "normalized_name": "palisades fu",
+                "account_id": "1234",
                 "decision_source": "ai",
+                "primary_issue": "collection",
+                "confidence": 0.83,
+                "tier": 1,
+                "reasons_count": 1,
             },
-            {
-                "normalized_name": "acc2",
-                "primary_issue": "unknown",
-                "issue_types": [],
-                "problem_reasons": ["utilization"],
-                "confidence": 0.0,
-                "tier": 0,
-                "decision_source": "rules",
-            },
-        ],
-        "all_accounts": [
-            {"normalized_name": "acc1"},
-            {"normalized_name": "acc2"},
-            {"normalized_name": "acc3"},
-        ],
-    }
-    monkeypatch.setattr(
-        "backend.core.logic.compliance.upload_validator.move_uploaded_file",
-        lambda path, session_id: path,
-    )
-    monkeypatch.setattr(
-        "backend.core.logic.compliance.upload_validator.is_safe_pdf", lambda path: True
-    )
-    monkeypatch.setattr(
-        "backend.core.orchestrators.update_session", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "backend.core.logic.report_analysis.analyze_report.analyze_credit_report",
-        lambda *a, **k: sections,
-    )
-    monkeypatch.setenv("PROBLEM_DETECTION_ONLY", "1")
-    reload(orch)
-    caplog.set_level("INFO")
-    result = orch.extract_problematic_accounts_from_report("dummy.pdf")
-    assert result["problem_accounts"] == sections["problem_accounts"]
-    logs = [r.message for r in caplog.records if "stageA_problem_decision" in r.message]
-    assert len(logs) == 2
-    for entry in logs:
-        data = json.loads(entry.split(" ", 1)[1])
-        assert "decision_source" in data
+        )
+    ]

--- a/tests/test_stageA_trace.py
+++ b/tests/test_stageA_trace.py
@@ -1,0 +1,47 @@
+import json
+
+from backend.core.logic.report_analysis.candidate_logger import StageATraceLogger
+
+
+def test_stageA_trace_lines(tmp_path):
+    logger = StageATraceLogger("sess1", base_folder=tmp_path)
+    logger.append(
+        {
+            "normalized_name": "foo",
+            "account_id": "1234",
+            "decision_source": "ai",
+            "primary_issue": "collection",
+            "confidence": 0.9,
+            "tier": 1,
+            "reasons": ["r1"],
+            "ai_latency_ms": 10,
+            "ai_tokens_in": 5,
+            "ai_tokens_out": 2,
+            "ai_error": None,
+        }
+    )
+    logger.append(
+        {
+            "normalized_name": "bar",
+            "account_id": "abcd",
+            "decision_source": "rules",
+            "primary_issue": "unknown",
+            "confidence": 0.0,
+            "tier": 0,
+            "reasons": [],
+            "ai_latency_ms": 0,
+            "ai_tokens_in": 0,
+            "ai_tokens_out": 0,
+            "ai_error": None,
+        }
+    )
+    path = tmp_path / "sess1" / "stageA_trace.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(rows) == 2
+    for row in rows:
+        assert "ts" in row
+        assert "decision_source" in row
+        assert "ai_latency_ms" in row
+        assert "ai_tokens_in" in row
+        assert "ai_tokens_out" in row
+        assert "ai_error" in row


### PR DESCRIPTION
## Summary
- implement unified Stage A problem decision contract with AI fallback handling
- log per-account Stage A decisions and emit telemetry events
- surface decision source, tier, confidence, and reasons in review UI

## Testing
- `pre-commit run --files backend/core/telemetry/emit.py backend/core/logic/report_analysis/problem_detection.py backend/core/logic/report_analysis/candidate_logger.py backend/core/logic/report_analysis/analyze_report.py backend/core/orchestrators.py frontend/src/pages/ReviewPage.jsx frontend/src/pages/ReviewPage.test.jsx tests/test_problem_detection_ai.py tests/test_orchestrator_stageA_ai.py tests/test_stageA_trace.py`
- `pytest tests/test_problem_detection_ai.py tests/test_orchestrator_stageA_ai.py tests/test_stageA_trace.py`
- `(cd frontend && npm test)`

------
https://chatgpt.com/codex/tasks/task_b_68ae03d493988325a6d392ae49c532e4