### PR TITLE
feat: persist parsed triples for debugging

### DIFF
--- a/tests/report_analysis/test_parsed_triples_debug.py
+++ b/tests/report_analysis/test_parsed_triples_debug.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from backend.core.logic.report_analysis.report_parsing import parse_account_block
 
-
 FULL_BLOCK = """Field: TransUnion Experian Equifax
 Account Number: 12345 23456 34567
 High Balance: 100 200 300


### PR DESCRIPTION
## Summary
- add helper to persist parsed triples debug data per account
- call helper from account and collection parsers to write JSON traces

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_parsing.py tests/report_analysis/test_parsed_triples_debug.py`
- `pytest tests/report_analysis/test_parsed_triples_debug.py::test_parsed_triples_debug -q`
- `pytest tests/report_analysis -q` *(fails: KeyError: 'advisor_comment')*


------
https://chatgpt.com/codex/tasks/task_b_68b5e4ec45f08325bcac12d00e3afe06