### PR TITLE
Preserve unknown fields in case store models

### DIFF
--- a/backend/core/case_store/models.py
+++ b/backend/core/case_store/models.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, confloat, conint
+from pydantic import BaseModel, Field, ConfigDict, confloat, conint
 
 
 class Bureau(str, Enum):
@@ -22,6 +22,8 @@ class Artifact(BaseModel):
     decision_source: Optional[str] = None
     debug: Optional[Dict[str, Any]] = None
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+    model_config = ConfigDict(extra="allow")
 
 
 class AccountFields(BaseModel):
@@ -49,6 +51,8 @@ class AccountFields(BaseModel):
     credit_limit: Optional[confloat(gt=-1e18, lt=1e18)] = None
     two_year_payment_history: Optional[str | List[str]] = None
     days_late_7y: Optional[str | List[str]] = None
+
+    model_config = ConfigDict(extra="allow")
 
 
 class AccountCase(BaseModel):

--- a/tests/test_pydantic_extra_allowed.py
+++ b/tests/test_pydantic_extra_allowed.py
@@ -1,0 +1,44 @@
+def _dump(model):
+    if hasattr(model, "model_dump"):
+        return model.model_dump()
+    return model.dict()
+
+
+def test_accountfields_preserves_unknown(monkeypatch):
+    from backend.core.case_store.models import AccountFields
+
+    payload = {
+        "balance_owed": 100.0,
+        "credit_limit": 1000.0,
+        "EXTRA_label_new": "seen-in-report",
+        "weird_field": {"nested": 1, "arr": [1, 2]},
+    }
+    m = AccountFields(**payload)
+    out = _dump(m)
+    assert out["EXTRA_label_new"] == "seen-in-report"
+    assert out["weird_field"]["nested"] == 1
+    assert out["weird_field"]["arr"] == [1, 2]
+
+    m2 = AccountFields(**out)
+    out2 = _dump(m2)
+    assert "EXTRA_label_new" in out2 and "weird_field" in out2
+
+
+def test_artifact_preserves_unknown():
+    from backend.core.case_store.models import Artifact
+
+    payload = {
+        "primary_issue": "unknown",
+        "tier": "none",
+        "decision_source": "rules",
+        "ai_meta": {"latency_ms": 12, "trace_id": "abc"},
+        "EXTRA_debug_blob": {"foo": "bar"},
+    }
+    a = Artifact(**payload)
+    out = _dump(a)
+    assert out["ai_meta"]["latency_ms"] == 12
+    assert out["EXTRA_debug_blob"]["foo"] == "bar"
+
+    a2 = Artifact(**out)
+    out2 = _dump(a2)
+    assert "EXTRA_debug_blob" in out2


### PR DESCRIPTION
## Summary
- allow AccountFields and Artifact models to retain unrecognized keys
- add regression tests ensuring extras survive round-trip serialization

## Testing
- `pytest tests/test_pydantic_extra_allowed.py -q`
- `pytest` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b7178a75988325b7615d505c7d88f0