### PR TITLE
Add PII redaction utilities for case store

### DIFF
--- a/backend/core/case_store/redaction.py
+++ b/backend/core/case_store/redaction.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict
+
+PII_REPLACEMENTS = {
+    "NAME": "REDACTED_NAME",
+    "SSN": "REDACTED_SSN",
+    "ADDRESS": "REDACTED_ADDRESS",
+    "PHONE": "REDACTED_PHONE",
+    "EMAIL": "REDACTED_EMAIL",
+}
+
+ACCOUNT_REPLACEMENT = "REDACTED_ACCOUNT"
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_RE = re.compile(r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}")
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b|\b\d{9}\b")
+ADDRESS_RE = re.compile(
+    r"\b(street|st\.|avenue|ave|road|rd\.|blvd|boulevard|apt|suite)\b", re.I
+)
+ACCOUNT_NUMBER_RE = re.compile(r"\d{8,}")
+
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%m/%d/%Y",
+    "%Y/%m/%d",
+    "%m-%d-%Y",
+    "%Y.%m.%d",
+    "%Y%m%d",
+)
+
+
+def _normalize_date(value: str) -> str:
+    for fmt in DATE_FORMATS:
+        try:
+            dt = datetime.strptime(value, fmt)
+            return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(value).date().isoformat()
+    except ValueError:
+        return value
+
+
+def _mask_dob(value: str) -> str:
+    normalized = _normalize_date(value)
+    m = re.match(r"(\d{4})", normalized)
+    if m:
+        return f"{m.group(1)}-**-**"
+    return normalized
+
+
+def _mask_account_number(value: str) -> str:
+    if value.startswith("****") or value == ACCOUNT_REPLACEMENT:
+        return value
+    digits = re.sub(r"\D", "", value)
+    if len(digits) < 4:
+        return ACCOUNT_REPLACEMENT
+    return f"****{digits[-4:]}"
+
+
+def _redact_string(key: str | None, value: str) -> str:
+    if value.startswith("REDACTED_"):
+        return value
+
+    lower_key = (key or "").lower()
+    if lower_key == "account_number":
+        return _mask_account_number(value)
+    if lower_key in {"name", "full_name", "first_name", "last_name"}:
+        return PII_REPLACEMENTS["NAME"]
+    if "address" in lower_key:
+        return PII_REPLACEMENTS["ADDRESS"]
+    if "email" in lower_key:
+        return PII_REPLACEMENTS["EMAIL"]
+    if "phone" in lower_key:
+        return PII_REPLACEMENTS["PHONE"]
+    if "ssn" in lower_key:
+        return PII_REPLACEMENTS["SSN"]
+    if lower_key in {"dob", "date_of_birth"}:
+        return _mask_dob(value)
+
+    if EMAIL_RE.search(value):
+        return PII_REPLACEMENTS["EMAIL"]
+    if PHONE_RE.search(value):
+        return PII_REPLACEMENTS["PHONE"]
+    if SSN_RE.search(value):
+        return PII_REPLACEMENTS["SSN"]
+    if ADDRESS_RE.search(value):
+        return PII_REPLACEMENTS["ADDRESS"]
+
+    def _acc_repl(match: re.Match[str]) -> str:
+        digits = match.group()
+        return f"****{digits[-4:]}"
+
+    value = ACCOUNT_NUMBER_RE.sub(_acc_repl, value)
+
+    if any(
+        token in lower_key
+        for token in (
+            "date",
+            "last_activity",
+            "last_payment",
+            "last_verified",
+            "opened",
+            "closed",
+        )
+    ):
+        return _normalize_date(value)
+
+    return value
+
+
+def _redact(obj: Any, key: str | None = None) -> Any:
+    if isinstance(obj, dict):
+        return {k: _redact(v, k) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact(v) for v in obj]
+    if isinstance(obj, str):
+        return _redact_string(key, obj)
+    return obj
+
+
+def redact_account_fields(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep-copied dict where PII is removed/masked and analytic fields preserved."""
+    return _redact(deepcopy(fields))
+
+
+AI_FIELD_WHITELIST = [
+    "account_status",
+    "payment_status",
+    "creditor_remarks",
+    "account_description",
+    "account_rating",
+    "past_due_amount",
+    "balance_owed",
+    "credit_limit",
+    "account_type",
+    "creditor_type",
+    "dispute_status",
+    "two_year_payment_history",
+    "days_late_7y",
+]
+
+
+def _extract_last4(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    digits = re.sub(r"\D", "", value)
+    if len(digits) >= 4:
+        return digits[-4:]
+    return None
+
+
+def redact_for_ai(account: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a minimized, PII-safe AI payload."""
+    fields = account.get("fields", {}) or {}
+    redacted = redact_account_fields(fields)
+
+    ai_fields = {k: redacted.get(k) for k in AI_FIELD_WHITELIST if k in redacted}
+    presence_map = {k: k in fields for k in AI_FIELD_WHITELIST}
+    last4 = _extract_last4(fields.get("account_number"))
+
+    return {
+        "fields": ai_fields,
+        "field_presence_map": presence_map,
+        "account_last4": last4,
+    }
+
+
+__all__ = [
+    "redact_account_fields",
+    "redact_for_ai",
+    "PII_REPLACEMENTS",
+]

--- a/tests/test_case_store_redaction.py
+++ b/tests/test_case_store_redaction.py
@@ -1,0 +1,116 @@
+import json
+
+from backend.core.case_store.redaction import (
+    PII_REPLACEMENTS,
+    redact_account_fields,
+    redact_for_ai,
+)
+
+
+def test_account_number_last4():
+    fields = {"account_number": "1234 5678 9012"}
+    redacted = redact_account_fields(fields)
+    assert redacted["account_number"] == "****9012"
+
+    fields = {"account_number": "****9012"}
+    redacted = redact_account_fields(fields)
+    assert redacted["account_number"] == "****9012"
+
+    fields = {"account_number": "123"}
+    redacted = redact_account_fields(fields)
+    assert redacted["account_number"] == "REDACTED_ACCOUNT"
+
+
+def test_emails_phones_ssn():
+    fields = {
+        "contact": "john.doe+test@x.com",
+        "phone": "(415) 555-1212",
+        "ssn1": "123-45-6789",
+        "ssn2": "123456789",
+    }
+    redacted = redact_account_fields(fields)
+    assert redacted["contact"] == PII_REPLACEMENTS["EMAIL"]
+    assert redacted["phone"] == PII_REPLACEMENTS["PHONE"]
+    assert redacted["ssn1"] == PII_REPLACEMENTS["SSN"]
+    assert redacted["ssn2"] == PII_REPLACEMENTS["SSN"]
+
+
+def test_names_and_addresses():
+    fields = {
+        "full_name": "Jane Q Public",
+        "address_line": "12 Main St, Springfield, IL 62704",
+    }
+    redacted = redact_account_fields(fields)
+    assert redacted["full_name"] == PII_REPLACEMENTS["NAME"]
+    assert redacted["address_line"] == PII_REPLACEMENTS["ADDRESS"]
+
+
+def test_date_normalization():
+    fields = {
+        "date_opened": "03/10/2019",
+        "unparseable": "32/13/2020",
+    }
+    redacted = redact_account_fields(fields)
+    assert redacted["date_opened"] == "2019-03-10"
+    assert redacted["unparseable"] == "32/13/2020"
+
+
+def test_preserve_analytic_fields():
+    fields = {
+        "balance_owed": 5000,
+        "credit_limit": 6000,
+        "payment_status": "120D late",
+        "two_year_payment_history": "1111",
+    }
+    redacted = redact_account_fields(fields)
+    assert redacted["balance_owed"] == 5000
+    assert redacted["credit_limit"] == 6000
+    assert redacted["payment_status"] == "120D late"
+    assert redacted["two_year_payment_history"] == "1111"
+
+
+def test_redact_for_ai_shape_contents():
+    account = {
+        "fields": {
+            "account_number": "1234 5678 9012",
+            "account_status": "Open",
+            "payment_status": "Current",
+            "creditor_remarks": "OK",
+            "account_description": "Credit card",
+            "account_rating": "A",
+            "past_due_amount": 0,
+            "balance_owed": 500,
+            "account_type": "Revolving",
+            "creditor_type": "Bank",
+            "dispute_status": "None",
+            "two_year_payment_history": "1111",
+            # intentionally missing credit_limit
+            "full_name": "Jane Q Public",
+            "email": "john@example.com",
+        }
+    }
+    out = redact_for_ai(account)
+    assert set(out.keys()) == {"fields", "field_presence_map", "account_last4"}
+    assert out["account_last4"] == "9012"
+    fields = out["fields"]
+    assert "account_status" in fields
+    assert "credit_limit" not in fields
+    assert out["field_presence_map"]["credit_limit"] is False
+    payload = json.dumps(out)
+    assert "@" not in payload
+    assert "Jane" not in payload
+
+
+def test_idempotent():
+    fields = {"account_number": "1234 5678 9012", "full_name": "Jane Q Public"}
+    once = redact_account_fields(fields)
+    twice = redact_account_fields(once)
+    assert once == twice
+
+
+def test_non_string_values():
+    fields = {"balance_owed": 100, "meta": {"phone": "415-555-1212", "note": None}}
+    redacted = redact_account_fields(fields)
+    assert redacted["balance_owed"] == 100
+    assert redacted["meta"]["phone"] == PII_REPLACEMENTS["PHONE"]
+    assert redacted["meta"]["note"] is None


### PR DESCRIPTION
## Summary
- implement `redact_account_fields` to mask PII in account data
- add `redact_for_ai` for safe minimal AI payloads
- test redaction of account numbers, PII patterns, dates, and idempotency

## Testing
- `pytest tests/test_case_store_redaction.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae2ee7ea9c83259eae8a7477c0e902