### PR TITLE
Add UI telemetry ingest endpoint

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -29,6 +29,7 @@ from backend.analytics.batch_runner import BatchFilters, BatchRunner
 from backend.api.admin import admin_bp
 from backend.api.ai_endpoints import ai_bp
 from backend.api.auth import require_api_key_or_role
+from backend.api.ui_events import ui_event_bp
 from backend.api.config import ENABLE_BATCH_RUNNER, get_app_config
 from backend.api.session_manager import (
     get_session,
@@ -312,6 +313,7 @@ def create_app() -> Flask:
     app.register_blueprint(admin_bp)
     app.register_blueprint(api_bp)
     app.register_blueprint(ai_bp)
+    app.register_blueprint(ui_event_bp)
 
     @app.before_request
     def _load_config() -> None:

--- a/backend/api/ui_events.py
+++ b/backend/api/ui_events.py
@@ -1,0 +1,62 @@
+"""Endpoint for ingesting UI telemetry events."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+from jsonschema import Draft7Validator, ValidationError
+
+from backend.api.config import env_int, env_list
+from backend.core.telemetry.ui_ingest import emit
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schemas"
+with open(SCHEMA_DIR / "ui_event.json") as _f:
+    _validator = Draft7Validator(json.load(_f))
+
+UI_EVENT_MAX_BODY_BYTES = env_int("UI_EVENT_MAX_BODY_BYTES", 4096)
+UI_EVENT_ACCEPTED_TYPES = env_list("UI_EVENT_ACCEPTED_TYPES") or [
+    "ui_review_expand",
+    "ui_review_collapse",
+]
+
+ui_event_bp = Blueprint("ui_event", __name__)
+
+
+@ui_event_bp.post("/api/ui-event")
+def receive_ui_event() -> Any:
+    """Validate and forward UI telemetry events."""
+    if request.content_length and request.content_length > UI_EVENT_MAX_BODY_BYTES:
+        return "", 413
+    try:
+        data = request.get_json(force=True) or {}
+    except Exception:
+        return jsonify({"error": "SchemaValidationError"}), 400
+    try:
+        _validator.validate(data)
+    except ValidationError:
+        return jsonify({"error": "SchemaValidationError"}), 400
+    if data["type"] not in UI_EVENT_ACCEPTED_TYPES:
+        return jsonify({"error": "SchemaValidationError"}), 400
+
+    emit(
+        data["type"],
+        session_id=data["session_id"],
+        account_id=data["payload"]["account_id"],
+        bureau=data["payload"]["bureau"],
+        decision_source=data["payload"].get("decision_source"),
+        tier=data["payload"].get("tier"),
+        ts=data["ts"],
+    )
+    logger.info(
+        "ui_event_validated type=%s session=%s account=%s bureau=%s",
+        data["type"],
+        data["session_id"],
+        data["payload"]["account_id"],
+        data["payload"]["bureau"],
+    )
+    return "", 204

--- a/backend/core/telemetry/ui_ingest.py
+++ b/backend/core/telemetry/ui_ingest.py
@@ -1,0 +1,11 @@
+"""UI telemetry ingestion helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from .emit import emit as telemetry_emit
+
+
+def emit(event_type: str, **fields: Any) -> None:
+    """Forward a UI telemetry event to the core telemetry emitter."""
+    telemetry_emit(event_type, fields)

--- a/backend/schemas/ui_event.json
+++ b/backend/schemas/ui_event.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "ts", "session_id", "payload"],
+  "properties": {
+    "type": { "type": "string", "enum": ["ui_review_expand", "ui_review_collapse"] },
+    "ts":   { "type": "string", "format": "date-time" },
+    "session_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["account_id", "bureau"],
+      "properties": {
+        "account_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "bureau":     { "type": "string", "minLength": 2, "maxLength": 32 },
+        "decision_source": { "type": "string", "enum": ["ai", "rules"] },
+        "tier": { "type": "string", "enum": ["Tier1","Tier2","Tier3","Tier4","none"] }
+      }
+    }
+  }
+}

--- a/tests/test_ui_event_api.py
+++ b/tests/test_ui_event_api.py
@@ -1,0 +1,98 @@
+import json
+import re
+
+import pytest
+
+from backend.api.app import create_app
+from backend.core.telemetry import ui_ingest
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_RE = re.compile(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b")
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+def _assert_no_pii(events):
+    payload = json.dumps([fields for _, fields in events])
+    for pat in (EMAIL_RE, PHONE_RE, SSN_RE):
+        assert not pat.search(payload)
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+def test_ui_event_happy_path(app, monkeypatch):
+    client = app.test_client()
+    events = []
+    monkeypatch.setattr(ui_ingest, "telemetry_emit", lambda e, p: events.append((e, p)))
+    payload = {
+        "type": "ui_review_expand",
+        "ts": "2024-01-01T00:00:00Z",
+        "session_id": "sess1",
+        "payload": {
+            "account_id": "acc1",
+            "bureau": "Experian",
+            "decision_source": "ai",
+            "tier": "Tier1",
+        },
+    }
+    resp = client.post("/api/ui-event", json=payload)
+    assert resp.status_code == 204
+    assert events == [
+        (
+            "ui_review_expand",
+            {
+                "session_id": "sess1",
+                "account_id": "acc1",
+                "bureau": "Experian",
+                "decision_source": "ai",
+                "tier": "Tier1",
+                "ts": "2024-01-01T00:00:00Z",
+            },
+        )
+    ]
+    _assert_no_pii(events)
+
+
+def test_ui_event_invalid_schema(app):
+    client = app.test_client()
+    bad_payload = {
+        "type": "ui_review_expand",
+        "ts": "2024-01-01T00:00:00Z",
+        "session_id": "sess1",
+        "payload": {
+            "account_id": "acc1",
+            "bureau": "Experian",
+            "decision_source": "maybe",
+        },
+    }
+    resp = client.post("/api/ui-event", json=bad_payload)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "SchemaValidationError"
+
+
+def test_ui_event_body_size_cap(app):
+    client = app.test_client()
+    big_session = "a" * 5000
+    payload = {
+        "type": "ui_review_expand",
+        "ts": "2024-01-01T00:00:00Z",
+        "session_id": big_session,
+        "payload": {"account_id": "acc1", "bureau": "EX"},
+    }
+    resp = client.post("/api/ui-event", json=payload)
+    assert resp.status_code == 413
+
+
+def test_ui_event_unknown_type(app):
+    client = app.test_client()
+    payload = {
+        "type": "ui_unknown",
+        "ts": "2024-01-01T00:00:00Z",
+        "session_id": "sess1",
+        "payload": {"account_id": "acc1", "bureau": "EX"},
+    }
+    resp = client.post("/api/ui-event", json=payload)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "SchemaValidationError"


### PR DESCRIPTION
## Summary
- add `/api/ui-event` endpoint to ingest UI telemetry and forward to telemetry emitter
- validate requests against strict schema and cap payload size
- cover API contract with tests

## Testing
- `pytest tests/test_ui_event_api.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68af1eb1d15083259d902fd17dd588c3