### PR TITLE
feat: add optional AI adjudication path

### DIFF
--- a/backend/api/ai_endpoints.py
+++ b/backend/api/ai_endpoints.py
@@ -1,0 +1,45 @@
+"""Internal AI adjudication endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+from pydantic import ValidationError
+
+from backend.config import AI_REQUEST_TIMEOUT_S
+from backend.core.ai.models import AIAdjudicateRequest, AIAdjudicateResponse
+from backend.core.ai.service import run_llm_prompt
+
+logger = logging.getLogger(__name__)
+
+ai_bp = Blueprint("ai_internal", __name__)
+
+
+@ai_bp.post("/internal/ai-adjudicate")
+def ai_adjudicate() -> Any:
+    """Internal-only AI adjudication endpoint."""
+    try:
+        raw = request.get_json(force=True) or {}
+        req = AIAdjudicateRequest.model_validate(raw)
+    except ValidationError:
+        return jsonify({"error": "invalid_request"}), 400
+
+    system_prompt = f"hierarchy_version={req.hierarchy_version}"
+    try:
+        llm_raw = run_llm_prompt(
+            system_prompt,
+            req.fields,
+            temperature=0.0,
+            timeout=AI_REQUEST_TIMEOUT_S,
+        )
+        data = json.loads(llm_raw)
+        resp = AIAdjudicateResponse.model_validate(data)
+        return jsonify(resp.model_dump())
+    except TimeoutError:
+        return jsonify({"error": "timeout"}), 504
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("ai_adjudicate_failure: %s", exc)
+        return jsonify({"error": "bad_gateway"}), 502

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -23,9 +23,9 @@ from werkzeug.utils import secure_filename
 
 from backend.analytics.batch_runner import BatchFilters, BatchRunner
 from backend.api.admin import admin_bp
+from backend.api.ai_endpoints import ai_bp
 from backend.api.auth import require_api_key_or_role
 from backend.api.config import ENABLE_BATCH_RUNNER, get_app_config
-from backend.api.internal_ai import internal_ai_bp
 from backend.api.session_manager import (
     get_session,
     set_session,
@@ -264,7 +264,7 @@ def create_app() -> Flask:
     CORS(app, resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)
     app.register_blueprint(admin_bp)
     app.register_blueprint(api_bp)
-    app.register_blueprint(internal_ai_bp)
+    app.register_blueprint(ai_bp)
 
     @app.before_request
     def _load_config() -> None:

--- a/backend/config.py
+++ b/backend/config.py
@@ -17,6 +17,28 @@ def env_str(name: str, default: str) -> str:
     return os.getenv(name, default)
 
 
+def env_float(name: str, default: float) -> float:
+    """Parse a float environment variable."""
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
+def env_int(name: str, default: int) -> int:
+    """Parse an int environment variable."""
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
 # Backwards compatibility for older imports
 _env_bool = env_bool
 
@@ -49,9 +71,11 @@ ENABLE_TIER2_KEYWORDS = _env_bool("ENABLE_TIER2_KEYWORDS", False)
 ENABLE_TIER3_KEYWORDS = _env_bool("ENABLE_TIER3_KEYWORDS", False)
 ENABLE_TIER2_NUMERIC = _env_bool("ENABLE_TIER2_NUMERIC", True)
 
-ENABLE_AI_ADJUDICATOR = _env_bool("ENABLE_AI_ADJUDICATOR", False)
-AI_MIN_CONFIDENCE = float(os.getenv("AI_MIN_CONFIDENCE", "0.65"))
-AI_TIMEOUT_SEC = float(os.getenv("AI_TIMEOUT_SEC", "8"))
+ENABLE_AI_ADJUDICATOR = env_bool("ENABLE_AI_ADJUDICATOR", False)
+AI_MIN_CONFIDENCE = env_float("AI_MIN_CONFIDENCE", 0.70)
+AI_REQUEST_TIMEOUT_S = env_int("AI_REQUEST_TIMEOUT_S", 8)
+AI_MAX_RETRIES = env_int("AI_MAX_RETRIES", 1)
+AI_HIERARCHY_VERSION = env_str("AI_HIERARCHY_VERSION", "v1")
 AI_REDACT_STRATEGY = os.getenv("AI_REDACT_STRATEGY", "hash_last4")
 
 _raw_t1, _raw_t2, _raw_t3 = _load_keyword_lists()
@@ -63,9 +87,7 @@ TIER3_KEYWORDS = _raw_t3 if ENABLE_TIER3_KEYWORDS else {}
 
 # Case Store configuration
 CASESTORE_DIR = env_str("CASESTORE_DIR", "/var/app/run/cases")
-CASESTORE_REDACT_BEFORE_STORE = env_bool(
-    "CASESTORE_REDACT_BEFORE_STORE", True
-)
+CASESTORE_REDACT_BEFORE_STORE = env_bool("CASESTORE_REDACT_BEFORE_STORE", True)
 CASESTORE_ATOMIC_WRITES = env_bool("CASESTORE_ATOMIC_WRITES", True)
 CASESTORE_VALIDATE_ON_LOAD = env_bool("CASESTORE_VALIDATE_ON_LOAD", True)
 
@@ -81,7 +103,5 @@ CASESTORE_STAGEA_LOG_PARITY = env_bool("CASESTORE_STAGEA_LOG_PARITY", True)
 PROBLEM_DETECTION_ONLY = env_bool("PROBLEM_DETECTION_ONLY", True)
 
 # Candidate token logging
-ENABLE_CANDIDATE_TOKEN_LOGGER = env_bool(
-    "ENABLE_CANDIDATE_TOKEN_LOGGER", True
-)
+ENABLE_CANDIDATE_TOKEN_LOGGER = env_bool("ENABLE_CANDIDATE_TOKEN_LOGGER", True)
 CANDIDATE_LOG_FORMAT = env_str("CANDIDATE_LOG_FORMAT", "jsonl")

--- a/backend/core/ai/adjudicator_client.py
+++ b/backend/core/ai/adjudicator_client.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Optional
+
+import httpx
+from pydantic import ValidationError
+
+from backend.config import AI_MAX_RETRIES, AI_REQUEST_TIMEOUT_S
+from backend.core.ai.models import AIAdjudicateRequest, AIAdjudicateResponse
+from backend.core.case_store.telemetry import emit
+
+AI_URL = "/internal/ai-adjudicate"
+
+
+def call_adjudicator(
+    session, payload: AIAdjudicateRequest
+) -> Optional[AIAdjudicateResponse]:
+    """Call internal AI adjudicator endpoint.
+
+    Returns parsed ``AIAdjudicateResponse`` or ``None`` on failure. Any
+    validation, timeout, or HTTP error results in ``None`` and emits telemetry
+    with the error class name as status.
+    """
+
+    attempts = AI_MAX_RETRIES + 1
+    for attempt in range(1, attempts + 1):
+        t0 = time.perf_counter()
+        status = "ok"
+        try:
+            with httpx.Client(timeout=AI_REQUEST_TIMEOUT_S) as cli:
+                r = cli.post(AI_URL, json=payload.model_dump(mode="json"))
+            r.raise_for_status()
+            data = r.json()
+            resp = AIAdjudicateResponse.model_validate(data)
+            dur = (time.perf_counter() - t0) * 1000
+            emit(
+                "stageA_ai_call",
+                attempt=attempt,
+                status=status,
+                duration_ms=round(dur, 3),
+                confidence=resp.confidence,
+            )
+            return resp
+        except (
+            httpx.TimeoutException,
+            httpx.HTTPError,
+            json.JSONDecodeError,
+            ValidationError,
+        ) as e:
+            status = e.__class__.__name__
+            dur = (time.perf_counter() - t0) * 1000
+            emit(
+                "stageA_ai_call",
+                attempt=attempt,
+                status=status,
+                duration_ms=round(dur, 3),
+            )
+            pass
+    return None

--- a/backend/core/ai/models.py
+++ b/backend/core/ai/models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal
+
+from pydantic import BaseModel, Field, confloat, constr
+
+PrimaryIssue = Literal[
+    "collection",
+    "charge_off",
+    "bankruptcy",
+    "repossession",
+    "foreclosure",
+    "severe_delinquency",
+    "derogatory",
+    "high_utilization",
+    "none",
+    "unknown",
+]
+
+Tier = Literal["Tier1", "Tier2", "Tier3", "Tier4", "none"]
+
+
+class AIAdjudicateRequest(BaseModel):
+    doc_fingerprint: constr(strip_whitespace=True)
+    account_fingerprint: constr(strip_whitespace=True)
+    hierarchy_version: constr(strip_whitespace=True) = "v1"
+    fields: Dict[str, Any]
+
+
+class AIAdjudicateResponse(BaseModel):
+    primary_issue: PrimaryIssue
+    tier: Tier
+    problem_reasons: List[str] = Field(default_factory=list)
+    confidence: confloat(ge=0.0, le=1.0)
+    fields_used: List[str] = Field(default_factory=list)
+    decision_source: Literal["ai"] = "ai"
+
+
+__all__ = [
+    "PrimaryIssue",
+    "Tier",
+    "AIAdjudicateRequest",
+    "AIAdjudicateResponse",
+]

--- a/backend/core/ai/service.py
+++ b/backend/core/ai/service.py
@@ -1,0 +1,22 @@
+"""Lightweight LLM service stubs used for tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_llm_prompt(
+    system: str, user: Any, *, temperature: float = 0.0, timeout: int | None = None
+) -> str:
+    """Stubbed LLM caller.
+
+    In production this would call an AI service.  Tests patch this function to
+    return deterministic JSON strings or to raise errors.  The default
+    implementation simply raises ``NotImplementedError`` to avoid accidental
+    network calls.
+    """
+
+    raise NotImplementedError("run_llm_prompt is not implemented")
+
+
+__all__ = ["run_llm_prompt"]

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -116,16 +116,25 @@ def collect_stageA_problem_accounts(
                 )
                 continue
             data = art.model_dump()
