### PR TITLE
feat: aggregate Stage A decisions across bureaus

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -158,7 +158,7 @@ def start_process():
         )
 
         try:
-            problem_accounts = orch.collect_stageA_problem_accounts(session_id)
+            problem_accounts = orch.collect_stageA_logical_accounts(session_id)
         except Exception:
             logger.warning(
                 "collect_stageA_problem_accounts_failed session=%s", session_id,


### PR DESCRIPTION
## Summary
- aggregate Stage A problem accounts into logical accounts when cross-bureau flag enabled
- use resolved logical accounts in `/api/start-process`
- add integration tests covering cross-bureau aggregation behaviour

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c /dev/null tests/test_start_process_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae6432e62883259aae14b0067a30aa