### PR TITLE
Improve SmartCredit bureau parsing

### DIFF
--- a/backend/core/logic/report_analysis/normalize.py
+++ b/backend/core/logic/report_analysis/normalize.py
@@ -2,10 +2,17 @@
 from datetime import datetime
 
 def to_number(val):
+    """Return ``val`` converted to ``float`` when unambiguous."""
+
     if val is None:
         return None
+
     s = str(val).strip()
+    # Remove currency symbols, thousands separators and optional CR/DR tokens
     s = re.sub(r"[,$]", "", s)
+    s = re.sub(r"\b(?:CR|DR)\b", "", s, flags=re.I)
+    s = s.strip()
+
     try:
         return float(s)
     except Exception:
@@ -13,10 +20,12 @@ def to_number(val):
 
 
 def to_iso_date(val):
+    """Return ``val`` normalized to ``YYYY-MM-DD`` when possible."""
+
     if val is None:
         return None
     s = str(val).strip()
-    for fmt in ("%m/%d/%Y", "%Y-%m-%d", "%m/%Y"):
+    for fmt in ("%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%m/%Y", "%Y-%m"):
         try:
             dt = datetime.strptime(s, fmt)
             return dt.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- normalize numbers & dates with CR/DR handling
- robustly parse SmartCredit account blocks via header-based column spans
- extract footer triplets, payment history, and 7-year late totals

## Testing
- `pytest -m "not external" -q` *(fails: OPENAI_API_KEY is not set, multiple tests)*
- `python traces_coverage.py` *(custom script to count filled bureau fields)*

------
https://chatgpt.com/codex/tasks/task_b_68b22821b6a08325aef36ce2f2f44c73