### PR TITLE
feat: add detailed account materializer logs

### DIFF
--- a/backend/core/materialize/account_materializer.py
+++ b/backend/core/materialize/account_materializer.py
@@ -15,21 +15,19 @@ Scope and constraints:
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
 import logging
 import re
-from typing import Optional
 from datetime import datetime
+from typing import Any, Iterable, Mapping, Optional
 
 from backend.core.logic.report_analysis.report_parsing import (
+    ACCOUNT_FIELD_SET,
     _empty_bureau_map,
+    _fill_bureau_map_from_sources,
     _find_block_lines_for_account,
     parse_account_block,
     parse_collection_block,
-    _fill_bureau_map_from_sources,
-    ACCOUNT_FIELD_SET,
 )
-from backend.core.logic.report_analysis.normalize import to_number, to_iso_date
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +114,9 @@ def _to_iso_date(val: Any) -> Optional[str]:  # gentle normalization
 
 
 def _build_bureau_complete(acc: dict) -> dict[str, dict[str, Any]]:
-    by_field: dict[str, dict[str, Any]] = {b: {f: None for f in FIELDS} for b in BUREAUS}
+    by_field: dict[str, dict[str, Any]] = {
+        b: {f: None for f in FIELDS} for b in BUREAUS
+    }
 
     # Map bureaus[] entries by normalized name
     by_name: dict[str, dict] = {}
@@ -135,7 +135,11 @@ def _build_bureau_complete(acc: dict) -> dict[str, dict[str, Any]]:
         _norm_bureau_key(k): v for k, v in (acc.get("bureau_statuses") or {}).items()
     }
     details_map_raw = acc.get("bureau_details") or {}
-    details_map = { _norm_bureau_key(k): v for k, v in details_map_raw.items() if isinstance(v, dict) }
+    details_map = {
+        _norm_bureau_key(k): v
+        for k, v in details_map_raw.items()
+        if isinstance(v, dict)
+    }
 
     # Common top-level fallbacks
     acc_num_disp = acc.get("account_number_display")
@@ -170,24 +174,52 @@ def _build_bureau_complete(acc: dict) -> dict[str, dict[str, Any]]:
                 out["date_reported"] = _to_iso_date(src.get("date_reported"))
 
         # 2) Flat maps for payment/account status
-        if out["payment_status"] is None and b in ps_map and ps_map[b] not in (None, "", {}):
+        if (
+            out["payment_status"] is None
+            and b in ps_map
+            and ps_map[b] not in (None, "", {})
+        ):
             out["payment_status"] = ps_map[b]
-        if out["account_status"] is None and b in bs_map and bs_map[b] not in (None, "", {}):
+        if (
+            out["account_status"] is None
+            and b in bs_map
+            and bs_map[b] not in (None, "", {})
+        ):
             out["account_status"] = bs_map[b]
 
         # 3) Bureau details for financials/dates
         if isinstance(det, dict):
-            if out["past_due_amount"] is None and det.get("past_due_amount") not in (None, "", {}):
+            if out["past_due_amount"] is None and det.get("past_due_amount") not in (
+                None,
+                "",
+                {},
+            ):
                 out["past_due_amount"] = _to_number(det.get("past_due_amount"))
             if out["balance"] is None and det.get("balance") not in (None, "", {}):
                 out["balance"] = _to_number(det.get("balance"))
-            if out["credit_limit"] is None and det.get("credit_limit") not in (None, "", {}):
+            if out["credit_limit"] is None and det.get("credit_limit") not in (
+                None,
+                "",
+                {},
+            ):
                 out["credit_limit"] = _to_number(det.get("credit_limit"))
-            if out["last_reported"] is None and det.get("last_reported") not in (None, "", {}):
+            if out["last_reported"] is None and det.get("last_reported") not in (
+                None,
+                "",
+                {},
+            ):
                 out["last_reported"] = _to_iso_date(det.get("last_reported"))
-            if out["date_opened"] is None and det.get("date_opened") not in (None, "", {}):
+            if out["date_opened"] is None and det.get("date_opened") not in (
+                None,
+                "",
+                {},
+            ):
                 out["date_opened"] = _to_iso_date(det.get("date_opened"))
-            if out["date_reported"] is None and det.get("date_reported") not in (None, "", {}):
+            if out["date_reported"] is None and det.get("date_reported") not in (
+                None,
+                "",
+                {},
+            ):
                 out["date_reported"] = _to_iso_date(det.get("date_reported"))
 
         # 4) Cross-bureau consistent fields (safe replication): account number
