### PR TITLE
Tighten AI adjudication schema validation

### DIFF
--- a/backend/api/ai_endpoints.py
+++ b/backend/api/ai_endpoints.py
@@ -48,9 +48,13 @@ def ai_adjudicate() -> Any:
         return jsonify(payload)
     except TimeoutError:
         return jsonify({"error": "timeout"}), 504
-    except (PydanticValidationError, SchemaValidationError) as exc:
+    except (
+        json.JSONDecodeError,
+        PydanticValidationError,
+        SchemaValidationError,
+    ) as exc:
         logger.debug("ai_adjudicate_schema_failure: %s", exc)
-        return jsonify({"error": "bad_gateway"}), 502
+        return jsonify({"error": "SchemaValidationError"}), 502
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("ai_adjudicate_failure: %s", exc)
         return jsonify({"error": "bad_gateway"}), 502

--- a/backend/core/ai/adjudicator_client.py
+++ b/backend/core/ai/adjudicator_client.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
 from typing import Optional
 
 import httpx
+from jsonschema import Draft7Validator, ValidationError as SchemaValidationError
 from pydantic import ValidationError
 
 from backend.config import AI_MAX_RETRIES, AI_REQUEST_TIMEOUT_S
@@ -12,6 +14,10 @@ from backend.core.ai.models import AIAdjudicateRequest, AIAdjudicateResponse
 from backend.core.case_store.telemetry import emit
 
 AI_URL = "/internal/ai-adjudicate"
