### PR TITLE
Add diagnostics for ANZ and MAT block fallback

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -1902,6 +1902,16 @@ def analyze_credit_report(
         logger.exception("persist_identifiers_failed")
     # --- END: persist identifiers on analysis result ---
 
+    # --- BEGIN: ANZ diagnostics ---
+    logger.warning(
+        "ANZ: pre-save fbk=%d fuzzy=%d sid=%s req=%s",
+        len(result.get("fbk_blocks") or []),
+        len((result.get("blocks_by_account_fuzzy") or {}).keys()),
+        result.get("session_id"),
+        result.get("request_id"),
+    )
+    # --- END: ANZ diagnostics ---
+
     try:
         sid = result.get("session_id") or session_id or request_id
         if sid and os.getenv("EXPORT_ACCOUNT_BLOCKS", "0") != "0":


### PR DESCRIPTION
## Summary
- log ANZ block counts before saving analysis results
- rebuild account blocks from traces in materializer with unified SID and diagnostics

## Testing
- `pytest` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b4c2b84ad08325bbb6cfe78a875ebf