### PR TITLE
Add case store storage with atomic write and validation options

### DIFF
--- a/backend/core/case_store/storage.py
+++ b/backend/core/case_store/storage.py
@@ -1,0 +1,78 @@
+import json
+import os
+import random
+from typing import Any
+
+from pydantic import ValidationError
+
+from backend.config import (
+    CASESTORE_ATOMIC_WRITES,
+    CASESTORE_DIR,
+    CASESTORE_VALIDATE_ON_LOAD,
+)
+
+from .errors import IO_ERROR, NOT_FOUND, VALIDATION_FAILED, CaseStoreError
+from .models import SessionCase
+
+__all__ = ["load_session_case", "save_session_case"]
+
+
+def _session_path(session_id: str) -> str:
+    return os.path.join(CASESTORE_DIR, f"{session_id}.json")
+
+
+def load_session_case(session_id: str) -> SessionCase:
+    """Load a SessionCase from disk."""
+    path = _session_path(session_id)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+    except FileNotFoundError as exc:  # pragma: no cover - exercised in tests
+        raise CaseStoreError(code=NOT_FOUND, message=str(exc)) from exc
+    except (PermissionError, OSError, IOError) as exc:  # pragma: no cover
+        raise CaseStoreError(code=IO_ERROR, message=str(exc)) from exc
+
+    try:
+        if CASESTORE_VALIDATE_ON_LOAD:
+            return SessionCase.model_validate_json(content)
+        data: Any = json.loads(content)
+        if not isinstance(data, dict):
+            raise TypeError("SessionCase JSON must be an object")
+        return SessionCase.model_construct(**data)
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised in tests
+        raise CaseStoreError(code=VALIDATION_FAILED, message=str(exc)) from exc
+    except (ValidationError, TypeError) as exc:  # pragma: no cover
+        raise CaseStoreError(code=VALIDATION_FAILED, message=str(exc)) from exc
+
+
+def save_session_case(case: SessionCase) -> None:
+    """Persist a SessionCase to disk."""
+    path = _session_path(case.session_id)
+    data = case.model_dump(mode="json")
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+    try:
+        os.makedirs(CASESTORE_DIR, exist_ok=True)
+    except (PermissionError, OSError, IOError) as exc:  # pragma: no cover
+        raise CaseStoreError(code=IO_ERROR, message=str(exc)) from exc
+
+    if CASESTORE_ATOMIC_WRITES:
+        tmp_path = f"{path}.tmp.{os.getpid()}.{random.randint(0, 1_000_000)}"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, path)
+        except (PermissionError, OSError, IOError) as exc:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            finally:  # pragma: no cover
+                raise CaseStoreError(code=IO_ERROR, message=str(exc)) from exc
+    else:
+        try:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+        except (PermissionError, OSError, IOError) as exc:  # pragma: no cover
+            raise CaseStoreError(code=IO_ERROR, message=str(exc)) from exc

--- a/tests/test_case_store_storage.py
+++ b/tests/test_case_store_storage.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+import backend.core.case_store.storage as storage
+from backend.core.case_store import (
+    IO_ERROR,
+    NOT_FOUND,
+    VALIDATION_FAILED,
+    CaseStoreError,
+    ReportMeta,
+    SessionCase,
+    Summary,
+)
+
+
+def make_case(session_id: str = "sess") -> SessionCase:
+    return SessionCase(
+        session_id=session_id,
+        accounts={},
+        summary=Summary(),
+        report_meta=ReportMeta(),
+    )
+
+
+def configure(monkeypatch, tmp_path: Path, *, atomic=True, validate=True):
+    monkeypatch.setattr(storage, "CASESTORE_DIR", tmp_path.as_posix())
+    monkeypatch.setattr(storage, "CASESTORE_ATOMIC_WRITES", atomic)
+    monkeypatch.setattr(storage, "CASESTORE_VALIDATE_ON_LOAD", validate)
+
+
+def test_save_load_round_trip(tmp_path, monkeypatch):
+    configure(monkeypatch, tmp_path)
+    case = make_case("abc")
+    storage.save_session_case(case)
+    loaded = storage.load_session_case("abc")
+    assert loaded == case
+
+
+def test_atomic_write_creates_no_temp(tmp_path, monkeypatch):
+    configure(monkeypatch, tmp_path, atomic=True)
+    case = make_case("atom")
+    storage.save_session_case(case)
+    assert (tmp_path / "atom.json").exists()
+    assert not list(tmp_path.glob("*.tmp*"))
+
+
+def test_validation_on_load(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path, validate=True)
+    path = tmp_path / "bad.json"
+    path.write_text('{"session": "x"}', encoding="utf-8")
+    with pytest.raises(CaseStoreError) as exc:
+        storage.load_session_case("bad")
+    assert exc.value.code == VALIDATION_FAILED
+
+    configure(monkeypatch, tmp_path, validate=False)
+    loaded = storage.load_session_case("bad")
+    assert isinstance(loaded, SessionCase)
+    assert not hasattr(loaded, "session_id")
+
+
+def test_missing_file(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    with pytest.raises(CaseStoreError) as exc:
+        storage.load_session_case("missing")
+    assert exc.value.code == NOT_FOUND
+
+
+def test_io_error_on_save(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+
+    def fail_open(*args, **kwargs):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    case = make_case("io")
+    with pytest.raises(CaseStoreError) as exc:
+        storage.save_session_case(case)
+    assert exc.value.code == IO_ERROR
+
+
+def test_non_atomic_mode(tmp_path, monkeypatch):
+    configure(monkeypatch, tmp_path, atomic=False)
+    case = make_case("plain")
+    storage.save_session_case(case)
+    assert (tmp_path / "plain.json").exists()
+    loaded = storage.load_session_case("plain")
+    assert loaded.session_id == "plain"


### PR DESCRIPTION
## Summary
- implement `load_session_case` and `save_session_case` for filesystem persistence
- support optional schema validation and atomic writes based on configuration flags

## Testing
- `pre-commit run --files backend/core/case_store/storage.py tests/test_case_store_storage.py`
- `pytest tests/test_case_store_storage.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae2cc36aac8325945e2dce498031a4