@@ -197,13 +229,15 @@ def _build_bureau_complete(acc: dict) -> dict[str, dict[str, Any]]:
     # If raw.account_history.by_bureau exists, use its balance_owed as overlay 'balance' when missing
     try:
         raw_by_bureau = (
-            acc.get("raw", {})
-            .get("account_history", {})
-            .get("by_bureau", {})
+            acc.get("raw", {}).get("account_history", {}).get("by_bureau", {})
         )
         for b in BUREAUS:
             if by_field.get(b, {}).get("balance") is None:
-                val = raw_by_bureau.get(b, {}).get("balance_owed") if isinstance(raw_by_bureau, dict) else None
+                val = (
+                    raw_by_bureau.get(b, {}).get("balance_owed")
+                    if isinstance(raw_by_bureau, dict)
+                    else None
+                )
                 if val not in (None, "", {}, []):
                     by_field[b]["balance"] = _to_number(val)
     except Exception:
@@ -223,7 +257,9 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
     Gentle normalization for numbers/dates within this view only.
     """
 
-    by_hist: dict[str, dict[str, Any]] = {b: {f: None for f in ACCOUNT_FIELD_SET} for b in BUREAUS}
+    by_hist: dict[str, dict[str, Any]] = {
+        b: {f: None for f in ACCOUNT_FIELD_SET} for b in BUREAUS
+    }
 
     # Map bureaus[] entries by normalized name
     by_name: dict[str, dict] = {}
@@ -234,7 +270,11 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
                 by_name[bk] = entry
 
     details_map_raw = acc.get("bureau_details") or {}
-    details_map = { _norm_bureau_key(k): v for k, v in details_map_raw.items() if isinstance(v, dict) }
+    details_map = {
+        _norm_bureau_key(k): v
+        for k, v in details_map_raw.items()
+        if isinstance(v, dict)
+    }
 
     acc_num_disp = acc.get("account_number_display")
     acc_num_last4 = acc.get("account_number_last4")
@@ -245,7 +285,12 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
         det = details_map.get(b) or {}
 
         # Prefer bureaus[] source first
-        def _copy_src(key: str, norm: Optional[str] = None, numeric: bool = False, date: bool = False):
+        def _copy_src(
+            key: str,
+            norm: Optional[str] = None,
+            numeric: bool = False,
+            date: bool = False,
+        ):
             val = src.get(key)
             if val not in (None, "", {}, []):
                 if numeric:
@@ -263,7 +308,9 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
                 return val2
             return None
 
-        out["account_number_display"] = src.get("account_number_display") or acc_num_disp
+        out["account_number_display"] = (
+            src.get("account_number_display") or acc_num_disp
+        )
         out["account_number_last4"] = src.get("account_number_last4") or acc_num_last4
         out["high_balance"] = _copy_src("high_balance", numeric=True)
         out["last_verified"] = _copy_src("last_verified", date=True)
@@ -271,7 +318,9 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
         out["date_reported"] = _copy_src("date_reported", date=True)
         out["date_opened"] = _copy_src("date_opened", date=True)
         # Balance owed may be named 'balance' in details or src
-        out["balance_owed"] = _copy_src("balance_owed", norm="balance", numeric=True) or _copy_src("balance", numeric=True)
+        out["balance_owed"] = _copy_src(
+            "balance_owed", norm="balance", numeric=True
+        ) or _copy_src("balance", numeric=True)
         out["closed_date"] = _copy_src("closed_date", date=True)
         out["account_rating"] = _copy_src("account_rating")
         out["account_description"] = _copy_src("account_description")
@@ -287,8 +336,12 @@ def _build_account_history_by_bureau(acc: dict) -> dict[str, dict[str, Any]]:
         out["account_type"] = _copy_src("account_type")
         out["payment_frequency"] = _copy_src("payment_frequency")
         out["credit_limit"] = _copy_src("credit_limit", numeric=True)
-        out["two_year_payment_history"] = src.get("two_year_payment_history") or det.get("two_year_payment_history")
-        out["seven_year_days_late"] = src.get("seven_year_days_late") or det.get("seven_year_days_late")
+        out["two_year_payment_history"] = src.get(
+            "two_year_payment_history"
+        ) or det.get("two_year_payment_history")
+        out["seven_year_days_late"] = src.get("seven_year_days_late") or det.get(
+            "seven_year_days_late"
+        )
 
     return by_hist
 
@@ -310,7 +363,11 @@ def _collect_sources_map(ocr_doc: Any) -> dict[str, list[dict]]:
     The function does not derive; it only exposes existing containers.
     """
 
