### PR TITLE
Implement optimistic concurrency for Case Store writes

### DIFF
--- a/backend/core/case_store/errors.py
+++ b/backend/core/case_store/errors.py
@@ -7,10 +7,24 @@ class CaseStoreError(Exception):
     message: str
 
 
+@dataclass
+class CaseWriteConflict(CaseStoreError):
+    account_id: str
+    last_seen_version: int
+
+
 # Known error codes
 NOT_FOUND = "NOT_FOUND"
 VALIDATION_FAILED = "VALIDATION_FAILED"
 IO_ERROR = "IO_ERROR"
+WRITE_CONFLICT = "WRITE_CONFLICT"
 
 
-__all__ = ["CaseStoreError", "NOT_FOUND", "VALIDATION_FAILED", "IO_ERROR"]
+__all__ = [
+    "CaseStoreError",
+    "CaseWriteConflict",
+    "NOT_FOUND",
+    "VALIDATION_FAILED",
+    "IO_ERROR",
+    "WRITE_CONFLICT",
+]

--- a/backend/core/case_store/models.py
+++ b/backend/core/case_store/models.py
@@ -60,6 +60,7 @@ class AccountCase(BaseModel):
     fields: AccountFields = Field(default_factory=AccountFields)
     artifacts: Dict[str, Artifact | None] = Field(default_factory=dict)
     tags: Dict[str, Any] = Field(default_factory=dict)
+    version: int = 0
 
 
 class PersonalInformation(BaseModel):
@@ -99,6 +100,7 @@ class SessionCase(BaseModel):
     report_meta: ReportMeta = Field(default_factory=ReportMeta)
     summary: Summary = Field(default_factory=Summary)
     accounts: Dict[str, AccountCase]
