### PR TITLE
feat: add decision badges with chips and telemetry

### DIFF
--- a/frontend/src/__tests__/ReviewPage.ui2.test.jsx
+++ b/frontend/src/__tests__/ReviewPage.ui2.test.jsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ReviewPage from '../pages/ReviewPage';
+import { emitUiEvent } from '../telemetry/uiTelemetry';
+
+jest.mock('../telemetry/uiTelemetry', () => ({
+  emitUiEvent: jest.fn(),
+}));
+jest.mock('../api', () => ({
+  submitExplanations: jest.fn(),
+  getSummaries: jest.fn().mockResolvedValue({ summaries: {} }),
+}));
+
+const baseUploadData = {
+  session_id: 'sess1',
+  filename: 'file.pdf',
+  email: 'test@example.com',
+};
+
+beforeEach(() => {
+  process.env.REACT_APP_UI_DECISION_BADGES = 'true';
+  process.env.REACT_APP_UI_MAX_REASON_CHIPS = '4';
+  process.env.REACT_APP_UI_CONFIDENCE_DECIMALS = '2';
+  process.env.REACT_APP_UI_SHOW_FIELDS_USED = 'false';
+  jest.clearAllMocks();
+});
+
+test('AI account shows badge, tier colors, confidence tooltip and chips', async () => {
+  const acc = {
+    account_id: 'a1',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+    problem_reasons: ['late_payment'],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+    decision_meta: {
+      decision_source: 'ai',
+      tier: 'Tier1',
+      confidence: 0.82,
+      fields_used: ['payment_status'],
+    },
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const badge = await screen.findByText('AI decision');
+  expect(badge).toHaveClass('bg-red-100');
+  expect(screen.getByTitle('AI confidence: 0.82')).toBeInTheDocument();
+  expect(screen.getByText('late_payment')).toHaveClass('chip');
+});
+
+test('rules account shows rule-based badge and tooltip', async () => {
+  const acc = {
+    account_id: 'a2',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+    problem_reasons: ['over_limit'],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText('Rule-based')).toBeInTheDocument();
+  expect(screen.getByTitle('No AI used (rules-only)')).toBeInTheDocument();
+});
+
+test('chips truncation with +N more', async () => {
+  const acc = {
+    account_id: 'a3',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+    problem_reasons: ['r1','r2','r3','r4','r5','r6','r7'],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  const { container } = render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const chips = container.querySelectorAll('.chip');
+  expect(chips.length).toBe(5); // 4 + "more"
+  expect(screen.getByText('+3')).toBeInTheDocument();
+});
+
+test('flag off hides badges and tooltip', async () => {
+  process.env.REACT_APP_UI_DECISION_BADGES = 'false';
+  const acc = {
+    account_id: 'a4',
+    bureau: 'Equifax',
+    decision_source: 'ai',
+    tier: 'Tier2',
+    confidence: 0.5,
+    problem_reasons: ['reason'],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(screen.queryByText('AI decision')).not.toBeInTheDocument();
+  expect(screen.queryByTitle(/AI confidence/i)).not.toBeInTheDocument();
+  expect(screen.getByText('reason')).toBeInTheDocument();
+});
+
+test('PII strings rendered plainly', async () => {
+  const acc = {
+    account_id: 'a5',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+    problem_reasons: ['user@example.com','555-123-4567','123-45-6789'],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText('user@example.com')).toBeInTheDocument();
+  expect(screen.getByText('555-123-4567')).toBeInTheDocument();
+  expect(screen.getByText('123-45-6789')).toBeInTheDocument();
+});
+
+test('telemetry emitted on expand', async () => {
+  const acc = {
+    account_id: 'a6',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+    problem_reasons: [],
+    primary_issue: 'collection',
+    issue_types: ['collection'],
+  };
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [acc] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const toggle = await screen.findByLabelText(/Show how the system understood/i);
+  fireEvent.click(toggle);
+  expect(emitUiEvent).toHaveBeenCalledWith('ui_review_expand', {
+    session_id: 'sess1',
+    account_id: 'a6',
+    bureau: 'Equifax',
+    decision_source: 'rules',
+    tier: 'none',
+  });
+});

--- a/frontend/src/components/ConfidenceTooltip.jsx
+++ b/frontend/src/components/ConfidenceTooltip.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function ConfidenceTooltip({ decisionSource, confidence, fieldsUsed, showFieldsUsed = false, decimals = 2 }) {
+  let lines = [];
+  if (decisionSource === 'ai') {
+    const value = Number(confidence);
+    if (!Number.isNaN(value)) {
+      lines.push(`AI confidence: ${value.toFixed(decimals)}`);
+    } else {
+      lines.push('AI confidence: N/A');
+    }
+  } else {
+    lines.push('No AI used (rules-only)');
+  }
+  if (showFieldsUsed && Array.isArray(fieldsUsed) && fieldsUsed.length > 0) {
+    lines.push(`Fields used: ${fieldsUsed.join(', ')}`);
+  }
+  return (
+    <span className="info-icon" title={lines.join('\n')}>
+      ℹ️
+    </span>
+  );
+}

--- a/frontend/src/components/DecisionBadge.jsx
+++ b/frontend/src/components/DecisionBadge.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { tierColors } from '../utils/tierColors';
+
+export default function DecisionBadge({ decisionSource, tier }) {
+  const colors = tierColors[tier] || tierColors.none;
+  const label = decisionSource === 'ai'
+    ? 'AI decision'
+    : decisionSource === 'rules'
+    ? 'Rule-based'
+    : 'Unknown';
+  const classes = `inline-flex items-center text-xs font-medium rounded ${colors.bg} ${colors.text} border-l-4 ${colors.border} pl-2 pr-2 py-1`;
+  return <span className={classes}>{label}</span>;
+}

--- a/frontend/src/components/ReasonChips.jsx
+++ b/frontend/src/components/ReasonChips.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function truncate(str) {
+  return str.length > 48 ? str.slice(0, 45) + '...' : str;
+}
+
+export default function ReasonChips({ reasons = [], max = 4 }) {
+  if (!reasons || reasons.length === 0) return null;
+  const chips = reasons.slice(0, max).map((r, i) => (
+    <span key={i} className="chip">
+      {truncate(r)}
+    </span>
+  ));
+  const extra = reasons.length - max;
+  if (extra > 0) {
+    chips.push(
+      <span key="more" className="chip" title={reasons.slice(max).join(', ')}>
+        +{extra}
+      </span>
+    );
+  }
+  return <div className="reason-chips">{chips}</div>;
+}

--- a/frontend/src/telemetry/uiTelemetry.js
+++ b/frontend/src/telemetry/uiTelemetry.js
@@ -1,0 +1,3 @@
+export const emitUiEvent = (event, payload) => {
+  console.debug('telemetry', event, payload);
+};

--- a/frontend/src/utils/tierColors.js
+++ b/frontend/src/utils/tierColors.js
@@ -1,0 +1,7 @@
+export const tierColors = {
+  Tier1: { bg: 'bg-red-100', text: 'text-red-800', border: 'border-red-300' },
+  Tier2: { bg: 'bg-orange-100', text: 'text-orange-800', border: 'border-orange-300' },
+  Tier3: { bg: 'bg-yellow-100', text: 'text-yellow-800', border: 'border-yellow-300' },
+  Tier4: { bg: 'bg-gray-100', text: 'text-gray-800', border: 'border-gray-300' },
+  none:  { bg: 'bg-slate-100', text: 'text-slate-700', border: 'border-slate-300' },
+};


### PR DESCRIPTION
## Summary
- surface decision source, tier accents, and confidence tooltip on review cards
- show concise reason chips with "+N" overflow
- emit `ui_review_expand` telemetry on card expansion

## Testing
- `npm test -- ReviewPage.test.jsx __tests__/ReviewPage.ui2.test.jsx`

------
https://chatgpt.com/codex/tasks/task_b_68ae5563b1748325adc49cf33d817b6b