-            if data.get("problem_reasons"):
+            tier = str(data.get("tier", "none"))
+            source = data.get("decision_source", "rules")
+            reasons = data.get("problem_reasons", [])
+            include = False
+            if config.ENABLE_AI_ADJUDICATOR and source == "ai":
+                if tier in {"Tier1", "Tier2", "Tier3"}:
+                    include = True
+            elif reasons:
+                include = True
+            if include:
                 acc = {"account_id": acc_id}
                 acc.update(
                     {
                         "primary_issue": data.get("primary_issue", "unknown"),
                         "issue_types": data.get("issue_types", []),
-                        "problem_reasons": data.get("problem_reasons", []),
+                        "problem_reasons": reasons,
                         "confidence": data.get("confidence", 0.0),
                         "tier": data.get("tier", 0),
-                        "decision_source": data.get("decision_source", "rules"),
+                        "decision_source": source,
                     }
                 )
                 problems.append(acc)

--- a/backend/schemas/ai_adjudication.json
+++ b/backend/schemas/ai_adjudication.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AIAdjudicateResponse",
+  "type": "object",
+  "properties": {
+    "primary_issue": {"type": "string"},
+    "tier": {"type": "string"},
+    "problem_reasons": {"type": "array", "items": {"type": "string"}},
+    "confidence": {"type": "number"},
+    "fields_used": {"type": "array", "items": {"type": "string"}},
+    "decision_source": {"type": "string"}
+  },
+  "required": ["primary_issue", "tier", "confidence", "decision_source"]
+}

