### PR TITLE
feat(case-store): add safe deep merge for account fields

### DIFF
--- a/backend/core/case_store/merge.py
+++ b/backend/core/case_store/merge.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, List, Dict
+
+
+def _merge_lists(base: List[Any], patch: List[Any]) -> List[Any]:
+    """Merge two lists according to safe_deep_merge semantics."""
+    # Keyed merge for payment_history by 'date'
+    if all(isinstance(item, dict) and "date" in item for item in base + patch):
+        result = [deepcopy(item) for item in base]
+        index_map = {
+            item["date"]: idx for idx, item in enumerate(base) if isinstance(item, dict) and "date" in item
+        }
+        for p_item in patch:
+            key = p_item["date"]
+            if key in index_map:
+                idx = index_map[key]
+                result[idx] = safe_deep_merge(result[idx], p_item)
+            else:
+                result.append(deepcopy(p_item))
+        return result
+
+    # Fallback: union preserving order, deduplicating by value
+    result: List[Any] = []
+    for item in base:
+        result.append(deepcopy(item))
+    for item in patch:
+        if item not in result:
+            result.append(deepcopy(item))
+    return result
+
+
+def safe_deep_merge(base: Any, patch: Any) -> Any:
+    """Safely merge ``patch`` into ``base`` without mutating inputs."""
+    if patch is None:
+        return deepcopy(base)
+
+    if isinstance(base, dict) and isinstance(patch, dict):
+        result: Dict[Any, Any] = {}
+        for key in base.keys() | patch.keys():
+            if key in base and key in patch:
+                result[key] = safe_deep_merge(base[key], patch[key])
+            elif key in base:
+                result[key] = deepcopy(base[key])
+            else:
+                result[key] = deepcopy(patch[key])
+        return result
+
+    if isinstance(base, list) and isinstance(patch, list):
+        return _merge_lists(base, patch)
+
+    if isinstance(base, (dict, list)) and not isinstance(patch, (dict, list)):
+        return deepcopy(base)
+
+    if not isinstance(base, (dict, list)) and isinstance(patch, (dict, list)):
+        return deepcopy(patch)
+
+    # Scalars
+    if patch in (None, "") and base not in (None, ""):
+        return deepcopy(base)
+    return deepcopy(patch)

--- a/tests/test_merge_semantics.py
+++ b/tests/test_merge_semantics.py
@@ -1,0 +1,131 @@
+import importlib
+
+import pytest
+
+from backend.core.case_store.merge import safe_deep_merge
+
+
+def _reload_api(monkeypatch, enabled: bool):
+    monkeypatch.setenv("SAFE_MERGE_ENABLED", "1" if enabled else "0")
+    from backend.core.config import flags
+
+    importlib.reload(flags)
+    from backend.core.case_store import api as api_module
+
+    importlib.reload(api_module)
+    return api_module
+
+
+def test_merge_dict_nested():
+    base = {"a": {"b": 1, "c": {"d": 2}}}
+    patch = {"a": {"c": {"e": 3}}}
+    result = safe_deep_merge(base, patch)
+    assert result == {"a": {"b": 1, "c": {"d": 2, "e": 3}}}
+
+
+def test_merge_list_by_key():
+    base = {"payment_history": [
+        {"date": "2024-01-01", "status": "late"},
+        {"date": "2024-02-01", "status": "ok"},
+    ]}
+    patch = {"payment_history": [
+        {"date": "2024-01-01", "status": "ok"},
+        {"date": "2024-03-01", "status": "late"},
+    ]}
+    result = safe_deep_merge(base, patch)
+    assert result["payment_history"] == [
+        {"date": "2024-01-01", "status": "ok"},
+        {"date": "2024-02-01", "status": "ok"},
+        {"date": "2024-03-01", "status": "late"},
+    ]
+
+
+def test_merge_list_union_no_key():
+    base = {"tags": ["A", "B"]}
+    patch = {"tags": ["B", "C"]}
+    result = safe_deep_merge(base, patch)
+    assert result["tags"] == ["A", "B", "C"]
+
+
+def test_merge_scalar_guard():
+    base = {"status": "OPEN"}
+    patch_empty = {"status": ""}
+    patch_none = {"status": None}
+    assert safe_deep_merge(base, patch_empty)["status"] == "OPEN"
+    assert safe_deep_merge(base, patch_none)["status"] == "OPEN"
+
+
+def test_type_mismatch_prefers_structure():
+    base = {"field": "text"}
+    patch = {"field": {"inner": 1}}
+    result = safe_deep_merge(base, patch)
+    assert result == {"field": {"inner": 1}}
+
+    base2 = {"field": {"inner": 1}}
+    patch2 = {"field": None}
+    result2 = safe_deep_merge(base2, patch2)
+    assert result2 == base2
+
+
+def test_flag_off_keeps_old_behavior(monkeypatch):
+    api = _reload_api(monkeypatch, False)
+    store = {}
+
+    def fake_load(session_id):
+        return store[session_id]
+
+    def fake_save(case):
+        store[case.session_id] = case
+
+    monkeypatch.setattr(api, "_load", fake_load)
+    monkeypatch.setattr(api, "save_session_case", fake_save)
+
+    case = api.create_session_case("sess")
+    store["sess"] = case
+
+    api.upsert_account_fields(
+        "sess",
+        "acc",
+        "Equifax",
+        {"two_year_payment_history": ["A", "B"]},
+    )
+    api.upsert_account_fields(
+        "sess",
+        "acc",
+        "Equifax",
+        {"two_year_payment_history": ["B", "C"]},
+    )
+    result = store["sess"].accounts["acc"].fields.model_dump()
+    assert result["two_year_payment_history"] == ["B", "C"]
+
+
+def test_flag_on_uses_safe_merge(monkeypatch):
+    api = _reload_api(monkeypatch, True)
+    store = {}
+
+    def fake_load(session_id):
+        return store[session_id]
+
+    def fake_save(case):
+        store[case.session_id] = case
+
+    monkeypatch.setattr(api, "_load", fake_load)
+    monkeypatch.setattr(api, "save_session_case", fake_save)
+
+    case = api.create_session_case("sess")
+    store["sess"] = case
+
+    api.upsert_account_fields(
+        "sess",
+        "acc",
+        "Equifax",
+        {"two_year_payment_history": ["A", "B"]},
+    )
+    api.upsert_account_fields(
+        "sess",
+        "acc",
+        "Equifax",
+        {"two_year_payment_history": ["B", "C"]},
+    )
+    result = store["sess"].accounts["acc"].fields.model_dump()
+    assert result["two_year_payment_history"] == ["A", "B", "C"]


### PR DESCRIPTION
## Summary
- add `safe_deep_merge` for dict/list/scalar merging
- gate `upsert_account_fields` with SAFE_MERGE_ENABLED flag
- cover merge semantics and flag behavior with tests

## Testing
- `pytest tests/test_merge_semantics.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b71571eff08325a565f4eb4e9fe9a1