### PR TITLE
Propagate session_id through analyze_report orchestrators

### DIFF
--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -521,17 +521,18 @@ def analyze_credit_report(
 
     print("[INFO] Parsing SmartCredit report...")
     analyzed_json_path = Path("output/analyzed_report.json")
+    req_id = session_id
     sections = analyze_report_logic(
         pdf_path,
         analyzed_json_path,
         client_info,
         session_id=session_id,
-        request_id=session_id,
+        request_id=req_id,
     )
     logger.info(
         "ORCH: analyze_report returned sid=%s req=%s",
         sections.get("session_id"),
-        sections.get("request_id"),
+        req_id,
     )
     _emit_stageA_events(session_id, sections.get("problem_accounts", []))
     if (
@@ -1237,6 +1238,7 @@ def extract_problematic_accounts_from_report(
         raise ValueError("Uploaded file failed PDF safety checks.")
 
     analyzed_json_path = Path("output/analyzed_report.json")
+    req_id = session_id
 
     ai_client = get_ai_client()
     run_ai = not isinstance(ai_client, _StubAIClient)
@@ -1260,12 +1262,12 @@ def extract_problematic_accounts_from_report(
         ai_client=ai_client if run_ai else None,
         run_ai=run_ai,
         session_id=session_id,
-        request_id=session_id,
+        request_id=req_id,
     )
     logger.info(
         "ORCH: analyze_report returned sid=%s req=%s",
         sections.get("session_id"),
-        sections.get("request_id"),
+        req_id,
     )
 
     force_parser = os.getenv("ANALYSIS_FORCE_PARSER_ONLY") == "1"
@@ -1278,14 +1280,14 @@ def extract_problematic_accounts_from_report(
             ai_client=None,
             run_ai=False,
             session_id=session_id,
-            request_id=session_id,
+            request_id=req_id,
         )
         sections["needs_human_review"] = True
         sections["ai_failed"] = True
         logger.info(
             "ORCH: analyze_report returned sid=%s req=%s",
             sections.get("session_id"),
-            sections.get("request_id"),
+            req_id,
         )
     if (
         os.getenv("DEFER_ASSIGN_ISSUE_TYPES") == "1"


### PR DESCRIPTION
## Summary
- pass session_id through analyze_report calls and log the request id separately

## Testing
- `python - <<'PY' > /tmp/run.log 2>&1
import uuid, logging
logging.basicConfig(level=logging.INFO)
from backend.core import orchestrators
sid=str(uuid.uuid4())
try:
    orchestrators.extract_problematic_accounts_from_report(
        file_path="backend/assets/templates/FTC_FCRA_605b.pdf", session_id=sid
    )
except Exception as e:
    pass
PY
`
- `tail -n 20 /tmp/run.log`
- `pytest tests/test_account_trace_bug.py -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68b5e2b590fc8325810ac0d363ad65da