### PR TITLE
Add Case Store API with account field, artifact, and tag management

### DIFF
--- a/backend/core/case_store/api.py
+++ b/backend/core/case_store/api.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import ValidationError
+
+from backend.config import CASESTORE_REDACT_BEFORE_STORE
+
+from .errors import CaseStoreError, NOT_FOUND, VALIDATION_FAILED
+from .models import Artifact, AccountCase, AccountFields, Bureau, SessionCase
+from .redaction import redact_account_fields
+from .storage import load_session_case as _load, save_session_case as _save
+
+__all__ = [
+    "create_session_case",
+    "load_session_case",
+    "save_session_case",
+    "upsert_account_fields",
+    "get_account_case",
+    "get_account_fields",
+    "append_artifact",
+    "set_tags",
+    "list_accounts",
+]
+
+
+def _coerce_bureau(value: str | Bureau) -> Bureau:
+    if isinstance(value, Bureau):
+        return value
+    for member in Bureau:
+        if member.value.lower() == str(value).lower():
+            return member
+    raise CaseStoreError(code=VALIDATION_FAILED, message=f"Invalid bureau: {value}")
+
+
+def create_session_case(session_id: str, meta: Dict[str, Any] | None = None) -> SessionCase:
+    """Create a new in-memory SessionCase with optional metadata."""
+
+    case = SessionCase(session_id=session_id, accounts={})
+    if meta:
+        fields = case.report_meta.__class__.model_fields
+        allowed = {k: v for k, v in meta.items() if k in fields}
+        if allowed:
+            case.report_meta = case.report_meta.model_copy(update=allowed)
+    return case
+
+
+def load_session_case(session_id: str) -> SessionCase:
+    """Load a session from storage."""
+
+    return _load(session_id)
+
+
+def save_session_case(case: SessionCase) -> None:
+    """Persist a session to storage."""
+
+    _save(case)
+
+
+def upsert_account_fields(
+    session_id: str,
+    account_id: str,
+    bureau: str | Bureau,
+    fields: Dict[str, Any],
+) -> None:
+    """Upsert account fields, optionally redacting sensitive data."""
+
+    case = _load(session_id)
+    if CASESTORE_REDACT_BEFORE_STORE:
+        fields = redact_account_fields(fields)
+
+    bureau_enum = _coerce_bureau(bureau)
+
+    account = case.accounts.get(account_id)
+    if account is None:
+        account = AccountCase(bureau=bureau_enum)
+        case.accounts[account_id] = account
+    else:
+        account.bureau = bureau_enum
+
+    current = account.fields.model_dump()
+    current.update(fields)
+    try:
+        account.fields = AccountFields(**current)
+    except ValidationError as exc:
+        raise CaseStoreError(code=VALIDATION_FAILED, message=str(exc)) from exc
+
+    save_session_case(case)
+
+
+def get_account_case(session_id: str, account_id: str) -> AccountCase:
+    """Return the full AccountCase."""
+
+    case = _load(session_id)
+    account = case.accounts.get(account_id)
+    if account is None:
+        raise CaseStoreError(code=NOT_FOUND, message=f"Account '{account_id}' not found")
+    return account
+
+
+def get_account_fields(
+    session_id: str,
+    account_id: str,
+    field_names: List[str],
+) -> Dict[str, Any]:
+    """Return a dict subset of AccountFields by name."""
+
+    case = _load(session_id)
+    account = case.accounts.get(account_id)
+    if account is None:
+        raise CaseStoreError(code=NOT_FOUND, message=f"Account '{account_id}' not found")
+
+    return {name: getattr(account.fields, name, None) for name in field_names}
+
+
+def append_artifact(
+    session_id: str,
+    account_id: str,
+    namespace: str,
+    payload: Dict[str, Any],
+    *,
+    overwrite: bool = True,
+    attach_provenance: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Add or replace an artifact under a namespace."""
+
+    case = _load(session_id)
+    account = case.accounts.get(account_id)
+    if account is None:
+        raise CaseStoreError(code=NOT_FOUND, message=f"Account '{account_id}' not found")
+
+    existing = account.artifacts.get(namespace)
+    if not overwrite and existing is not None:
+        raise CaseStoreError(code=VALIDATION_FAILED, message="Artifact exists")
+
+    try:
+        artifact = Artifact(**payload)
+    except ValidationError as exc:
+        raise CaseStoreError(code=VALIDATION_FAILED, message=str(exc)) from exc
+
+    if attach_provenance:
+        debug = artifact.debug or {}
+        debug["provenance"] = attach_provenance
+        artifact.debug = debug
+
+    account.artifacts[namespace] = artifact
+    save_session_case(case)
+
+
+def set_tags(session_id: str, account_id: str, **tags) -> None:
+    """Merge tags into the account."""
+
+    case = _load(session_id)
+    account = case.accounts.get(account_id)
+    if account is None:
+        raise CaseStoreError(code=NOT_FOUND, message=f"Account '{account_id}' not found")
+
+    account.tags.update(tags)
+    save_session_case(case)
+
+
+def list_accounts(
+    session_id: str, bureau: str | Bureau | None = None
+) -> List[str]:
+    """List account IDs for a session, optionally filtered by bureau."""
+
+    case = _load(session_id)
+    if bureau is None:
+        return list(case.accounts.keys())
+
+    bureau_enum = _coerce_bureau(bureau)
+    return [aid for aid, acc in case.accounts.items() if acc.bureau == bureau_enum]

--- a/tests/test_case_store_api.py
+++ b/tests/test_case_store_api.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from backend.core.case_store import api, storage
+from backend.core.case_store.errors import CaseStoreError, NOT_FOUND, VALIDATION_FAILED
+from backend.core.case_store.models import Bureau
+
+
+# Helpers ---------------------------------------------------------------
+
+def configure(monkeypatch, tmp_path: Path, *, redact: bool = True) -> None:
+    monkeypatch.setattr(storage, "CASESTORE_DIR", tmp_path.as_posix())
+    monkeypatch.setattr(api, "CASESTORE_REDACT_BEFORE_STORE", redact)
+
+
+def bootstrap_session(monkeypatch, tmp_path: Path, *, redact: bool = True) -> str:
+    configure(monkeypatch, tmp_path, redact=redact)
+    case = api.create_session_case("sess", meta={"raw_source": {"vendor": "SmartCredit"}})
+    api.save_session_case(case)
+    return case.session_id
+
+
+# Tests ----------------------------------------------------------------
+
+def test_round_trip(tmp_path, monkeypatch):
+    configure(monkeypatch, tmp_path)
+    case = api.create_session_case("abc", meta={"raw_source": {"vendor": "SmartCredit"}})
+    api.save_session_case(case)
+    loaded = api.load_session_case("abc")
+    assert loaded.report_meta.raw_source["vendor"] == "SmartCredit"
+
+
+def test_upsert_account_fields_redaction(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path, redact=True)
+    api.upsert_account_fields(
+        session_id,
+        "acc1",
+        "Equifax",
+        {
+            "account_number": "1234 5678 9012",
+            "balance_owed": 5000,
+            "payment_status": "120D late",
+        },
+    )
+    loaded = api.load_session_case(session_id)
+    acc = loaded.accounts["acc1"]
+    assert acc.bureau == Bureau.Equifax
+    assert acc.fields.account_number == "****9012"
+    assert acc.fields.balance_owed == 5000
+
+
+def test_upsert_account_fields_no_redaction(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path, redact=False)
+    api.upsert_account_fields(
+        session_id,
+        "acc1",
+        "Experian",
+        {"account_number": "1234 5678 9012"},
+    )
+    loaded = api.load_session_case(session_id)
+    acc = loaded.accounts["acc1"]
+    assert acc.fields.account_number == "1234 5678 9012"
+
+
+def test_get_account_fields_subset(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path, redact=False)
+    api.upsert_account_fields(
+        session_id,
+        "acc1",
+        "Equifax",
+        {"balance_owed": 5000, "payment_status": "late"},
+    )
+    fields = api.get_account_fields(
+        session_id,
+        "acc1",
+        ["balance_owed", "payment_status", "missing_field"],
+    )
+    assert fields == {
+        "balance_owed": 5000,
+        "payment_status": "late",
+        "missing_field": None,
+    }
+
+
+def test_append_artifact_and_overwrite(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path, redact=False)
+    api.upsert_account_fields(session_id, "acc1", "Equifax", {})
+    payload: Dict[str, object] = {
+        "primary_issue": "unknown",
+        "confidence": 0.0,
+        "tier": "none",
+        "decision_source": "rules",
+        "problem_reasons": [],
+    }
+    api.append_artifact(session_id, "acc1", "stageA_detection", payload)
+    loaded = api.load_session_case(session_id)
+    art = loaded.accounts["acc1"].artifacts["stageA_detection"]
+    assert art.timestamp is not None
+    with pytest.raises(CaseStoreError) as exc:
+        api.append_artifact(session_id, "acc1", "stageA_detection", payload, overwrite=False)
+    assert exc.value.code == VALIDATION_FAILED
+
+
+def test_set_tags_and_list_accounts(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path, redact=False)
+    api.upsert_account_fields(session_id, "acc_eq", "Equifax", {})
+    api.upsert_account_fields(session_id, "acc_ex", "Experian", {})
+    api.set_tags(session_id, "acc_eq", is_problematic=True, tier="Tier2")
+    loaded = api.load_session_case(session_id)
+    assert loaded.accounts["acc_eq"].tags["is_problematic"] is True
+    assert loaded.accounts["acc_eq"].tags["tier"] == "Tier2"
+    ids_all = set(api.list_accounts(session_id))
+    assert ids_all == {"acc_eq", "acc_ex"}
+    ids_eq = api.list_accounts(session_id, bureau="Equifax")
+    assert ids_eq == ["acc_eq"]
+    with pytest.raises(CaseStoreError) as exc:
+        api.list_accounts(session_id, bureau="BadBureau")
+    assert exc.value.code == VALIDATION_FAILED
+
+
+def test_error_paths(tmp_path, monkeypatch):
+    configure(monkeypatch, tmp_path)
+    with pytest.raises(CaseStoreError) as exc:
+        api.get_account_case("missing", "acc")
+    assert exc.value.code == NOT_FOUND
+
+    session_id = bootstrap_session(monkeypatch, tmp_path)
+    with pytest.raises(CaseStoreError) as exc:
+        api.get_account_case(session_id, "missing")
+    assert exc.value.code == NOT_FOUND
+    with pytest.raises(CaseStoreError) as exc:
+        api.append_artifact(session_id, "missing", "ns", {})
+    assert exc.value.code == NOT_FOUND
+    with pytest.raises(CaseStoreError) as exc:
+        api.set_tags(session_id, "missing", foo=1)
+    assert exc.value.code == NOT_FOUND


### PR DESCRIPTION
## Summary
- implement high-level Case Store API for creating, persisting, and loading session cases
- support account field upserts with optional redaction, artifact management, tag updates, and account listing
- add comprehensive tests covering read/write operations, redaction toggles, artifacts, tags, and error paths

## Testing
- `pytest tests/test_case_store_api.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae30d042d08325b28e97be95203a43