### PR TITLE
feat: add vertical triples fallback

### DIFF
--- a/tests/report_analysis/test_account_number_parsing.py
+++ b/tests/report_analysis/test_account_number_parsing.py
@@ -11,3 +11,11 @@ def test_parse_account_block_extracts_account_numbers():
         bm = result[bureau]
         assert bm["account_number_display"] == "517805******"
         assert bm["account_number_last4"] == "7805"
+
+
+def test_parse_account_block_vertical_triples_fallback_default_order():
+    lines = ["Account #: 11111111 22222222 33333333"]
+    result = rp.parse_account_block(lines)
+    assert result["transunion"]["account_number_display"] == "11111111"
+    assert result["experian"]["account_number_display"] == "22222222"
+    assert result["equifax"]["account_number_display"] == "33333333"


### PR DESCRIPTION
## Summary
- fallback to vertical triples layout when bureau order is missing
- default column order to TransUnion-Experian-Equifax and log TEQ fallback
- cover vertical triple fallback with unit test

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_parsing.py tests/report_analysis/test_account_number_parsing.py`
- `pytest tests/report_analysis/test_account_number_parsing.py`


------
https://chatgpt.com/codex/tasks/task_b_68b5abe24f388325b55879702b6149a9