### PR TITLE
Add case store models and configuration

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -4,11 +4,21 @@ from pathlib import Path
 from typing import Any, Tuple
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
+def env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable."""
     val = os.getenv(name)
     if val is None:
         return default
     return val.lower() in {"1", "true", "yes", "on"}
+
+
+def env_str(name: str, default: str) -> str:
+    """Fetch a string environment variable."""
+    return os.getenv(name, default)
+
+
+# Backwards compatibility for older imports
+_env_bool = env_bool
 
 
 def _load_keyword_lists() -> Tuple[dict, dict, dict]:
@@ -49,3 +59,12 @@ _raw_t1, _raw_t2, _raw_t3 = _load_keyword_lists()
 TIER1_KEYWORDS = _raw_t1 if ENABLE_TIER1_KEYWORDS else {}
 TIER2_KEYWORDS = _raw_t2 if ENABLE_TIER2_KEYWORDS else {}
 TIER3_KEYWORDS = _raw_t3 if ENABLE_TIER3_KEYWORDS else {}
+
+
+# Case Store configuration
+CASESTORE_DIR = env_str("CASESTORE_DIR", "/var/app/run/cases")
+CASESTORE_REDACT_BEFORE_STORE = env_bool(
+    "CASESTORE_REDACT_BEFORE_STORE", True
+)
+CASESTORE_ATOMIC_WRITES = env_bool("CASESTORE_ATOMIC_WRITES", True)
+CASESTORE_VALIDATE_ON_LOAD = env_bool("CASESTORE_VALIDATE_ON_LOAD", True)

--- a/backend/core/case_store/__init__.py
+++ b/backend/core/case_store/__init__.py
@@ -1,0 +1,43 @@
+"""Case Store models and helpers."""
+
+from .errors import CaseStoreError, IO_ERROR, NOT_FOUND, VALIDATION_FAILED
+from .models import (
+    AccountCase,
+    AccountFields,
+    Artifact,
+    Bureau,
+    PersonalInformation,
+    ReportMeta,
+    SessionCase,
+    Summary,
+)
+from pydantic import ValidationError
+
+__all__ = [
+    "AccountCase",
+    "AccountFields",
+    "Artifact",
+    "Bureau",
+    "PersonalInformation",
+    "ReportMeta",
+    "SessionCase",
+    "Summary",
+    "CaseStoreError",
+    "NOT_FOUND",
+    "VALIDATION_FAILED",
+    "IO_ERROR",
+    "load_session_case_json",
+]
+
+
+def load_session_case_json(data: str) -> SessionCase:
+    """Parse a SessionCase from a JSON string.
+
+    Raises:
+        CaseStoreError: if validation fails.
+    """
+
+    try:
+        return SessionCase.model_validate_json(data)
+    except ValidationError as exc:  # pragma: no cover - exercised in tests
+        raise CaseStoreError(code=VALIDATION_FAILED, message=str(exc)) from exc

--- a/backend/core/case_store/errors.py
+++ b/backend/core/case_store/errors.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CaseStoreError(Exception):
+    code: str
+    message: str
+
+
+# Known error codes
+NOT_FOUND = "NOT_FOUND"
+VALIDATION_FAILED = "VALIDATION_FAILED"
+IO_ERROR = "IO_ERROR"
+
+
+__all__ = ["CaseStoreError", "NOT_FOUND", "VALIDATION_FAILED", "IO_ERROR"]

--- a/backend/core/case_store/models.py
+++ b/backend/core/case_store/models.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, confloat, conint
+
+
+class Bureau(str, Enum):
+    Equifax = "Equifax"
+    Experian = "Experian"
+    TransUnion = "TransUnion"
+
+
+class Artifact(BaseModel):
+    primary_issue: Optional[str] = None
+    issue_types: Optional[List[str]] = None
+    problem_reasons: Optional[List[str]] = None
+    confidence: Optional[confloat(ge=0.0, le=1.0)] = None
+    tier: Optional[str] = None
+    decision_source: Optional[str] = None
+    debug: Optional[Dict[str, Any]] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class AccountFields(BaseModel):
+    account_number: Optional[str] = None
+    high_balance: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    last_verified: Optional[date | str] = None
+    date_of_last_activity: Optional[date | str] = None
+    date_reported: Optional[date | str] = None
+    date_opened: Optional[date | str] = None
+    balance_owed: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    closed_date: Optional[date | str] = None
+    account_rating: Optional[str] = None
+    account_description: Optional[str] = None
+    dispute_status: Optional[str] = None
+    creditor_type: Optional[str] = None
+    account_status: Optional[str] = None
+    payment_status: Optional[str] = None
+    creditor_remarks: Optional[str] = None
+    payment_amount: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    last_payment: Optional[date | str] = None
+    term_length: Optional[str | int] = None
+    past_due_amount: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    account_type: Optional[str] = None
+    payment_frequency: Optional[str] = None
+    credit_limit: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    two_year_payment_history: Optional[str | List[str]] = None
+    days_late_7y: Optional[str | List[str]] = None
+
+
+class AccountCase(BaseModel):
+    bureau: Bureau
+    fields: AccountFields = Field(default_factory=AccountFields)
+    artifacts: Dict[str, Artifact | None] = Field(default_factory=dict)
+    tags: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PersonalInformation(BaseModel):
+    name: Optional[str] = None
+    also_known_as: Optional[str | List[str]] = None
+    dob: Optional[date | str] = None
+    current_address: Optional[str] = None
+    previous_address: Optional[str] = None
+    employer: Optional[str] = None
+
+
+class ReportMeta(BaseModel):
+    credit_report_date: Optional[date | str] = None
+    personal_information: Optional[PersonalInformation] = Field(
+        default_factory=PersonalInformation
+    )
+    public_information: List[Dict[str, Any]] = Field(default_factory=list)
+    inquiries: List[Dict[str, Any]] = Field(default_factory=list)
+    raw_source: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Summary(BaseModel):
+    total_accounts: conint(ge=0) = 0
+    open_accounts: conint(ge=0) = 0
+    closed_accounts: conint(ge=0) = 0
+    delinquent: conint(ge=0) = 0
+    derogatory: conint(ge=0) = 0
+    balances: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    payments: Optional[confloat(gt=-1e18, lt=1e18)] = None
+    public_records: conint(ge=0) = 0
+    inquiries_2y: conint(ge=0) = 0
+
+
+class SessionCase(BaseModel):
+    session_id: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    report_meta: ReportMeta = Field(default_factory=ReportMeta)
+    summary: Summary = Field(default_factory=Summary)
+    accounts: Dict[str, AccountCase]
+
+
+__all__ = [
+    "Bureau",
+    "Artifact",
+    "AccountFields",
+    "AccountCase",
+    "PersonalInformation",
+    "ReportMeta",
+    "Summary",
+    "SessionCase",
+]

--- a/tests/test_case_store_validation.py
+++ b/tests/test_case_store_validation.py
@@ -1,0 +1,122 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from backend.core.case_store import (
+    CaseStoreError,
+    ReportMeta,
+    SessionCase,
+    Summary,
+    VALIDATION_FAILED,
+    load_session_case_json,
+)
+
+EXAMPLE_JSON = {
+    "session_id": "7a0f4d7e-1f3a-4b0e-9e8f-88f2c4b1fd00",
+    "created_at": "2025-08-27T12:00:00Z",
+    "report_meta": {
+        "credit_report_date": "2025-08-01",
+        "personal_information": {
+            "name": "REDACTED",
+            "dob": "1989-**-**",
+            "current_address": "REDACTED",
+        },
+        "public_information": [],
+        "inquiries": [],
+        "raw_source": {"vendor": "SmartCredit", "version": None, "doc_fingerprint": "abc123"},
+    },
+    "summary": {
+        "total_accounts": 12,
+        "open_accounts": 9,
+        "closed_accounts": 3,
+        "delinquent": 2,
+        "derogatory": 1,
+        "balances": 21500,
+        "payments": None,
+        "public_records": 0,
+        "inquiries_2y": 2,
+    },
+    "accounts": {
+        "acc_001_Equifax": {
+            "bureau": "Equifax",
+            "fields": {
+                "account_number": "****1234",
+                "date_opened": "2019-03-10",
+                "balance_owed": 5000,
+                "credit_limit": 6000,
+                "payment_status": "120D late",
+                "account_rating": "Derogatory",
+            },
+            "artifacts": {
+                "stageA_detection": {
+                    "primary_issue": "unknown",
+                    "issue_types": [],
+                    "problem_reasons": [],
+                    "confidence": 0.0,
+                    "tier": "none",
+                    "decision_source": "rules",
+                    "timestamp": "2025-08-27T12:01:20Z",
+                }
+            },
+            "tags": {},
+        }
+    },
+}
+
+
+def test_round_trip_example():
+    data = json.dumps(EXAMPLE_JSON)
+    case = load_session_case_json(data)
+    dumped = case.model_dump_json()
+    again = load_session_case_json(dumped)
+    assert again.session_id == EXAMPLE_JSON["session_id"]
+
+
+def test_missing_summary_defaults():
+    payload = dict(EXAMPLE_JSON)
+    payload.pop("summary")
+    data = json.dumps(payload)
+    case = load_session_case_json(data)
+    assert case.summary.total_accounts == 0
+
+
+def test_missing_accounts_raises():
+    payload = dict(EXAMPLE_JSON)
+    payload.pop("accounts")
+    data = json.dumps(payload)
+    with pytest.raises(CaseStoreError) as exc:
+        load_session_case_json(data)
+    assert exc.value.code == VALIDATION_FAILED
+
+
+def test_enum_and_invalid_value():
+    payload = dict(EXAMPLE_JSON)
+    acc = payload["accounts"]["acc_001_Equifax"]
+    acc["bureau"] = "TransUnion"
+    data = json.dumps(payload)
+    case = load_session_case_json(data)
+    assert case.accounts["acc_001_Equifax"].bureau.value == "TransUnion"
+
+    acc["bureau"] = "BadBureau"
+    data = json.dumps(payload)
+    with pytest.raises(CaseStoreError):
+        load_session_case_json(data)
+
+
+def test_wrong_type_validation_error():
+    payload = dict(EXAMPLE_JSON)
+    payload["summary"]["balances"] = "oops"
+    data = json.dumps(payload)
+    with pytest.raises(CaseStoreError):
+        load_session_case_json(data)
+
+
+def test_optionals_accept_none():
+    case = SessionCase(
+        session_id="1",
+        accounts={},
+        summary=Summary(),
+        report_meta=ReportMeta(),
+    )
+    assert case.summary.balances is None


### PR DESCRIPTION
## Summary
- add Case Store configuration flags
- define Pydantic models for Case Store sessions, accounts, and summaries
- introduce CaseStoreError and helper to parse and validate SessionCase JSON
- cover new models and errors with tests

## Testing
- `pytest tests/test_case_store_validation.py --cov=backend/core/case_store --cov-report=term-missing:skip-covered`


------
https://chatgpt.com/codex/tasks/task_b_68ae2ac84f9c832588364c056a849892