--- a/tests/test_ai_models.py
+++ b/tests/test_ai_models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.core.ai.models import AIAdjudicateRequest, AIAdjudicateResponse
+
+
+def test_request_model_valid():
+    req = AIAdjudicateRequest(
+        doc_fingerprint="doc",
+        account_fingerprint="acct",
+        fields={"balance_owed": 100},
+    )
+    assert req.hierarchy_version == "v1"
+
+
+def test_response_model_valid():
+    resp = AIAdjudicateResponse(
+        primary_issue="collection",
+        tier="Tier1",
+        confidence=0.9,
+        problem_reasons=["reason"],
+        fields_used=["balance_owed"],
+    )
+    assert resp.decision_source == "ai"
+    assert resp.problem_reasons == ["reason"]
+
+
+def test_invalid_primary_issue():
+    with pytest.raises(ValidationError):
+        AIAdjudicateResponse(
+            primary_issue="bogus",  # type: ignore[arg-type]
+            tier="Tier1",
+            confidence=0.5,
+        )
+
+
+def test_missing_fields_in_request():
+    with pytest.raises(ValidationError):
+        AIAdjudicateRequest(doc_fingerprint="doc", fields={})  # type: ignore[call-arg]

--- a/tests/test_orchestrator_stageA_ai.py
+++ b/tests/test_orchestrator_stageA_ai.py
@@ -1,39 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+import backend.config as config
 from backend.core import orchestrators as orch