+    version: int = 0
 
 
 __all__ = [

--- a/tests/test_concurrency_merge.py
+++ b/tests/test_concurrency_merge.py
@@ -1,0 +1,175 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.core.case_store import api
+from backend.core.case_store.models import AccountCase, AccountFields, Bureau
+from backend.core.case_store.errors import CaseWriteConflict
+from backend.core.config.flags import Flags
+
+
+class FakeStore:
+    def __init__(self):
+        self.db = {}
+        self.overrides = []
+
+    def read(self, session_id):
+        if self.overrides:
+            return deepcopy(self.overrides.pop(0))
+        return deepcopy(self.db[session_id])
+
+    def write(self, session_id, case):
+        self.db[session_id] = deepcopy(case)
+
+
+def setup_store(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(api, "_load", lambda sid: store.read(sid))
+    monkeypatch.setattr(api, "_save", lambda case: store.write(case.session_id, case))
+    return store
+
+
+def enable_safe_merge(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "FLAGS",
+        Flags(safe_merge_enabled=True, normalized_overlay_enabled=False, case_first_build_enabled=False),
+    )
+
+
+def test_no_conflict_single_writer(monkeypatch):
+    store = setup_store(monkeypatch)
+    enable_safe_merge(monkeypatch)
+
+    session_id = "s1"
+    account_id = "a1"
+
+    case = api.create_session_case(session_id)
+    case.accounts[account_id] = AccountCase(bureau=Bureau.Equifax)
+    store.write(session_id, case)
+
+    api.upsert_account_fields(session_id, account_id, "Equifax", {"balance_owed": 100})
+
+    result = store.read(session_id).accounts[account_id]
+    assert result.version == 1
+    assert result.fields.balance_owed == 100
+
+
+def test_concurrent_updates_merge_preserved(monkeypatch):
+    store = setup_store(monkeypatch)
+    enable_safe_merge(monkeypatch)
+
+    session_id = "s2"
+    account_id = "a2"
+    case = api.create_session_case(session_id)
+    case.accounts[account_id] = AccountCase(bureau=Bureau.Equifax)
+    store.write(session_id, case)
+
+    stale_case = store.read(session_id)
+
+    api.upsert_account_fields(
+        session_id, account_id, "Equifax", {"past_due_amount": 50}
+    )
+
+    store.overrides = [stale_case]
+    api.upsert_account_fields(
+        session_id, account_id, "Equifax", {"credit_limit": 1000}
+    )
+
+    final = store.read(session_id).accounts[account_id]
+    assert final.version == 2
+    assert final.fields.past_due_amount == 50
+    assert final.fields.credit_limit == 1000
+
+
+def test_list_merge_with_conflict(monkeypatch):
+    store = setup_store(monkeypatch)
+    enable_safe_merge(monkeypatch)
+
+    session_id = "s3"
+    account_id = "a3"
+    base_case = api.create_session_case(session_id)
+    base_case.accounts[account_id] = AccountCase(
+        bureau=Bureau.Equifax,
+        fields=AccountFields(
+            payment_history=[{"date": "2024-01", "status": "OK"}]
+        ),
+    )
+    store.write(session_id, base_case)
+
+    stale_case = store.read(session_id)
+
+    api.upsert_account_fields(
+        session_id,
+        account_id,
+        "Equifax",
+        {"payment_history": [{"date": "2024-01", "status": "OK*"}]},
+    )
+
+    store.overrides = [stale_case]
+    api.upsert_account_fields(
+        session_id,
+        account_id,
+        "Equifax",
+        {"payment_history": [{"date": "2024-02", "status": "LATE"}]},
+    )
+
+    final = store.read(session_id).accounts[account_id]
+    hist = final.fields.payment_history
+    assert final.version == 2
+    assert len(hist) == 2
+    jan = next(item for item in hist if item["date"] == "2024-01")
+    feb = next(item for item in hist if item["date"] == "2024-02")
+    assert jan["status"] == "OK*"
+    assert feb["status"] == "LATE"
+
+
+def test_retry_exhaustion_raises(monkeypatch):
+    store = setup_store(monkeypatch)
+    enable_safe_merge(monkeypatch)
+
+    session_id = "s4"
+    account_id = "a4"
+
+    # Prepare overrides with steadily increasing versions to force retry exhaustion
+    overrides = []
+    for v in range(6):
+        c = api.create_session_case(session_id)
+        c.accounts[account_id] = AccountCase(bureau=Bureau.Equifax, version=v)
+        overrides.append(c)
+    store.overrides = overrides
+
+    with pytest.raises(CaseWriteConflict) as exc:
+        api.upsert_account_fields(
+            session_id, account_id, "Equifax", {"credit_limit": 100}
+        )
+
+    assert exc.value.last_seen_version == 5
+
+
+def test_append_artifact_concurrent(monkeypatch):
+    store = setup_store(monkeypatch)
+    enable_safe_merge(monkeypatch)
+
+    session_id = "s5"
+    account_id = "a5"
+    case = api.create_session_case(session_id)
+    case.accounts[account_id] = AccountCase(bureau=Bureau.Equifax)
+    store.write(session_id, case)
+
+    stale_case = store.read(session_id)
+
+    api.append_artifact(
+        session_id, account_id, "stageA_detection", {"primary_issue": "B"}
+    )
+
+    store.overrides = [stale_case]
+    api.append_artifact(
+        session_id, account_id, "stageA_detection", {"primary_issue": "A"}
+    )
+
+    final = store.read(session_id).accounts[account_id]
+    assert final.version == 2
+    assert final.artifacts["stageA_detection"].primary_issue == "A"
+    assert final.fields.model_dump(exclude_none=True) == {}
+


### PR DESCRIPTION
## Summary
- add version tracking to account and session cases
- introduce compare-and-swap loops for account field, artifact, and tag writes
- cover concurrency scenarios with new tests

## Testing
- `pytest tests/test_concurrency_merge.py -q`
- `pytest tests/test_start_process.py::test_start_process_success -q` *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68b71a0d6b908325a8610e9cbe8a1e59