+
+SCHEMA_DIR = Path(__file__).resolve().parent.parent.parent / "schemas"
+with open(SCHEMA_DIR / "ai_adjudication.json") as _f:
+    _ai_response_validator = Draft7Validator(json.load(_f))
 
 
 def call_adjudicator(
@@ -34,6 +40,7 @@ def call_adjudicator(
             r.raise_for_status()
             data = r.json()
             resp = AIAdjudicateResponse.model_validate(data)
+            _ai_response_validator.validate(resp.model_dump())
             dur = (time.perf_counter() - t0) * 1000
             emit(
                 "stageA_ai_call",
@@ -48,6 +55,7 @@ def call_adjudicator(
             httpx.HTTPError,
             json.JSONDecodeError,
             ValidationError,
+            SchemaValidationError,
         ) as e:
             status = e.__class__.__name__
             dur = (time.perf_counter() - t0) * 1000

--- a/backend/core/ai/models.py
+++ b/backend/core/ai/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal
 
-from pydantic import BaseModel, Field, confloat, constr
+from pydantic import BaseModel, ConfigDict, Field, confloat, constr
 
 PrimaryIssue = Literal[
     "collection",
@@ -21,6 +21,8 @@ Tier = Literal["Tier1", "Tier2", "Tier3", "Tier4", "none"]
 
 
 class AIAdjudicateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     doc_fingerprint: constr(strip_whitespace=True)
     account_fingerprint: constr(strip_whitespace=True)
     hierarchy_version: constr(strip_whitespace=True) = "v1"
@@ -28,11 +30,17 @@ class AIAdjudicateRequest(BaseModel):
 
 
 class AIAdjudicateResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     primary_issue: PrimaryIssue
     tier: Tier
-    problem_reasons: List[str] = Field(default_factory=list)
+    problem_reasons: List[constr(strip_whitespace=True, max_length=200)] = Field(
+        default_factory=list, min_length=0, max_length=10
+    )
     confidence: confloat(ge=0.0, le=1.0)
-    fields_used: List[str] = Field(default_factory=list)
+    fields_used: List[
+        constr(strip_whitespace=True, pattern=r"^[a-z0-9_]+$", max_length=64)
+    ] = Field(default_factory=list, min_length=0, max_length=12)
     decision_source: Literal["ai"] = "ai"
 
 

--- a/backend/schemas/ai_adjudication.json
+++ b/backend/schemas/ai_adjudication.json
@@ -2,13 +2,55 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AIAdjudicateResponse",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
-    "primary_issue": {"type": "string"},
-    "tier": {"type": "string"},
-    "problem_reasons": {"type": "array", "items": {"type": "string"}},
-    "confidence": {"type": "number"},
-    "fields_used": {"type": "array", "items": {"type": "string"}},
-    "decision_source": {"type": "string"}
+    "primary_issue": {
+      "type": "string",
+      "enum": [
+        "collection",
+        "charge_off",
+        "bankruptcy",
+        "repossession",
+        "foreclosure",
+        "severe_delinquency",
+        "derogatory",
+        "high_utilization",
+        "none",
+        "unknown"
+      ]
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["Tier1", "Tier2", "Tier3", "Tier4", "none"]
+    },
+    "problem_reasons": {
+      "type": "array",
+      "items": {"type": "string", "maxLength": 200},
+      "minItems": 0,
+      "maxItems": 10
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "fields_used": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[a-z0-9_]+$", "maxLength": 64},
+      "minItems": 0,
+      "maxItems": 12
+    },
+    "decision_source": {
+      "type": "string",
+      "enum": ["ai"]
+    }
   },
-  "required": ["primary_issue", "tier", "confidence", "decision_source"]
+  "required": [
+    "primary_issue",
+    "tier",
+    "problem_reasons",
+    "confidence",
+    "fields_used",
+    "decision_source"
+  ]
 }

--- a/tests/test_problem_detection_ai.py
+++ b/tests/test_problem_detection_ai.py
@@ -95,6 +95,19 @@ def test_timeout_fallback(monkeypatch, session_case):
     assert dec3["problem_reasons"] == ["late: 1×30,1×60"]
 
 
+def test_schema_reject_fallback(monkeypatch, session_case):
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+
+    monkeypatch.setattr(pd, "call_adjudicator", lambda session, req: None)
+
+    pd.run_stage_a(session_case, [])
+    dec = _decision(session_case, "acc1")
+    assert dec["decision_source"] == "rules"
+    assert dec["tier"] == "none"
+    assert dec["problem_reasons"] == []
+
+
 def test_idempotent(monkeypatch, session_case):
     monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
     monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft7Validator, ValidationError
 
-SCHEMA_DIR = Path('backend/schemas')
+SCHEMA_DIR = Path("backend/schemas")
+
 
 def _load(name: str) -> dict:
     with open(SCHEMA_DIR / name) as f:
         return json.load(f)
+
 
 def _problem_account_base() -> dict:
     return {
@@ -21,6 +23,18 @@ def _problem_account_base() -> dict:
         "decision_source": "ai",
         "fields_used": ["balance_owed"],
     }
+
+
+def _ai_base() -> dict:
+    return {
+        "primary_issue": "collection",
+        "tier": "Tier1",
+        "problem_reasons": ["foo"],
+        "confidence": 0.9,
+        "fields_used": ["balance_owed"],
+        "decision_source": "ai",
+    }
+
 
 def test_happy_path_valid_accounts():
     ai_schema = _load("ai_adjudication.json")
@@ -42,12 +56,14 @@ def test_happy_path_valid_accounts():
     neutral.update({"account_id": "2", "tier": "none", "decision_source": "rules"})
     Draft7Validator(account_schema).validate(neutral)
 
+
 def test_extra_property_fails():
     schema = _load("problem_account.json")
     obj = _problem_account_base()
     obj["extra"] = True
     with pytest.raises(ValidationError):
         Draft7Validator(schema).validate(obj)
+
 
 def test_wrong_bureau_fails():
     schema = _load("problem_account.json")
@@ -56,9 +72,58 @@ def test_wrong_bureau_fails():
     with pytest.raises(ValidationError):
         Draft7Validator(schema).validate(obj)
 
+
 def test_confidence_out_of_range_fails():
     schema = _load("problem_account.json")
     obj = _problem_account_base()
     obj["confidence"] = 2.0
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_extra_property_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["extra"] = True
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_bad_tier_enum_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["tier"] = "TIER1"
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_bad_primary_issue_enum_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["primary_issue"] = "bogus"
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_too_many_problem_reasons_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["problem_reasons"] = ["r"] * 11
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_fields_used_illegal_chars_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["fields_used"] = ["Payment Status"]
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(obj)
+
+
+def test_ai_confidence_out_of_range_fails():
+    schema = _load("ai_adjudication.json")
+    obj = _ai_base()
+    obj["confidence"] = 1.5
     with pytest.raises(ValidationError):
         Draft7Validator(schema).validate(obj)


### PR DESCRIPTION
## Summary
- enforce strict enum and bounds in `ai_adjudication` schema, forbidding extra properties
- align Pydantic models and client/endpoint validation to new schema
- add tests for schema strictness and Stage A fallback

## Testing
- `pre-commit run --files backend/schemas/ai_adjudication.json backend/core/ai/models.py backend/api/ai_endpoints.py backend/core/ai/adjudicator_client.py tests/test_schemas.py tests/test_ai_endpoint.py tests/test_problem_detection_ai.py`
- `pytest tests/test_schemas.py tests/test_ai_endpoint.py tests/test_problem_detection_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae4fed07a4832581a9c8c5c93fb8b6