### PR TITLE
Enable Case Store reads for Stage A (post-parity)

### DIFF
--- a/tests/test_stagea_casestore_migration.py
+++ b/tests/test_stagea_casestore_migration.py
@@ -1,37 +1,50 @@
-import os
-import time
 import logging
+import time
 
 import pytest
 
 import backend.config as config
+from backend.core import orchestrators as orch
 from backend.core.case_store import api as cs_api
 from backend.core.logic.report_analysis import problem_detection as pd
-from backend.core import orchestrators as orch
 
 
 @pytest.fixture
 def session_case(tmp_path, monkeypatch):
-    """Create a synthetic Case Store session with two accounts."""
+    """Create a synthetic Case Store session with three accounts."""
     session_id = "sess1"
     monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
     case = cs_api.create_session_case(session_id)
     cs_api.save_session_case(case)
+    base = {
+        "balance_owed": 100.0,
+        "credit_limit": 1000.0,
+        "payment_status": "",
+        "account_status": "",
+        "two_year_payment_history": "",
+        "days_late_7y": "",
+    }
+    # Clean account
+    cs_api.upsert_account_fields(session_id, "acc1", "Experian", dict(base))
+    # Numeric past-due evidence
     cs_api.upsert_account_fields(
-        session_id,
-        "acc1",
-        "Experian",
-        {"past_due_amount": 50.0, "balance_owed": 100.0},
+        session_id, "acc2", "Experian", dict(base, past_due_amount=50.0)
     )
+    # Late-history evidence
     cs_api.upsert_account_fields(
         session_id,
-        "acc2",
-        "Equifax",
-        {"past_due_amount": 0.0, "balance_owed": 100.0},
+        "acc3",
+        "Experian",
+        dict(base, two_year_payment_history="OK,30,OK,60,OK"),
     )
     legacy_accounts = [
-        {"account_id": "acc1", "past_due_amount": 50.0},
-        {"account_id": "acc2", "past_due_amount": 0.0},
+        {"account_id": "acc1"},
+        {"account_id": "acc2", "past_due_amount": 50.0},
+        {
+            "account_id": "acc3",
+            "two_year_payment_history": "OK,30,OK,60,OK",
+            "past_due_amount": 0.0,
+        },
     ]
     return session_id, legacy_accounts
 
@@ -41,7 +54,7 @@ def test_legacy_path(session_case, monkeypatch):
     monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", False)
     pd.run_stage_a(session_id, legacy_accounts)
     problems = orch.collect_stageA_problem_accounts(session_id, legacy_accounts)
-    assert [p["account_id"] for p in problems] == ["acc1"]
+    assert {p["account_id"] for p in problems} == {"acc2", "acc3"}
 
 
 def test_casestore_path(session_case, monkeypatch):
@@ -49,11 +62,20 @@ def test_casestore_path(session_case, monkeypatch):
     monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
     pd.run_stage_a(session_id, legacy_accounts)
     # artifacts written
-    for aid in ["acc1", "acc2"]:
+    for aid in ["acc1", "acc2", "acc3"]:
         case = cs_api.get_account_case(session_id, aid)
         assert "stageA_detection" in case.artifacts
     problems = orch.collect_stageA_problem_accounts(session_id, [])
-    assert [p["account_id"] for p in problems] == ["acc1"]
+    ids = {p["account_id"] for p in problems}
+    assert ids == {"acc2", "acc3"}
+    for acc in problems:
+        assert acc["primary_issue"] == "unknown"
+        assert acc["tier"] == "none"
+        assert acc["decision_source"] == "rules"
+        assert acc["confidence"] == 0.0
+    reasons = {p["account_id"]: p["problem_reasons"] for p in problems}
+    assert reasons["acc2"] == ["past_due_amount: 50.00"]
+    assert reasons["acc3"] == ["late: 1×30,1×60"]
 
 
 def test_parity_logging(session_case, monkeypatch, caplog):
@@ -63,7 +85,27 @@ def test_parity_logging(session_case, monkeypatch, caplog):
     caplog.set_level(logging.INFO)
     pd.run_stage_a(session_id, legacy_accounts)
     parity_logs = [r for r in caplog.records if "stageA_parity" in r.message]
-    assert len(parity_logs) == 2
+    assert len(parity_logs) == 3
+
+
+def test_idempotent(session_case, monkeypatch):
+    session_id, legacy_accounts = session_case
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    pd.run_stage_a(session_id, legacy_accounts)
+    first = (
+        cs_api.get_account_case(session_id, "acc2")
+        .artifacts["stageA_detection"]
+        .model_dump()
+    )
+    pd.run_stage_a(session_id, legacy_accounts)
+    second = (
+        cs_api.get_account_case(session_id, "acc2")
+        .artifacts["stageA_detection"]
+        .model_dump()
+    )
+    first.pop("timestamp", None)
+    second.pop("timestamp", None)
+    assert first == second
 
 
 def test_missing_account_resilience(session_case, monkeypatch, caplog):
@@ -71,20 +113,22 @@ def test_missing_account_resilience(session_case, monkeypatch, caplog):
     monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
     caplog.set_level(logging.WARNING)
 
-    orig = pd.get_account_fields
+    orig = pd.append_artifact
 
-    def broken_get_fields(session_id, account_id, fields):
-        if account_id == "acc2":
-            raise cs_api.CaseStoreError(code=cs_api.NOT_FOUND, message="missing")
-        return orig(session_id, account_id, fields)
+    def broken_append(session_id, acc_id, namespace, payload, **kw):
+        if acc_id == "acc3":
+            raise cs_api.CaseStoreError(code=cs_api.NOT_FOUND, message="boom")
+        return orig(session_id, acc_id, namespace, payload, **kw)
 
-    monkeypatch.setattr(pd, "get_account_fields", broken_get_fields)
+    monkeypatch.setattr(pd, "append_artifact", broken_append)
     pd.run_stage_a(session_id, legacy_accounts)
     case1 = cs_api.get_account_case(session_id, "acc1")
     assert "stageA_detection" in case1.artifacts
     case2 = cs_api.get_account_case(session_id, "acc2")
-    assert "stageA_detection" not in case2.artifacts
-    assert any("stageA_missing_account" in r.message for r in caplog.records)
+    assert "stageA_detection" in case2.artifacts
+    case3 = cs_api.get_account_case(session_id, "acc3")
+    assert "stageA_detection" not in case3.artifacts
+    assert any("stageA_append_failed" in r.message for r in caplog.records)
 
 
 def test_performance_sanity(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- centralize Stage A required fields and switch to Case Store account iteration
- log parity against legacy accounts and handle artifact write errors
- orchestrator reads Stage A artifacts, warning on missing data; add comprehensive migration tests

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/problem_detection.py backend/core/orchestrators.py tests/test_stagea_casestore_migration.py`
- `pytest tests/test_stagea_casestore_migration.py tests/test_problem_detection_rules_only.py`


------
https://chatgpt.com/codex/tasks/task_b_68ae3f5c7a648325a2bace94d45804e6