### PR TITLE
fix: robust footer parsing

### DIFF
--- a/tests/report_analysis/test_footer_lines.py
+++ b/tests/report_analysis/test_footer_lines.py
@@ -1,0 +1,20 @@
+from backend.core.logic.report_analysis.report_parsing import parse_three_footer_lines
+
+
+def test_footer_handles_missing_middle_and_non_numeric_limit():
+    lines = [
+        "Account Type: Revolving Payment Frequency: Monthly Credit Limit: $1,500",
+        "Account Type: Collection/Chargeoff",
+        "Two-Year Payment History: OK",
+    ]
+    result = parse_three_footer_lines(lines)
+
+    assert result["transunion"]["account_type"] == "revolving"
+    assert result["transunion"]["payment_frequency"] == "monthly"
+    assert result["transunion"]["credit_limit"] == 1500
+
+    assert result["experian"]["account_type"] is None
+    assert result["experian"]["credit_limit"] is None
+
+    assert result["equifax"]["account_type"] == "collection/chargeoff"
+    assert result["equifax"]["credit_limit"] is None


### PR DESCRIPTION
## Summary
- handle footer lines per bureau without shifting when lines are missing
- parse account type, payment frequency, and credit limit with numeric validation
- add tests covering missing bureaus and non-numeric credit limits

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_parsing.py tests/report_analysis/test_footer_lines.py`
- `pytest tests/report_analysis/test_footer_lines.py::test_footer_handles_missing_middle_and_non_numeric_limit -q`
- `pytest -q` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b60ecb17708325b59b68f4d2add2a4