+from backend.core.ai.models import AIAdjudicateResponse
+from backend.core.case_store import api as cs_api
+from backend.core.logic.report_analysis import problem_detection as pd
 
 
-def test_emit_called_for_problem_accounts(monkeypatch):
-    events = []
+@pytest.fixture
+def session_case(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
+    session_id = "sess1"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    base = {
+        "balance_owed": 100.0,
+        "credit_limit": 1000.0,
+        "high_balance": 500.0,
+        "payment_status": "",
+        "account_status": "",
+        "two_year_payment_history": "",
+        "days_late_7y": "",
+    }
+    cs_api.upsert_account_fields(
+        session_id, "acc1", "Experian", dict(base, past_due_amount=0.0)
+    )
+    cs_api.upsert_account_fields(
+        session_id, "acc2", "Experian", dict(base, past_due_amount=125.0)
+    )
+    cs_api.upsert_account_fields(
+        session_id,
+        "acc3",
+        "Experian",
+        dict(base, past_due_amount=0.0, two_year_payment_history="OK,30,OK,60"),
+    )
+    return session_id
 
-    def fake_emit(event, payload):
-        events.append((event, payload))
 
-    monkeypatch.setattr(orch, "emit", fake_emit)
+def test_orchestrator_filters_ai_tiers(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
 
-    accounts = [
-        {
-            "normalized_name": "palisades fu",
-            "account_number_last4": "1234",
-            "decision_source": "ai",
-            "primary_issue": "collection",
-            "confidence": 0.83,
-            "tier": 1,
-            "problem_reasons": ["remarks"],
-        }
+    responses = [
+        AIAdjudicateResponse(
+            primary_issue="collection",
+            tier="Tier1",
+            confidence=0.9,
+            problem_reasons=["ai_reason"],
+            fields_used=["balance_owed"],
+        ),
+        AIAdjudicateResponse(
+            primary_issue="collection",
+            tier="Tier4",
+            confidence=0.9,
+            problem_reasons=["ai_reason"],
+            fields_used=["balance_owed"],
+        ),
+        None,
     ]
 
-    orch._emit_stageA_events("sess1", accounts)
-    assert events == [
-        (
-            "stageA_problem_decision",
-            {
-                "session_id": "sess1",
-                "normalized_name": "palisades fu",
-                "account_id": "1234",
-                "decision_source": "ai",
-                "primary_issue": "collection",
-                "confidence": 0.83,
-                "tier": 1,
-                "reasons_count": 1,
-            },
-        )
-    ]
+    def fake_call(session, req):
+        return responses.pop(0)
+
+    monkeypatch.setattr(pd, "call_adjudicator", fake_call)
+
+    pd.run_stage_a(session_case, [])
+    problems = orch.collect_stageA_problem_accounts(session_case, [])
+    ids = {p["account_id"] for p in problems}
+    assert ids == {"acc1", "acc3"}
+
+
+def test_orchestrator_fallback(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: None)
+
+    pd.run_stage_a(session_case, [])
+    problems = orch.collect_stageA_problem_accounts(session_case, [])
+    ids = {p["account_id"] for p in problems}
+    assert ids == {"acc2", "acc3"}

--- a/tests/test_problem_detection_ai.py
+++ b/tests/test_problem_detection_ai.py
@@ -1,75 +1,109 @@
-from importlib import reload
+from __future__ import annotations
 
-import backend.api.internal_ai as ai
-import backend.config as base_config
-import backend.core.logic.report_analysis.problem_detection as pd
+import pytest
 
-
-def _reload(monkeypatch, **env):
-    for k, v in env.items():
-        monkeypatch.setenv(k, v)
-    reload(base_config)
-    reload(ai)
-    reload(pd)
+import backend.config as config
+from backend.core.ai.models import AIAdjudicateResponse
+from backend.core.case_store import api as cs_api
+from backend.core.logic.report_analysis import problem_detection as pd
 
 
-def test_ai_high_confidence(monkeypatch):
-    def fake_adjudicate(session_id, hv, account):
-        return {
-            "primary_issue": "collection",
-            "issue_types": ["collection"],
-            "problem_reasons": ["ai"],
-            "confidence": 0.9,
-            "tier": 1,
-            "decision_source": "ai",
-            "adjudicator_version": "ai-v1",
-            "advice": None,
-            "error": None,
-        }
-
-    _reload(monkeypatch, ENABLE_AI_ADJUDICATOR="1")
-    monkeypatch.setattr(pd, "ai_adjudicate", fake_adjudicate)
-    acct = {"account_status": "Open"}
-    result = pd.evaluate_account_problem(acct)
-    assert result["primary_issue"] == "collection"
-    assert result["decision_source"] == "ai"
-    assert result["confidence"] >= 0.9
-    assert result["tier"] == 1
-    assert result["problem_reasons"]
-
-
-def test_ai_low_confidence_fallback(monkeypatch):
-    def fake_adjudicate(session_id, hv, account):
-        return {
-            "primary_issue": "collection",
-            "issue_types": ["collection"],
-            "problem_reasons": ["ai"],
-            "confidence": 0.2,
-            "tier": 1,
-            "decision_source": "ai",
-            "adjudicator_version": "ai-v1",
-            "advice": None,
-            "error": None,
-        }
-
-    _reload(monkeypatch, ENABLE_AI_ADJUDICATOR="1", AI_MIN_CONFIDENCE="0.65")
-    monkeypatch.setattr(pd, "ai_adjudicate", fake_adjudicate)
-    acct = {"account_status": "Open"}
-    result = pd.evaluate_account_problem(acct)
-    assert result["primary_issue"] == "unknown"
-    assert result["decision_source"] == "fallback_ai_low_conf"
-    assert result["confidence"] == 0
-    assert result["tier"] == 0
+@pytest.fixture
+def session_case(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
+    session_id = "sess1"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    base = {
+        "balance_owed": 100.0,
+        "credit_limit": 1000.0,
+        "high_balance": 500.0,
+        "payment_status": "",
+        "account_status": "",
+        "two_year_payment_history": "",
+        "days_late_7y": "",
+    }
+    cs_api.upsert_account_fields(
+        session_id, "acc1", "Experian", dict(base, past_due_amount=0.0)
+    )
+    cs_api.upsert_account_fields(
+        session_id, "acc2", "Experian", dict(base, past_due_amount=125.0)
+    )
+    cs_api.upsert_account_fields(
+        session_id,
+        "acc3",
+        "Experian",
+        dict(base, past_due_amount=0.0, two_year_payment_history="OK,30,OK,60"),
+    )
+    return session_id
 
 
-def test_ai_error_fallback(monkeypatch):
-    def fake_adjudicate(session_id, hv, account):
-        raise RuntimeError("boom")
+def _decision(session_id, acc_id):
+    case = cs_api.get_account_case(session_id, acc_id)
+    return case.artifacts["stageA_detection"].model_dump()
 
-    _reload(monkeypatch, ENABLE_AI_ADJUDICATOR="1")
-    monkeypatch.setattr(pd, "ai_adjudicate", fake_adjudicate)
-    acct = {"late_payments": {"exp": {"30": 1}}}
-    result = pd.evaluate_account_problem(acct)
-    assert result["decision_source"] == "fallback_ai_error"
-    assert result["confidence"] == 0
-    assert result["problem_reasons"]
+
+def test_adopt_ai(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+
+    resp = AIAdjudicateResponse(
+        primary_issue="collection",
+        tier="Tier1",
+        confidence=0.82,
+        problem_reasons=["ai_reason"],
+        fields_used=["balance_owed"],
+    )
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: resp)
+
+    pd.run_stage_a(session_case, [])
+    dec1 = _decision(session_case, "acc1")
+    assert dec1["decision_source"] == "ai"
+    assert dec1["primary_issue"] == "collection"
+    assert dec1["tier"] == "Tier1"
+    assert dec1["problem_reasons"] == ["ai_reason"]
+
+
+def test_low_confidence_fallback(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+
+    resp = AIAdjudicateResponse(
+        primary_issue="collection",
+        tier="Tier1",
+        confidence=0.4,
+        problem_reasons=["ai_reason"],
+        fields_used=["balance_owed"],
+    )
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: resp)
+
+    pd.run_stage_a(session_case, [])
+    dec2 = _decision(session_case, "acc2")
+    assert dec2["decision_source"] == "rules"
+    assert dec2["problem_reasons"] == ["past_due_amount: 125.00"]
+
+
+def test_timeout_fallback(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: None)
+
+    pd.run_stage_a(session_case, [])
+    dec3 = _decision(session_case, "acc3")
+    assert dec3["decision_source"] == "rules"
+    assert dec3["problem_reasons"] == ["late: 1×30,1×60"]
+
+
+def test_idempotent(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: None)
+
+    pd.run_stage_a(session_case, [])
+    first = _decision(session_case, "acc2")
+    pd.run_stage_a(session_case, [])
+    second = _decision(session_case, "acc2")
+    first.pop("timestamp", None)
+    second.pop("timestamp", None)
+    assert first == second


### PR DESCRIPTION
## Summary
- add typed AI adjudication models and HTTP client
- expose `/internal/ai-adjudicate` endpoint
- wire Stage A and orchestrator to adopt AI decisions with safe fallback

## Testing
- `pytest tests/test_ai_models.py tests/test_ai_endpoint.py tests/test_problem_detection_ai.py tests/test_orchestrator_stageA_ai.py -q`
- `pre-commit run --files backend/config.py backend/core/ai/models.py backend/core/ai/adjudicator_client.py backend/core/ai/service.py backend/api/ai_endpoints.py backend/api/app.py backend/core/logic/report_analysis/problem_detection.py backend/core/orchestrators.py backend/schemas/ai_adjudication.json tests/test_ai_models.py tests/test_ai_endpoint.py tests/test_problem_detection_ai.py tests/test_orchestrator_stageA_ai.py`
- `pytest -q` *(fails: extract_problematic_accounts tests, start_process tests)*

------
https://chatgpt.com/codex/tasks/task_b_68ae43a8490c832592cfaed4007cc9ab