### PR TITLE
feat: expand bureau meta parsing

### DIFF
--- a/backend/core/materialize/account_materializer.py
+++ b/backend/core/materialize/account_materializer.py
@@ -560,6 +560,12 @@ def materialize_accounts(
                     )
                 if pitems:
                     raw["public_information"]["items"] = pitems
+                elif pub:
+                    logger.warning(
+                        "public_info_detected_but_not_written session=%s account=%s",
+                        session_id,
+                        src.get("account_id") or _slug(src.get("name")),
+                    )
             except Exception:
                 pass
             src["raw"] = raw


### PR DESCRIPTION
## Summary
- add SmartCredit block parser and numeric/date normalizers
- enrich bureau meta tables with fallback parsing and coverage logs
- warn if public info detected but not written during materialization

## Testing
- `pytest` *(fails: OPENAI_API_KEY is not set, various API contract tests)*
- `python - <<'PY' ...` counts bureau fields from sample block *(partial output)*

------
https://chatgpt.com/codex/tasks/task_b_68b224a904588325a72d85604a867759