### PR TITLE
feat: add dev debug panel and telemetry

### DIFF
--- a/frontend/src/__tests__/ReviewPage.debug.test.jsx
+++ b/frontend/src/__tests__/ReviewPage.debug.test.jsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ReviewPage from '../pages/ReviewPage';
+import { emitUiEvent } from '../telemetry/uiTelemetry';
+
+jest.mock('../telemetry/uiTelemetry', () => ({
+  emitUiEvent: jest.fn(),
+}));
+jest.mock('../api', () => ({
+  submitExplanations: jest.fn(),
+  getSummaries: jest.fn().mockResolvedValue({ summaries: {} }),
+}));
+
+const baseUploadData = {
+  session_id: 'sess1',
+  filename: 'file.pdf',
+  email: 'test@example.com',
+};
+
+const account = {
+  account_id: 'acc1',
+  bureau: 'Equifax',
+  name: 'Account 1',
+  normalized_name: 'account 1',
+  primary_issue: 'late_payment',
+  issue_types: ['late_payment'],
+  decision_meta: {
+    decision_source: 'ai',
+    tier: 'Tier1',
+    confidence: 0.91,
+    fields_used: ['f1', 'f2', 'f3'],
+  },
+  stage_a_decision: { result: 'ok' },
+  problem_reasons: ['late_payment'],
+};
+
+beforeEach(() => {
+  process.env.REACT_APP_UI_DEV_DEBUG_PANEL = 'true';
+  process.env.REACT_APP_UI_SHOW_FIELDS_USED = 'true';
+  process.env.REACT_APP_UI_MAX_FIELDS_USED = '2';
+  jest.clearAllMocks();
+});
+
+test('debug panel shows meta and capped fields', async () => {
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [account] } };
+  const { container } = render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const toggle = await screen.findByText('Debug');
+  fireEvent.click(toggle);
+  expect(screen.getByText(/source:/)).toHaveTextContent('ai');
+  expect(screen.getByText(/tier:/)).toHaveTextContent('Tier1');
+  expect(screen.getByText(/confidence:/)).toHaveTextContent('0.91');
+  expect(screen.getByText('f1')).toBeInTheDocument();
+  expect(screen.getByText('f2')).toBeInTheDocument();
+  expect(screen.queryByText('f3')).not.toBeInTheDocument();
+  const panel = container.querySelector('.debug-panel');
+  expect(panel).toMatchSnapshot();
+  const text = panel.textContent;
+  expect(text).not.toMatch(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/);
+  expect(text).not.toMatch(/\b\d{3}-\d{2}-\d{4}\b/);
+  expect(text).not.toMatch(/\b\d{3}-\d{3}-\d{4}\b/);
+});
+
+test('debug panel hidden when flag off', async () => {
+  process.env.REACT_APP_UI_DEV_DEBUG_PANEL = 'false';
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [account] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  expect(screen.queryByText('Debug')).not.toBeInTheDocument();
+});
+
+test('telemetry fires on expand and collapse', async () => {
+  const uploadData = { ...baseUploadData, accounts: { problem_accounts: [account] } };
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/review', state: { uploadData } }]}> 
+      <ReviewPage />
+    </MemoryRouter>
+  );
+  const toggle = await screen.findByLabelText(/Show how the system understood/i);
+  fireEvent.click(toggle);
+  expect(emitUiEvent).toHaveBeenCalledWith('ui_review_expand', {
+    session_id: 'sess1',
+    account_id: 'acc1',
+    bureau: 'Equifax',
+    decision_source: 'ai',
+    tier: 'Tier1',
+  });
+  fireEvent.click(toggle);
+  expect(emitUiEvent).toHaveBeenCalledWith('ui_review_collapse', {
+    session_id: 'sess1',
+    account_id: 'acc1',
+    bureau: 'Equifax',
+  });
+});
+

