### PR TITLE
Persist parsed triples for debugging

### DIFF
--- a/backend/core/materialize/account_materializer.py
+++ b/backend/core/materialize/account_materializer.py
@@ -639,7 +639,7 @@ def materialize_accounts(
             )
             for b in BUREAUS:
                 try:
-                    _fill_bureau_map_from_sources(src, b, by[b], lines)
+                    _fill_bureau_map_from_sources(src, b, by[b], lines, sid=sid)
                     filled = sum(
                         1 for f in ACCOUNT_FIELD_SET if by[b].get(f) is not None
                     )
@@ -667,7 +667,12 @@ def materialize_accounts(
 
             try:
                 # 2) Parser for collection/chargeoff (fills gaps)
-                maps_col = parse_collection_block(lines or [])
+                maps_col = parse_collection_block(
+                    lines or [],
+                    heading=src.get("normalized_name") or src.get("name"),
+                    sid=sid,
+                    account_id=src.get("account_id") or _slug(src.get("name")),
+                )
             except Exception:
                 logger.exception("parse_collection_block_failed")
                 maps_col = {}

--- a/tests/report_analysis/test_parsed_triples_debug.py
+++ b/tests/report_analysis/test_parsed_triples_debug.py
@@ -42,7 +42,7 @@ def test_parsed_triples_debug(tmp_path):
     lines = [ln for ln in FULL_BLOCK.strip().split("\n")]
     parse_account_block(lines, heading="Sample", sid=sid, account_id=acc_id)
 
-    dbg_path = Path("traces") / sid / "parsed_triples" / f"{acc_id}.json"
+    dbg_path = Path("traces") / sid / "debug" / "parsed_triples" / f"{acc_id}.json"
     assert dbg_path.exists()
     data = json.loads(dbg_path.read_text())
     assert data["bureau_order"] == ["transunion", "experian", "equifax"]


### PR DESCRIPTION
## Summary
- save parsed triples in `traces/<sid>/debug/parsed_triples`
- hook parse_account_block and parse_collection_block into debug saving
- plumb `sid` through `_fill_bureau_map_from_sources` and account materializer

## Testing
- `pytest tests/report_analysis/test_parsed_triples_debug.py -q`
- `pytest tests/report_analysis -q` *(fails: KeyError 'advisor_comment')*

------
https://chatgpt.com/codex/tasks/task_b_68b5f41c7528832593f7056981d1d69e