### PR TITLE
Parse footer lines in collection blocks

### DIFF
--- a/tests/report_analysis/test_alias_coverage_and_collections.py
+++ b/tests/report_analysis/test_alias_coverage_and_collections.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend.core.logic.report_analysis.report_parsing import (
     _assign_std,
     parse_collection_block,
@@ -34,8 +32,8 @@ def test_collection_lines_without_colon_are_parsed():
     tu = res["transunion"]
     filled = sum(1 for v in tu.values() if v is not None)
     assert filled >= 5
-    assert tu["high_balance"] == 23025.0
-    assert tu["date_opened"] == "2018-01-23"
+    assert tu["high_balance"]["normalized"] == 23025.0
+    assert tu["date_opened"]["normalized"] == "2018-01-23"
 
 
 def test_collection_order_carry_forward_without_header():
@@ -45,9 +43,9 @@ def test_collection_order_carry_forward_without_header():
     ]
     order = ["experian", "equifax", "transunion"]
     res = parse_collection_block(lines, bureau_order=order)
-    assert res["experian"]["high_balance"] == 100.0
-    assert res["equifax"]["high_balance"] == 200.0
-    assert res["transunion"]["high_balance"] == 300.0
+    assert res["experian"]["high_balance"]["normalized"] == 100.0
+    assert res["equifax"]["high_balance"]["normalized"] == 200.0
+    assert res["transunion"]["high_balance"]["normalized"] == 300.0
 
 
 def test_currency_and_dates_normalized_in_collections():
@@ -57,5 +55,5 @@ def test_currency_and_dates_normalized_in_collections():
         "Date Opened 1/1/2018 1/1/2018 1/1/2018",
     ]
     res = parse_collection_block(lines)
-    assert res["transunion"]["high_balance"] == 23025.0
-    assert res["transunion"]["date_opened"] == "2018-01-01"
+    assert res["transunion"]["high_balance"]["normalized"] == 23025.0
+    assert res["transunion"]["date_opened"]["normalized"] == "2018-01-01"

--- a/tests/report_analysis/test_footer_lines.py
+++ b/tests/report_analysis/test_footer_lines.py
@@ -1,4 +1,7 @@
-from backend.core.logic.report_analysis.report_parsing import parse_account_block
+from backend.core.logic.report_analysis.report_parsing import (
+    parse_account_block,
+    parse_collection_block,
+)
 
 
 def test_footer_handles_missing_middle_and_non_numeric_limit():
@@ -12,6 +15,29 @@ def test_footer_handles_missing_middle_and_non_numeric_limit():
     result = parse_account_block(lines)
 
     assert result["transunion"]["credit_limit"]["normalized"] == 1500.0
+    assert result["experian"]["account_type"] is None
+
+    eq = result["equifax"]["credit_limit"]
+    assert eq["raw"] == "N/A"
+    assert eq["normalized"] is None
+    assert eq["provenance"] == "footer"
+    assert result["equifax"]["account_type"]["raw"] == "collection/chargeoff"
+
+
+def test_collection_block_footer_parsing():
+    lines = [
+        "TransUnion Experian Equifax",
+        "Field:",
+        "Payment Status Pays As Agreed | Charged Off | Unknown",
+        "TransUnion Account Type Revolving Payment Frequency Monthly Credit Limit 1000",
+        "Equifax Account Type Collection/Chargeoff Payment Frequency Monthly Credit Limit N/A",
+        "Two-Year Payment History: OK",
+    ]
+    result = parse_collection_block(
+        lines, bureau_order=["transunion", "experian", "equifax"]
+    )
+
+    assert result["transunion"]["credit_limit"]["normalized"] == 1000.0
     assert result["experian"]["account_type"] is None
 
     eq = result["equifax"]["credit_limit"]


### PR DESCRIPTION
## Summary
- feed trailing lines of collection blocks to `parse_three_footer_lines` for account type, payment frequency, and credit limit
- mark footer-derived cells with `provenance="footer"`
- add regression tests for collection block footer parsing and structured field expectations

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/report_parsing.py tests/report_analysis/test_footer_lines.py tests/report_analysis/test_alias_coverage_and_collections.py`
- `pytest tests/report_analysis/test_footer_lines.py tests/report_analysis/test_value_provenance.py tests/report_analysis/test_alias_coverage_and_collections.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b634e0d5ec832591a5fea1a5c8418b