### PR TITLE
Propagate session_id through report analysis

### DIFF
--- a/backend/core/logic/report_analysis/analyze_report.py
+++ b/backend/core/logic/report_analysis/analyze_report.py
@@ -1894,10 +1894,8 @@ def analyze_credit_report(
 
     # --- BEGIN: persist identifiers on analysis result ---
     try:
-        if "session_id" not in result and session_id:
-            result["session_id"] = session_id
-        if "request_id" not in result and request_id:
-            result["request_id"] = request_id
+        result["session_id"] = session_id or request_id
+        result["request_id"] = result.get("request_id") or request_id
     except Exception:
         logger.exception("persist_identifiers_failed")
     # --- END: persist identifiers on analysis result ---


### PR DESCRIPTION
## Summary
- ensure orchestrator always forwards a session ID when calling `analyze_report`
- persist `session_id` on analysis results, falling back to `request_id`

## Testing
- `pre-commit run --files backend/core/orchestrators.py backend/core/logic/report_analysis/analyze_report.py`
- `pytest` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b5f097391c8325be7b9d97020d828d