### PR TITLE
C-1: add centralized problem taxonomy

### DIFF
--- a/backend/core/taxonomy/__init__.py
+++ b/backend/core/taxonomy/__init__.py
@@ -1,0 +1,21 @@
+"""Taxonomy helpers for problem tiers."""
+
+from .problem_taxonomy import (
+    issue_to_tier,
+    compare_tiers,
+    strongest_tier,
+    clamp_issue,
+    normalize_decision,
+    PrimaryIssue,
+    Tier,
+)
+
+__all__ = [
+    "issue_to_tier",
+    "compare_tiers",
+    "strongest_tier",
+    "clamp_issue",
+    "normalize_decision",
+    "PrimaryIssue",
+    "Tier",
+]

--- a/backend/core/taxonomy/problem_taxonomy.py
+++ b/backend/core/taxonomy/problem_taxonomy.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+"""Problem taxonomy helpers.
+
+This module provides a single source of truth for mapping problem
+``primary_issue`` values to tiers and utilities for working with them.
+"""
+
+from typing import List, Dict, Any, Optional, Literal, cast
+
+PrimaryIssue = Literal[
+    "bankruptcy",
+    "charge_off",
+    "collection",
+    "repossession",
+    "foreclosure",
+    "severe_delinquency",
+    "moderate_delinquency",
+    "derogatory",
+    "high_utilization",
+    "none",
+    "unknown",
+]
+
+Tier = Literal["Tier1", "Tier2", "Tier3", "Tier4", "none"]
+
+# Mapping of canonical issue -> tier
+ISSUE_TIER_MAP: Dict[str, Tier] = {
+    "bankruptcy": "Tier1",
+    "charge_off": "Tier1",
+    "collection": "Tier1",
+    "repossession": "Tier1",
+    "foreclosure": "Tier1",
+    "severe_delinquency": "Tier2",
+    "moderate_delinquency": "Tier3",
+    "derogatory": "Tier3",
+    "high_utilization": "Tier4",
+    "none": "none",
+    "unknown": "none",
+}
+
+# Ranking used to compare tiers
+_TIER_RANK = {"Tier1": 4, "Tier2": 3, "Tier3": 2, "Tier4": 1, "none": 0}
+
+# Aliases for clamping non canonical issue strings
+_ISSUE_ALIASES: Dict[str, str] = {
+    "chargeoff": "charge_off",
+    "repo": "repossession",
+    "moderate_deliquency": "moderate_delinquency",  # common misspelling
+}
+
+
+def clamp_issue(issue: str) -> PrimaryIssue:
+    """Coerce a freeform issue string into the canonical enum.
+
+    Any unknown value resolves to ``"unknown"``.
+    """
+
+    if not isinstance(issue, str):
+        return cast(PrimaryIssue, "unknown")
+
+    key = issue.strip().lower()
+    key = _ISSUE_ALIASES.get(key, key)
+    if key in ISSUE_TIER_MAP:
+        return cast(PrimaryIssue, key)
+    return cast(PrimaryIssue, "unknown")
+
+
+def issue_to_tier(issue: str) -> Tier:
+    """Map a primary issue to its tier."""
+
+    canonical = clamp_issue(issue)
+    return ISSUE_TIER_MAP.get(canonical, "none")
+
+
+def compare_tiers(a: Tier, b: Tier) -> Tier:
+    """Return the stronger of two tiers."""
+
+    return a if _TIER_RANK[a] >= _TIER_RANK[b] else b
+
+
+def strongest_tier(issues: List[str]) -> Tier:
+    """Compute the strongest tier across a list of issues."""
+
+    current: Tier = "none"
+    for issue in issues:
+        current = compare_tiers(current, issue_to_tier(issue))
+    return current
+
+
+def _dedupe_reasons(reasons: List[str]) -> List[str]:
+    seen = set()
+    result: List[str] = []
+    for reason in reasons:
+        if reason is None:
+            continue
+        r = str(reason)[:200]
+        if r in seen:
+            continue
+        seen.add(r)
+        result.append(r)
+        if len(result) >= 10:
+            break
+    return result
+
+
+def normalize_decision(decision: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a decision dict into canonical enums and tiers.
+
+    Parameters
+    ----------
+    decision:
+        Dictionary containing keys such as ``primary_issue``, ``tier``,
+        ``decision_source``, ``problem_reasons`` and ``confidence``.
+    """
+
+    normalized = dict(decision)  # shallow copy to avoid mutating caller input
+
+    primary_issue = clamp_issue(normalized.get("primary_issue", "unknown"))
+    normalized["primary_issue"] = primary_issue
+
+    if primary_issue in {"unknown", "none"}:
+        tier: Tier = "none"
+    else:
+        tier = issue_to_tier(primary_issue)
+    normalized["tier"] = tier
+
+    # Normalize decision source to 'ai' or 'rules'
+    decision_source = normalized.get("decision_source", "ai")
+    normalized["decision_source"] = "rules" if decision_source == "rules" else "ai"
+
+    # Dedupe and trim problem reasons
+    reasons = normalized.get("problem_reasons") or []
+    if not isinstance(reasons, list):
+        reasons = [str(reasons)]
+    normalized["problem_reasons"] = _dedupe_reasons(reasons)
+
+    # Clamp confidence
+    confidence = normalized.get("confidence", 0.0)
+    try:
+        confidence_f = float(confidence)
+    except (TypeError, ValueError):
+        confidence_f = 0.0
+    confidence_f = max(0.0, min(1.0, confidence_f))
+    normalized["confidence"] = confidence_f
+
+    return normalized

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,97 @@
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.core.taxonomy import (
+    issue_to_tier,
+    compare_tiers,
+    strongest_tier,
+    normalize_decision,
+)
+
+
+def contains_pii(text: str) -> bool:
+    pii_regex = re.compile(
+        r"("  # email
+        r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"  # noqa: W605
+        r"|\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b"  # phone
+        r"|\b\d{3}-\d{2}-\d{4}\b"  # ssn
+        r"|\b\d{9,}\b"  # long digit run
+        r")"
+    )
+    return bool(pii_regex.search(text))
+
+
+def test_issue_to_tier_mapping():
+    cases = {
+        "bankruptcy": "Tier1",
+        "charge_off": "Tier1",
+        "collection": "Tier1",
+        "repossession": "Tier1",
+        "foreclosure": "Tier1",
+        "severe_delinquency": "Tier2",
+        "moderate_delinquency": "Tier3",
+        "derogatory": "Tier3",
+        "high_utilization": "Tier4",
+        "none": "none",
+        "unknown": "none",
+    }
+    for issue, tier in cases.items():
+        assert issue_to_tier(issue) == tier
+
+
+def test_tier_comparisons_and_strongest():
+    assert compare_tiers("Tier1", "Tier2") == "Tier1"
+    assert compare_tiers("Tier4", "Tier3") == "Tier3"
+    assert compare_tiers("none", "Tier2") == "Tier2"
+
+    assert strongest_tier(["high_utilization"]) == "Tier4"
+    assert strongest_tier(["moderate_delinquency", "high_utilization"]) == "Tier3"
+    assert strongest_tier(["collection", "high_utilization", "derogatory"]) == "Tier1"
+    assert strongest_tier([]) == "none"
+
+
+def test_normalize_decision_recomputes_and_clamps():
+    reasons = [
+        "dup",
+        "dup",
+        "x" * 250,
+    ] + [f"r{i}" for i in range(15)]
+    decision = {
+        "primary_issue": "collection",
+        "tier": "Tier3",
+        "decision_source": "ai",
+        "problem_reasons": reasons,
+        "confidence": 1.5,
+    }
+    norm = normalize_decision(decision)
+    assert norm["primary_issue"] == "collection"
+    assert norm["tier"] == "Tier1"  # recomputed
+    assert norm["decision_source"] == "ai"
+    assert norm["confidence"] == 1.0
+
+    # reasons deduped, trimmed and capped
+    assert norm["problem_reasons"][0] == "dup"
+    assert len(norm["problem_reasons"][1]) == 200
+    assert len(norm["problem_reasons"]) == 10
+    assert norm["problem_reasons"].count("dup") == 1
+
+    assert not contains_pii(str(norm))
+
+
+def test_normalize_decision_unknown_and_negative_confidence():
+    decision = {
+        "primary_issue": "gibberish",
+        "tier": "Tier1",
+        "decision_source": "rules",
+        "problem_reasons": ["ok"],
+        "confidence": -0.2,
+    }
+    norm = normalize_decision(decision)
+    assert norm["primary_issue"] == "unknown"
+    assert norm["tier"] == "none"
+    assert norm["decision_source"] == "rules"
+    assert norm["confidence"] == 0.0
+    assert not contains_pii(str(norm))


### PR DESCRIPTION
## Summary
- add backend taxonomy module mapping problem issues to tiers and helper utilities
- normalize decision objects with issue clamping, tier recompute, reason dedupe and confidence clamp
- test tier mapping, comparison, normalization, and PII checks

## Testing
- `pytest tests/test_taxonomy.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae60bad210832584fbad78c876fe94