### PR TITLE
Add ANZ logging for report analysis exports

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -1926,9 +1926,10 @@ def analyze_credit_report(
             with (out_dir / "_index.json").open("w", encoding="utf-8") as f:
                 json.dump(idx_info, f, ensure_ascii=False, indent=2)
             logger.warning(
-                "[TRACE] account blocks exported: %d -> traces/blocks/%s/",
-                len(fbk_blocks),
+                "ANZ: export blocks sid=%s dir=%s files=%d",
                 sid,
+                str(out_dir),
+                len(fbk_blocks),
             )
     except Exception:
         logger.exception("block_export_failed")


### PR DESCRIPTION
## Summary
- add warning log before saving report blocks with counts and IDs
- log exported account block details with path and file count

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/analyze_report.py`
- `pytest tests/letters/test_sanitizer.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4cce1ad80832593c6b688bd45c0cd