### PR TITLE
feat(report-parsing): standardize bureau field mapping

### DIFF
--- a/backend/core/materialize/account_materializer.py
+++ b/backend/core/materialize/account_materializer.py
@@ -503,7 +503,16 @@ def materialize_accounts(
             raw.setdefault("summary", {"_provenance": {}})
             # Account history by bureau (full field set)
             raw.setdefault("account_history", {})
-            raw["account_history"]["by_bureau"] = _build_account_history_by_bureau(src)
+            existing_by = raw.get("account_history", {}).get("by_bureau") or {}
+            built_by = _build_account_history_by_bureau(src)
+            merged: dict[str, dict[str, Any]] = {}
+            for b in BUREAUS:
+                cur = {f: None for f in ACCOUNT_FIELD_SET}
+                if isinstance(existing_by, Mapping):
+                    cur.update(existing_by.get(b) or {})
+                cur.update(built_by.get(b) or {})
+                merged[b] = cur
+            raw["account_history"]["by_bureau"] = merged
             # Public information / Inquiries arrays
             raw.setdefault("public_information", {"items": []})
             raw.setdefault("inquiries", {"items": []})


### PR DESCRIPTION
## Summary
- add centralized 25-field set and alias mapping for bureau data
- normalize account fields using helper `_assign_std`
- preserve existing `raw.account_history.by_bureau` when materializing accounts

## Testing
- `pytest -q` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b4aaa2a9708325b247a6d7f448fc0b