### PR TITLE
feat: add selective OCR fallback

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -33,6 +33,15 @@ def env_int(name: str, default: int) -> int:
     val = os.getenv(name)
     if val is None:
         return default
+
+
+def env_list(name: str, default: list[str]) -> list[str]:
+    """Parse a comma-separated list environment variable."""
+    val = os.getenv(name)
+    if val is None:
+        return default
+    parts = [p.strip() for p in val.split(",") if p.strip()]
+    return parts or default
     try:
         return int(val)
     except ValueError:
@@ -114,13 +123,15 @@ API_DECISION_META_MAX_FIELDS_USED = env_int("API_DECISION_META_MAX_FIELDS_USED",
 
 # Cross-bureau resolution
 ENABLE_CROSS_BUREAU_RESOLUTION = env_bool("ENABLE_CROSS_BUREAU_RESOLUTION", False)
-API_AGGREGATION_ID_STRATEGY = env_str(
-    "API_AGGREGATION_ID_STRATEGY", "winner"
-)
-API_INCLUDE_AGG_MEMBERS_META = env_bool(
-    "API_INCLUDE_AGG_MEMBERS_META", False
-)
+API_AGGREGATION_ID_STRATEGY = env_str("API_AGGREGATION_ID_STRATEGY", "winner")
+API_INCLUDE_AGG_MEMBERS_META = env_bool("API_INCLUDE_AGG_MEMBERS_META", False)
 
 # Parser audit instrumentation
 PARSER_AUDIT_ENABLED = env_bool("PARSER_AUDIT_ENABLED", True)
 PDF_TEXT_MIN_CHARS_PER_PAGE = env_int("PDF_TEXT_MIN_CHARS_PER_PAGE", 64)
+
+# OCR fallback configuration
+OCR_ENABLED = env_bool("OCR_ENABLED", False)
+OCR_PROVIDER = env_str("OCR_PROVIDER", "tesseract")
+OCR_TIMEOUT_MS = env_int("OCR_TIMEOUT_MS", 8000)
+OCR_LANGS = env_list("OCR_LANGS", ["eng"])

--- a/backend/core/logic/report_analysis/ocr_provider.py
+++ b/backend/core/logic/report_analysis/ocr_provider.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class OcrResult:
+    """Result of an OCR operation."""
+
+    text: str
+    duration_ms: int
+
+
+class OcrProvider(Protocol):
+    def ocr_page(
+        self,
+        pdf_path: str,
+        page_index: int,
+        *,
+        timeout_ms: int,
+        langs: list[str],
+    ) -> OcrResult: ...
+
+
+class TesseractProvider:
+    """Basic OCR provider backed by ``pytesseract`` and ``pdf2image``.
+
+    This implementation aims to be best-effort. Any errors or timeouts result in
+    an empty string being returned so that callers can decide how to proceed
+    without the OCR step interrupting the pipeline.
+    """
+
+    def ocr_page(
+        self,
+        pdf_path: str,
+        page_index: int,
+        *,
+        timeout_ms: int,
+        langs: list[str],
+    ) -> OcrResult:
+        import threading
+        import time
+
+        result: dict[str, str] = {"text": ""}
+
+        def worker() -> None:
+            try:
+                import pytesseract
+                from pdf2image import convert_from_path
+
+                images = convert_from_path(
+                    pdf_path,
+                    first_page=page_index + 1,
+                    last_page=page_index + 1,
+                    dpi=300,
+                )
+                if images:
+                    lang = "+".join(langs) if langs else "eng"
+                    result["text"] = pytesseract.image_to_string(images[0], lang=lang)
+            except Exception:
+                # Swallow all errors; caller can treat empty text as failure.
+                result["text"] = ""
+
+        start = time.perf_counter()
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        thread.join(timeout_ms / 1000)
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        if thread.is_alive():
+            return OcrResult(text="", duration_ms=duration_ms)
+        return OcrResult(text=result["text"], duration_ms=duration_ms)
+
+
+def get_ocr_provider(name: str) -> OcrProvider:
+    """Return an OCR provider implementation by name."""
+
+    name = (name or "").lower()
+    if name == "tesseract":
+        return TesseractProvider()
+    raise ValueError(f"Unsupported OCR provider: {name}")

--- a/backend/core/logic/report_analysis/pdf_io.py
+++ b/backend/core/logic/report_analysis/pdf_io.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Mapping
 
 import fitz  # PyMuPDF
 
@@ -21,3 +21,19 @@ def char_count(s: str) -> int:
 
     return len(s or "")
 
+
+def merge_text_with_ocr(
+    page_texts: List[str], ocr_texts: Mapping[int, str]
+) -> List[str]:
+    """Merge per-page OCR results into ``page_texts``.
+
+    ``ocr_texts`` maps a 0-indexed page number to its OCR extracted text. Any
+    non-empty OCR result replaces the corresponding entry in ``page_texts``.
+    Pages without an OCR result remain unchanged.
+    """
+
+    merged = list(page_texts)
+    for idx, txt in ocr_texts.items():
+        if 0 <= idx < len(merged) and txt:
+            merged[idx] = txt
+    return merged

--- a/backend/core/telemetry/parser_metrics.py
+++ b/backend/core/telemetry/parser_metrics.py
@@ -13,6 +13,9 @@ def emit_parser_audit(
     call_ai_ms: int | None,
     fields_written: int | None,
     errors: str | None,
+    parser_pdf_pages_ocr: int = 0,
+    parser_ocr_latency_ms_total: int = 0,
+    parser_ocr_errors: int = 0,
 ) -> None:
     """Emit a ``parser_audit`` telemetry event."""
 
@@ -26,5 +29,7 @@ def emit_parser_audit(
         call_ai_ms=call_ai_ms,
         fields_written=fields_written,
         errors=errors,
+        parser_pdf_pages_ocr=parser_pdf_pages_ocr,
+        parser_ocr_latency_ms_total=parser_ocr_latency_ms_total,
+        parser_ocr_errors=parser_ocr_errors,
     )
-

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -1,0 +1,143 @@
+import pytest
+
+from backend.core.logic.report_analysis import analyze_report, ocr_provider
+from backend.core.telemetry import parser_metrics
+
+
+@pytest.fixture(autouse=True)
+def stub_parsing_dependencies(monkeypatch):
+    """Stub heavy parsing helpers so tests can focus on OCR logic."""
+
+    monkeypatch.setattr(analyze_report, "extract_account_headings", lambda _: [])
+    monkeypatch.setattr(
+        analyze_report, "_reconcile_account_headings", lambda *a, **k: None
+    )
+    monkeypatch.setattr(analyze_report, "extract_inquiries", lambda _: [])
+    monkeypatch.setattr(analyze_report, "_merge_parser_inquiries", lambda *a, **k: None)
+    monkeypatch.setattr(
+        analyze_report, "extract_late_history_blocks", lambda *a, **k: ({}, {}, {})
+    )
+    monkeypatch.setattr(analyze_report, "_sanitize_late_counts", lambda *a, **k: None)
+    monkeypatch.setattr(
+        analyze_report,
+        "extract_three_column_fields",
+        lambda *a, **k: ({}, {}, {}, {}, {}, {}, {}),
+    )
+    monkeypatch.setattr(
+        analyze_report, "extract_payment_statuses", lambda *a, **k: ({}, {})
+    )
+    monkeypatch.setattr(analyze_report, "extract_creditor_remarks", lambda *a, **k: {})
+    monkeypatch.setattr(analyze_report, "extract_account_numbers", lambda *a, **k: {})
+    monkeypatch.setattr(
+        analyze_report, "_inject_missing_late_accounts", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        analyze_report, "_cleanup_unverified_late_text", lambda *a, **k: None
+    )
+    monkeypatch.setattr(analyze_report, "_attach_parser_signals", lambda *a, **k: None)
+    monkeypatch.setattr(analyze_report, "enrich_account_metadata", lambda acc: acc)
+    monkeypatch.setattr(analyze_report, "validate_analysis_sanity", lambda _: [])
+
+
+@pytest.fixture
+def capture_events(monkeypatch):
+    events = []
+
+    def fake_emit(event, **fields):
+        events.append((event, fields))
+
+    monkeypatch.setattr(parser_metrics, "emit", fake_emit)
+    return events
+
+
+def _run(tmp_path, **kwargs):
+    return analyze_report.analyze_credit_report(
+        "dummy.pdf",
+        tmp_path / "out.json",
+        {},
+        request_id="rid",
+        session_id="sid",
+        **kwargs,
+    )
+
+
+def test_no_ocr_when_disabled(tmp_path, monkeypatch, capture_events):
+    monkeypatch.setattr(analyze_report, "OCR_ENABLED", False)
+    monkeypatch.setattr(analyze_report, "extract_text_per_page", lambda _: ["page"])
+
+    called = False
+
+    def fake_get(name):  # pragma: no cover - provider should not be used
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(analyze_report, "get_ocr_provider", fake_get)
+
+    _run(tmp_path, run_ai=False)
+
+    assert called is False
+    payload = capture_events[0][1]
+    assert payload["parser_pdf_pages_ocr"] == 0
+
+
+def test_selective_ocr_merge(tmp_path, monkeypatch, capture_events):
+    pages = ["", "X" * 10, "Y" * 80]
+    monkeypatch.setattr(analyze_report, "extract_text_per_page", lambda _: pages.copy())
+    monkeypatch.setattr(analyze_report, "OCR_ENABLED", True)
+    monkeypatch.setattr(analyze_report, "PDF_TEXT_MIN_CHARS_PER_PAGE", 64)
+
+    class Provider:
+        def __init__(self):
+            self.calls = []
+
+        def ocr_page(self, pdf_path, page_index, *, timeout_ms, langs):
+            self.calls.append(page_index)
+            return ocr_provider.OcrResult(text=f"OCR{page_index}", duration_ms=5)
+
+    provider = Provider()
+    monkeypatch.setattr(analyze_report, "get_ocr_provider", lambda name: provider)
+
+    captured_text = []
+
+    def fake_extract_headings(txt):
+        captured_text.append(txt)
+        return []
+
+    monkeypatch.setattr(
+        analyze_report, "extract_account_headings", fake_extract_headings
+    )
+
+    _run(tmp_path, run_ai=False)
+
+    assert provider.calls == [0, 1]
+    text = captured_text[0]
+    assert "OCR0" in text
+    assert "OCR1" in text
+    assert "Y" * 80 in text
+
+    payload = capture_events[0][1]
+    assert payload["parser_pdf_pages_ocr"] == 2
+    assert payload["parser_ocr_latency_ms_total"] == 10
+    assert payload["parser_ocr_errors"] == 0
+    payload_str = str(payload)
+    assert "OCR0" not in payload_str and "Y" * 80 not in payload_str
+
+
+def test_ocr_timeout_counts_error(tmp_path, monkeypatch, capture_events):
+    pages = ["", "Z" * 80]
+    monkeypatch.setattr(analyze_report, "extract_text_per_page", lambda _: pages.copy())
+    monkeypatch.setattr(analyze_report, "OCR_ENABLED", True)
+    monkeypatch.setattr(analyze_report, "PDF_TEXT_MIN_CHARS_PER_PAGE", 64)
+
+    class ErrProvider:
+        def ocr_page(self, *a, **k):
+            return ocr_provider.OcrResult(text="", duration_ms=7)
+
+    monkeypatch.setattr(analyze_report, "get_ocr_provider", lambda name: ErrProvider())
+
+    _run(tmp_path, run_ai=False)
+
+    payload = capture_events[0][1]
+    assert payload["parser_pdf_pages_ocr"] == 1
+    assert payload["parser_ocr_errors"] == 1


### PR DESCRIPTION
## Summary
- add OCR configuration and provider interface with basic Tesseract implementation
- selectively run OCR for pages missing text and merge results into PDF text
- emit OCR telemetry and cover fallback behavior with tests

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/pdf_io.py backend/core/logic/report_analysis/ocr_provider.py backend/core/logic/report_analysis/analyze_report.py backend/core/telemetry/parser_metrics.py backend/config.py tests/test_ocr_fallback.py`
- `pytest tests/test_parser_audit.py -q`
- `pytest tests/test_ocr_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68af4ea7ed448325b758043d71e08f26