### PR TITLE
Add JSON schema validation for AI and problem accounts

### DIFF
--- a/backend/schemas/problem_account.json
+++ b/backend/schemas/problem_account.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ProblemAccount",
+  "type": "object",
+  "required": ["account_id","bureau","primary_issue","tier","problem_reasons","confidence","decision_source"],
+  "additionalProperties": false,
+  "properties": {
+    "account_id":       {"type": "string", "minLength": 1},
+    "bureau":           {"type": "string", "enum": ["Equifax","Experian","TransUnion"]},
+    "primary_issue":    {"type": "string"},
+    "tier":             {"type": "string", "enum": ["Tier1","Tier2","Tier3","Tier4","none"]},
+    "problem_reasons":  {"type": "array", "items": {"type": "string"}},
+    "confidence":       {"type": "number", "minimum": 0.0, "maximum": 1.0},
+    "decision_source":  {"type": "string", "enum": ["rules","ai","fallback","deterministic"]},
+    "fields_used":      {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, ValidationError
+
+SCHEMA_DIR = Path('backend/schemas')
+
+def _load(name: str) -> dict:
+    with open(SCHEMA_DIR / name) as f:
+        return json.load(f)
+
+def _problem_account_base() -> dict:
+    return {
+        "account_id": "1",
+        "bureau": "Equifax",
+        "primary_issue": "collection",
+        "tier": "Tier1",
+        "problem_reasons": ["reason"],
+        "confidence": 0.9,
+        "decision_source": "ai",
+        "fields_used": ["balance_owed"],
+    }
+
+def test_happy_path_valid_accounts():
+    ai_schema = _load("ai_adjudication.json")
+    account_schema = _load("problem_account.json")
+
+    Draft7Validator(ai_schema).validate(
+        {
+            "primary_issue": "collection",
+            "tier": "Tier1",
+            "problem_reasons": ["foo"],
+            "confidence": 0.85,
+            "fields_used": ["balance_owed"],
+            "decision_source": "ai",
+        }
+    )
+
+    Draft7Validator(account_schema).validate(_problem_account_base())
+    neutral = _problem_account_base()
+    neutral.update({"account_id": "2", "tier": "none", "decision_source": "rules"})
+    Draft7Validator(account_schema).validate(neutral)
+
+def test_extra_property_fails():
+    schema = _load("problem_account.json")
+    obj = _problem_account_base()
+    obj["extra"] = True
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+def test_wrong_bureau_fails():
+    schema = _load("problem_account.json")
+    obj = _problem_account_base()
+    obj["bureau"] = "FakeBureau"
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+def test_confidence_out_of_range_fails():
+    schema = _load("problem_account.json")
+    obj = _problem_account_base()
+    obj["confidence"] = 2.0
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)


### PR DESCRIPTION
## Summary
- add JSON schema for problem accounts and enforce it in start-process endpoint
- validate AI adjudicator responses against schema
- cover problem account and AI schemas with unit tests

## Testing
- `pytest tests/test_ai_endpoint.py tests/test_schemas.py tests/test_start_process.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae487d0f708325b9e800dd27398e28