### PR TITLE
Handle masked account number last4 parsing

### DIFF
--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -1183,7 +1183,7 @@ def parse_account_block(block_lines: list[str]) -> dict[str, dict[str, Any | Non
                         _assign_std(
                             bm,
                             "account_number_last4",
-                            digits[-4:] if digits else None,
+                            digits[-4:] if len(digits) >= 4 else None,
                         )
             count += 1
         logger.info(
@@ -1273,7 +1273,7 @@ def parse_account_block(block_lines: list[str]) -> dict[str, dict[str, Any | Non
                             _assign_std(
                                 bm,
                                 "account_number_last4",
-                                digits[-4:] if digits else None,
+                                digits[-4:] if len(digits) >= 4 else None,
                             )
                 parsed.add(bureau)
 
@@ -1301,7 +1301,11 @@ def parse_account_block(block_lines: list[str]) -> dict[str, dict[str, Any | Non
             bm = bureau_maps[b]
             _assign_std(bm, "account_number_display", masked)
             digits = re.sub(r"\D", "", masked) if re.search(r"\d", masked) else ""
-            _assign_std(bm, "account_number_last4", digits[-4:] if digits else None)
+            _assign_std(
+                bm,
+                "account_number_last4",
+                digits[-4:] if len(digits) >= 4 else None,
+            )
             _assign_std(bm, "high_balance", m.group(3))
             _assign_std(bm, "last_verified", m.group(4))
             _assign_std(bm, "date_of_last_activity", m.group(5))
@@ -1361,7 +1365,11 @@ def parse_collection_block(block_lines: list[str]) -> dict[str, dict[str, Any | 
             masked = acct.group(1)
             _assign_std(bm, "account_number_display", masked)
             digits = re.sub(r"\D", "", masked)
-            _assign_std(bm, "account_number_last4", digits[-4:] if digits else None)
+            _assign_std(
+                bm,
+                "account_number_last4",
+                digits[-4:] if len(digits) >= 4 else None,
+            )
 
         hb = re.search(
             r"(?:high balance|original (?:amount|balance))\s*:?\s*([-\d\$,CRDR ]+)",
@@ -1495,10 +1503,18 @@ def _fill_bureau_map_from_sources(
         last4 = acc.get("account_number_last4") or acc.get("account_number")
         if isinstance(last4, str):
             digits = re.sub(r"\D", "", last4)
-            _assign_std(dst, "account_number_last4", digits[-4:] if digits else None)
+            _assign_std(
+                dst,
+                "account_number_last4",
+                digits[-4:] if len(digits) >= 4 else None,
+            )
         elif isinstance(last4, (int, float)):
             s = str(int(last4))
-            _assign_std(dst, "account_number_last4", s[-4:] if s else None)
+            _assign_std(
+                dst,
+                "account_number_last4",
+                s[-4:] if len(s) >= 4 else None,
+            )
 
     if dst.get("account_number_display") in (None, ""):
         disp = (

--- a/tests/report_analysis/test_account_number_parsing.py
+++ b/tests/report_analysis/test_account_number_parsing.py
@@ -1,0 +1,13 @@
+import backend.core.logic.report_analysis.report_parsing as rp
+
+
+def test_parse_account_block_extracts_account_numbers():
+    lines = [
+        "Field: TransUnion Experian Equifax",
+        "Account #: 517805****** 517805****** 517805******",
+    ]
+    result = rp.parse_account_block(lines)
+    for bureau in ("transunion", "experian", "equifax"):
+        bm = result[bureau]
+        assert bm["account_number_display"] == "517805******"
+        assert bm["account_number_last4"] == "7805"


### PR DESCRIPTION
## Summary
- ensure `parse_account_block` stores masked account number display
- extract `account_number_last4` only when at least four digits are present
- add tests verifying account number parsing

## Testing
- `pytest tests/report_analysis/test_account_number_parsing.py::test_parse_account_block_extracts_account_numbers -q`
- `pytest tests/test_case_store_redaction.py -q`
- `pytest tests/report_analysis/test_assign_issue_types.py tests/test_case_store_redaction.py -q` *(fails: KeyError: 'advisor_comment')*

------
https://chatgpt.com/codex/tasks/task_b_68b4daa43eb88325861a2c2c494d4ac5