--- a/frontend/src/__tests__/__snapshots__/ReviewPage.debug.test.jsx.snap
+++ b/frontend/src/__tests__/__snapshots__/ReviewPage.debug.test.jsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`debug panel shows meta and capped fields 1`] = `
+<details
+  class="debug-panel"
+  open=""
+>
+  <summary>
+    Debug
+  </summary>
+  <div
+    class="decision-meta"
+  >
+    <div>
+      source: 
+      ai
+    </div>
+    <div>
+      tier: 
+      Tier1
+    </div>
+    <div>
+      confidence: 
+      0.91
+    </div>
+  </div>
+  <div
+    class="fields-used"
+  >
+    <div>
+      fields_used:
+    </div>
+    <ul>
+      <li>
+        f1
+      </li>
+      <li>
+        f2
+      </li>
+    </ul>
+  </div>
+  <pre
+    class="debug-json"
+  >
+    {
+  "result": "ok"
+}
+  </pre>
+</details>
+`;

--- a/frontend/src/components/DecisionDebugPanel.jsx
+++ b/frontend/src/components/DecisionDebugPanel.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+export default function DecisionDebugPanel({ meta, decision }) {
+  const showPanel =
+    (process.env.NODE_ENV !== 'production'
+      ? process.env.REACT_APP_UI_DEV_DEBUG_PANEL !== 'false'
+      : process.env.REACT_APP_UI_DEV_DEBUG_PANEL === 'true');
+
+  if (!showPanel) {
+    return null;
+  }
+
+  const showFields = process.env.REACT_APP_UI_SHOW_FIELDS_USED === 'true';
+  const maxFields = Number(process.env.REACT_APP_UI_MAX_FIELDS_USED || 8);
+  const fields = meta?.fields_used ? meta.fields_used.slice(0, maxFields) : [];
+  const source = meta?.decision_source ?? meta?.source;
+  const tier = meta?.tier;
+  const confidence = meta?.confidence;
+
+  // determine which decision artifact to show
+  const stageADecision =
+    decision?.stageA_decision ||
+    decision?.stage_a_decision ||
+    decision?.decision_json ||
+    decision?.decision ||
+    decision;
+
+  return (
+    <details className="debug-panel">
+      <summary>Debug</summary>
+      {meta && (
+        <div className="decision-meta">
+          <div>source: {source}</div>
+          <div>tier: {tier}</div>
+          <div>confidence: {confidence}</div>
+        </div>
+      )}
+      {showFields && fields.length > 0 && (
+        <div className="fields-used">
+          <div>fields_used:</div>
+          <ul>
+            {fields.map((f) => (
+              <li key={f}>{f}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {stageADecision && (
+        <pre className="debug-json">
+          {JSON.stringify(stageADecision, null, 2)}
+        </pre>
+      )}
+    </details>
+  );
+}
+

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -4,6 +4,7 @@ import { submitExplanations, getSummaries } from '../api';
 import DecisionBadge from '../components/DecisionBadge';
 import ReasonChips from '../components/ReasonChips';
 import ConfidenceTooltip from '../components/ConfidenceTooltip';
+import DecisionDebugPanel from '../components/DecisionDebugPanel';
 import { emitUiEvent } from '../telemetry/uiTelemetry';
 
 export default function ReviewPage() {
@@ -136,6 +137,12 @@ export default function ReviewPage() {
               decision_source: source,
               tier,
             });
+          } else {
+            emitUiEvent('ui_review_collapse', {
+              session_id: uploadData.session_id,
+              account_id: acc.account_id,
+              bureau: acc.bureau,
+            });
           }
         };
         return (
@@ -207,6 +214,7 @@ export default function ReviewPage() {
                 </pre>
               </details>
             )}
+            <DecisionDebugPanel meta={acc.decision_meta} decision={acc} />
           </div>
         );
       })}

--- a/frontend/src/telemetry/uiTelemetry.js
+++ b/frontend/src/telemetry/uiTelemetry.js
@@ -1,3 +1,18 @@
 export const emitUiEvent = (event, payload) => {
-  console.debug('telemetry', event, payload);
+  const body = { event, ...payload };
+  console.debug('telemetry', body);
+  try {
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      navigator.sendBeacon('/api/ui-event', JSON.stringify(body));
+    } else if (typeof fetch === 'function') {
+      fetch('/api/ui-event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch {
+    // ignore telemetry errors
+  }
 };


### PR DESCRIPTION
## Summary
- add flag-gated DecisionDebugPanel to view decision meta, fields used and Stage A JSON
- emit ui_review_expand/ui_review_collapse telemetry events with network beacon
- add unit tests for debug panel and telemetry

## Testing
- `npm test -- ReviewPage.debug.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68ae56cc63e88325830c1a7431234fdd