### PR TITLE
Add Stage E session summary telemetry

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -72,6 +72,7 @@ from backend.core.case_store.telemetry import emit
 from backend.policy.policy_loader import load_rulebook
 from backend.core.taxonomy.problem_taxonomy import compare_tiers, normalize_decision
 from planner import plan_next_step
+from backend.core.telemetry.stageE_summary import emit_stageE_summary
 
 logger = logging.getLogger(__name__)
 
@@ -209,6 +210,7 @@ def collect_stageA_logical_accounts(session_id: str) -> list[Mapping[str, Any]]:
     """
 
     problems = collect_stageA_problem_accounts(session_id)
+    emit_stageE_summary(session_id, problems)
     if not config.ENABLE_CROSS_BUREAU_RESOLUTION:
         return problems
 

--- a/backend/core/telemetry/stageE_summary.py
+++ b/backend/core/telemetry/stageE_summary.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, List, Dict, Set
+
+from backend.core.case_store import api as cs_api
+from backend.core.case_store.telemetry import emit
+
+_sessions: Dict[str, Dict[str, Any]] = {}
+
+
+def record_stageA_event(event: str, fields: Mapping[str, Any]) -> None:
+    """Record per-account Stage A telemetry for later aggregation.
+
+    Parameters
+    ----------
+    event:
+        Name of the telemetry event. Only ``stageA_eval`` and ``stageA_fallback``
+        are recognized.
+    fields:
+        Telemetry payload emitted for the event.
+    """
+    session_id = fields.get("session_id")
+    if not session_id:
+        return
+    info = _sessions.setdefault(session_id, {"fallbacks": set(), "latencies": []})
+    if event == "stageA_fallback":
+        acc_id = fields.get("account_id")
+        if acc_id is not None:
+            info["fallbacks"].add(str(acc_id))
+        latency = fields.get("latency_ms")
+        if isinstance(latency, (int, float)):
+            info["latencies"].append(float(latency))
+    elif event == "stageA_eval":
+        latency = fields.get("ai_latency_ms")
+        if isinstance(latency, (int, float)):
+            info["latencies"].append(float(latency))
+
+
+def _p95(values: List[float]) -> float:
+    if not values:
+        return 0.0
+    values = sorted(values)
+    idx = int(math.ceil(0.95 * len(values))) - 1
+    return float(values[idx])
+
+
+def emit_stageE_summary(session_id: str, problem_accounts: List[Mapping[str, Any]], duration_ms: float | None = None) -> None:
+    """Emit aggregated Stage E session summary telemetry."""
+    total_accounts = len(cs_api.list_accounts(session_id))
+    problem_count = len(problem_accounts or [])
+    ai_adoption = sum(1 for acc in problem_accounts if acc.get("decision_source") == "ai")
+    sess = _sessions.pop(session_id, {"fallbacks": set(), "latencies": []})
+    fallback_count = len(sess.get("fallbacks", set()))
+    latencies = sess.get("latencies", [])
+    latency_p95 = _p95(latencies)
+    emit(
+        "stageE_summary",
+        session_id=session_id,
+        total_accounts=total_accounts,
+        problem_accounts=problem_count,
+        ai_adoption_pct=ai_adoption / max(1, problem_count),
+        fallback_pct=fallback_count / max(1, problem_count),
+        ai_latency_p95_ms=latency_p95,
+        duration_ms=duration_ms if duration_ms is not None else 0.0,
+    )

--- a/tests/test_stageE_summary_telemetry.py
+++ b/tests/test_stageE_summary_telemetry.py
@@ -1,0 +1,102 @@
+import pytest
+
+import backend.config as config
+from backend.core.case_store import api as cs_api, telemetry
+from backend.core import orchestrators as orch
+from backend.core.telemetry import stageE_summary
+
+
+def _setup(monkeypatch, tmp_path, accounts):
+    """Create session with given account decision sources.
+
+    accounts: list of tuples (acc_id, decision_source)
+    """
+    monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "ENABLE_CROSS_BUREAU_RESOLUTION", False)
+    monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
+    session_id = "sess"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    base_fields = {
+        "account_number": "00001234",
+        "creditor_type": "bank",
+        "date_opened": "2020-01-01",
+    }
+    for acc_id, source in accounts:
+        cs_api.upsert_account_fields(session_id, acc_id, "Experian", base_fields)
+        payload = {
+            "primary_issue": "late_payment",
+            "tier": "Tier1",
+            "confidence": 0.9,
+            "problem_reasons": ["r"],
+            "decision_source": source,
+        }
+        cs_api.append_artifact(session_id, acc_id, "stageA_detection", payload)
+    return session_id
+
+
+def test_rules_only_adoption_zero(tmp_path, monkeypatch):
+    session_id = _setup(monkeypatch, tmp_path, [("a1", "rules"), ("a2", "rules")])
+    events = []
+    telemetry.set_emitter(lambda e, f: events.append((e, f)))
+    orch.collect_stageA_logical_accounts(session_id)
+    telemetry.set_emitter(None)
+    summary = [f for e, f in events if e == "stageE_summary"][0]
+    assert summary["ai_adoption_pct"] == 0.0
+    assert summary["fallback_pct"] == 0.0
+    assert summary["problem_accounts"] == 2
+
+
+def test_half_ai_half_fallback(tmp_path, monkeypatch):
+    session_id = _setup(monkeypatch, tmp_path, [("a1", "ai"), ("a2", "rules")])
+    stageE_summary.record_stageA_event(
+        "stageA_fallback", {"session_id": session_id, "account_id": "a2", "latency_ms": 100}
+    )
+    events = []
+    telemetry.set_emitter(lambda e, f: events.append((e, f)))
+    orch.collect_stageA_logical_accounts(session_id)
+    telemetry.set_emitter(None)
+    summary = [f for e, f in events if e == "stageE_summary"][0]
+    assert summary["ai_adoption_pct"] == pytest.approx(0.5)
+    assert summary["fallback_pct"] == pytest.approx(0.5)
+
+
+def test_latency_p95(tmp_path, monkeypatch):
+    session_id = _setup(monkeypatch, tmp_path, [("a1", "ai")])
+    stageE_summary.record_stageA_event(
+        "stageA_eval", {"session_id": session_id, "ai_latency_ms": 50}
+    )
+    stageE_summary.record_stageA_event(
+        "stageA_eval", {"session_id": session_id, "ai_latency_ms": 100}
+    )
+    stageE_summary.record_stageA_event(
+        "stageA_fallback", {"session_id": session_id, "account_id": "a1", "latency_ms": 300}
+    )
+    events = []
+    telemetry.set_emitter(lambda e, f: events.append((e, f)))
+    orch.collect_stageA_logical_accounts(session_id)
+    telemetry.set_emitter(None)
+    summary = [f for e, f in events if e == "stageE_summary"][0]
+    assert summary["ai_latency_p95_ms"] == pytest.approx(300)
+
+
+def test_emitted_with_no_problem_accounts(tmp_path, monkeypatch):
+    session_id = _setup(monkeypatch, tmp_path, [])
+    events = []
+    telemetry.set_emitter(lambda e, f: events.append((e, f)))
+    orch.collect_stageA_logical_accounts(session_id)
+    telemetry.set_emitter(None)
+    summary_events = [f for e, f in events if e == "stageE_summary"]
+    assert len(summary_events) == 1
+    summary = summary_events[0]
+    assert summary["problem_accounts"] == 0
+    allowed = {
+        "session_id",
+        "total_accounts",
+        "problem_accounts",
+        "ai_adoption_pct",
+        "fallback_pct",
+        "ai_latency_p95_ms",
+        "duration_ms",
+    }
+    assert set(summary) == allowed


### PR DESCRIPTION
## Summary
- add helper to aggregate Stage A telemetry and emit session-level `stageE_summary`
- emit session summary telemetry from orchestrator
- test summary telemetry for adoption, fallback, and latency percentile

## Testing
- `pytest tests/test_stageE_summary_telemetry.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68af2d38a41c8325a69065a534e20865