-    out: dict[str, list[dict]] = {"all_accounts": [], "accounts": [], "problem_accounts": []}
+    out: dict[str, list[dict]] = {
+        "all_accounts": [],
+        "accounts": [],
+        "problem_accounts": [],
+    }
 
     if isinstance(ocr_doc, list):
         # Non-structured list of dicts treated as 'accounts'
@@ -328,7 +385,9 @@ def _collect_sources_map(ocr_doc: Any) -> dict[str, list[dict]]:
     return out
 
 
-def _build_index(accounts: Iterable[Mapping[str, Any]]) -> tuple[dict[str, dict], dict[str, dict]]:
+def _build_index(
+    accounts: Iterable[Mapping[str, Any]]
+) -> tuple[dict[str, dict], dict[str, dict]]:
     """Return indices (by id, by normalized name) for quick matching."""
 
     by_id: dict[str, dict] = {}
@@ -398,7 +457,12 @@ def materialize_accounts(
 
     out: list[dict] = []
 
-    matched_from = {"all_accounts": 0, "accounts": 0, "problem_accounts": 0, "minimal": 0}
+    matched_from = {
+        "all_accounts": 0,
+        "accounts": 0,
+        "problem_accounts": 0,
+        "minimal": 0,
+    }
 
     for p in analyzer_problems or []:
         if not isinstance(p, Mapping):
@@ -453,7 +517,12 @@ def materialize_accounts(
 
         # Ensure IDs/names are present and aligned
         # Proper fix: set account_id to slug(normalized_name|name)
-        slug_id = _slug(p.get("normalized_name") or p.get("name") or src.get("normalized_name") or src.get("name"))
+        slug_id = _slug(
+            p.get("normalized_name")
+            or p.get("name")
+            or src.get("normalized_name")
+            or src.get("name")
+        )
         if slug_id:
             src["account_id"] = slug_id
         if not src.get("normalized_name") and pname:
@@ -466,22 +535,27 @@ def materialize_accounts(
             src["account_fingerprint"] = p.get("account_fingerprint")
 
         # Optional top-level mirror for compatibility (no overwrite)
-        if (src.get("primary_issue") in (None, "", "unknown")) and tags.get("primary_issue"):
+        if (src.get("primary_issue") in (None, "", "unknown")) and tags.get(
+            "primary_issue"
+        ):
             src["primary_issue"] = tags.get("primary_issue")
 
         # Build raw scaffold and account_history.by_bureau
         try:
             raw = dict(src.get("raw") or {})
             # Personal information (placeholders unless parser provided)
-            raw.setdefault("personal_information", {
-                "name": None,
-                "aka": None,
-                "dob": None,
-                "current_address": None,
-                "previous_addresses": None,
-                "employer": None,
-                "_provenance": {},
-            })
+            raw.setdefault(
+                "personal_information",
+                {
+                    "name": None,
+                    "aka": None,
+                    "dob": None,
+                    "current_address": None,
+                    "previous_addresses": None,
+                    "employer": None,
+                    "_provenance": {},
+                },
+            )
             # Summary (report-level metrics)
             raw.setdefault("summary", {"_provenance": {}})
             # Account history by bureau (full field set)
@@ -496,54 +570,85 @@ def materialize_accounts(
             sid = (
                 (ocr_doc.get("session_id") if isinstance(ocr_doc, Mapping) else None)
                 or (ocr_doc.get("request_id") if isinstance(ocr_doc, Mapping) else None)
-                or (sections.get("session_id") if isinstance(sections, Mapping) else None)
-                or (sections.get("request_id") if isinstance(sections, Mapping) else None)
+                or (
+                    sections.get("session_id")
+                    if isinstance(sections, Mapping)
+                    else None
+                )
+                or (
+                    sections.get("request_id")
+                    if isinstance(sections, Mapping)
+                    else None
+                )
+            )
+            logger.info(
+                "MAT: sid_resolved sid=%s src_sid=%s src_req=%s",
+                sid,
+                ocr_doc.get("session_id"),
+                ocr_doc.get("request_id"),
             )
             # --- END: unified SID ---
 
             # --- BEGIN: MAT fallback diagnostics ---
             try:
-                from pathlib import Path
                 import json
+                from pathlib import Path
 
                 blkdir = Path("traces") / "blocks" / (sid or "")
-                dir_exists = blkdir.is_dir()
-                files_count = len(list(blkdir.glob("block_*.json"))) if dir_exists else 0
-                logger.warning(
+                exists = blkdir.exists()
+                files = list(blkdir.glob("block_*.json")) if exists else []
+                logger.info(
                     "MAT: fallback sid=%s dir=%s exists=%s files=%d",
                     sid,
                     str(blkdir),
-                    dir_exists,
-                    files_count,
+                    exists,
+                    len(files),
                 )
 
-                if not ocr_doc.get("fbk_blocks") and dir_exists and files_count > 0:
+                if not ocr_doc.get("fbk_blocks") and exists and files:
                     blocks = []
-                    for p in sorted(blkdir.glob("block_*.json")):
+                    for p in sorted(files):
                         with p.open("r", encoding="utf-8") as f:
                             blocks.append(json.load(f))
                     if blocks:
                         ocr_doc["fbk_blocks"] = blocks
-                        from backend.core.logic.report_analysis.analyze_report import build_block_fuzzy
+                        from backend.core.logic.report_analysis.analyze_report import (
+                            build_block_fuzzy,
+                        )
+
                         ocr_doc["blocks_by_account_fuzzy"] = build_block_fuzzy(blocks)
-                        logger.warning(
+                        logger.info(
                             "MAT: rebuilt lines_map=%d from traces",
-                            len((ocr_doc.get("blocks_by_account_fuzzy") or {}).keys()),
+                            len(ocr_doc.get("blocks_by_account_fuzzy") or {}),
                         )
             except Exception:
                 logger.exception("materializer_block_fallback_failed")
 
-            logger.warning(
+            logger.info(
                 "MAT: before-find lines_map=%d sid=%s",
-                len((ocr_doc.get("blocks_by_account_fuzzy") or {}).keys()),
+                len(ocr_doc.get("blocks_by_account_fuzzy") or {}),
                 sid,
             )
             # --- END: MAT fallback diagnostics ---
 
             lines = _find_block_lines_for_account(ocr_doc, src)
+            logger.info(
+                "MAT: lines_for account=%s lines=%d",
+                src.get("normalized_name") or src.get("name"),
+                len(lines or []),
+            )
             for b in BUREAUS:
                 try:
                     _fill_bureau_map_from_sources(src, b, by[b], lines)
+                    filled = sum(
+                        1 for f in ACCOUNT_FIELD_SET if by[b].get(f) is not None
+                    )
+                    logger.info(
+                        "parser_bureau_fill account=%s bureau=%s filled=%d/25",
+                        src.get("normalized_name") or src.get("name"),
+                        b,
+                        filled,
+                    )
                 except Exception:
                     logger.exception("_fill_bureau_map_from_sources_failed")
 
@@ -572,15 +677,6 @@ def materialize_accounts(
                 for key in ACCOUNT_FIELD_SET:
                     if by[b].get(key) is None and bm2.get(key) is not None:
                         by[b][key] = bm2[key]
-
-            filled = {b: sum(1 for k in ACCOUNT_FIELD_SET if by[b].get(k) is not None) for b in BUREAUS}
-            for b in BUREAUS:
-                logger.warning(
-                    "parser_bureau_fill account=%s bureau=%s filled=%d/25",
-                    src.get("normalized_name") or src.get("name"),
-                    b,
-                    filled[b],
-                )
             # --- END: parser-driven merge ---
 
             # Merge into raw.account_history.by_bureau without overriding
@@ -604,12 +700,18 @@ def materialize_accounts(
                 for inq in inqs or []:
                     if not isinstance(inq, Mapping):
                         continue
-                    bureau = _norm_bureau_key(inq.get("bureau")) if inq.get("bureau") else None
+                    bureau = (
+                        _norm_bureau_key(inq.get("bureau"))
+                        if inq.get("bureau")
+                        else None
+                    )
                     date = _to_iso_date(inq.get("date")) if inq.get("date") else None
                     items.append(
                         {
                             "bureau": bureau,
-                            "subscriber": inq.get("creditor_name") or inq.get("subscriber") or inq.get("name"),
+                            "subscriber": inq.get("creditor_name")
+                            or inq.get("subscriber")
+                            or inq.get("name"),
                             "date": date,
                             "type": inq.get("type"),
                             "permissible_purpose": inq.get("permissible_purpose"),
@@ -629,13 +731,23 @@ def materialize_accounts(
                 pass
             # Populate raw.public_information from OCR doc if present
             try:
-                pub = ocr_doc.get("public_information") if isinstance(ocr_doc, Mapping) else []
+                pub = (
+                    ocr_doc.get("public_information")
+                    if isinstance(ocr_doc, Mapping)
+                    else []
+                )
                 pitems: list[dict] = []
                 for it in pub or []:
                     if not isinstance(it, Mapping):
                         continue
-                    bureau = _norm_bureau_key(it.get("bureau")) if it.get("bureau") else None
-                    date_filed = _to_iso_date(it.get("date_filed")) if it.get("date_filed") else None
+                    bureau = (
+                        _norm_bureau_key(it.get("bureau")) if it.get("bureau") else None
+                    )
+                    date_filed = (
+                        _to_iso_date(it.get("date_filed"))
+                        if it.get("date_filed")
+                        else None
+                    )
                     amount = _to_number(it.get("amount")) if it.get("amount") else None
                     pitems.append(
                         {
@@ -660,24 +772,20 @@ def materialize_accounts(
                 pass
             src["raw"] = raw
             # --- ensure meta coverage log after merge ---
-            by_bureau = raw.get("account_history", {}).get("by_bureau", {})
-            tu = sum(
-                1
-                for f in ACCOUNT_FIELD_SET
-                if by_bureau.get("transunion", {}).get(f) is not None
-            )
-            ex = sum(
-                1
-                for f in ACCOUNT_FIELD_SET
-                if by_bureau.get("experian", {}).get(f) is not None
-            )
-            eq = sum(
-                1
-                for f in ACCOUNT_FIELD_SET
-                if by_bureau.get("equifax", {}).get(f) is not None
-            )
-            logger.warning(
-                "bureau_meta_coverage name=%s tu_filled=%d ex_filled=%d eq_filled=%d",
+            byb = raw.get("account_history", {}).get("by_bureau", {})
+
+            def _count_non_null(bname):
+                return sum(
+                    1
+                    for f in ACCOUNT_FIELD_SET
+                    if (byb.get(bname, {}) or {}).get(f) is not None
+                )
+
+            tu = _count_non_null("transunion")
+            ex = _count_non_null("experian")
+            eq = _count_non_null("equifax")
+            logger.info(
+                "bureau_meta_coverage name=%s tu=%d/25 ex=%d/25 eq=%d/25",
                 src.get("normalized_name") or src.get("name"),
                 tu,
                 ex,
@@ -712,15 +820,24 @@ def materialize_accounts(
             ts = datetime.utcnow().isoformat(timespec="seconds") + "Z"
             mat["ts"] = ts
             # Coverage stats: per-bureau missing and top missing fields overall
-            by_bureau = src.get("raw", {}).get("account_history", {}).get("by_bureau", {})
-            counts = {b: sum(1 for f in ACCOUNT_FIELD_SET if by_bureau.get(b, {}).get(f) is None) for b in BUREAUS}
+            by_bureau = (
+                src.get("raw", {}).get("account_history", {}).get("by_bureau", {})
+            )
+            counts = {
+                b: sum(
+                    1 for f in ACCOUNT_FIELD_SET if by_bureau.get(b, {}).get(f) is None
+                )
+                for b in BUREAUS
+            }
             # Top missing fields across bureaus
             field_miss: dict[str, int] = {f: 0 for f in ACCOUNT_FIELD_SET}
             for b in BUREAUS:
                 for f in ACCOUNT_FIELD_SET:
                     if by_bureau.get(b, {}).get(f) is None:
                         field_miss[f] += 1
-            top_missing = sorted(field_miss.items(), key=lambda x: x[1], reverse=True)[:5]
+            top_missing = sorted(field_miss.items(), key=lambda x: x[1], reverse=True)[
+                :5
+            ]
             mat["coverage"] = {
                 "transunion_missing": counts.get("transunion", 0),
                 "experian_missing": counts.get("experian", 0),


### PR DESCRIPTION
## Summary
- log resolved session IDs
- provide detailed fallback and line-map diagnostics
- report per-bureau fill stats and coverage

## Testing
- `pre-commit run --files backend/core/materialize/account_materializer.py`
- `pytest` *(fails: OPENAI_API_KEY not set, API endpoints returning 500)*

------
https://chatgpt.com/codex/tasks/task_b_68b4ce173d408325a5eb41380e06de63