### PR TITLE
Emit field coverage metrics after account extraction

### DIFF
--- a/backend/core/logic/report_analysis/extractors/accounts.py
+++ b/backend/core/logic/report_analysis/extractors/accounts.py
@@ -1,9 +1,15 @@
 """Per-bureau account block parser."""
+
 from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
 from backend.core.case_store.api import upsert_account_fields
+from backend.core.metrics.field_coverage import (
+    emit_account_field_coverage,
+    emit_session_field_coverage_summary,
+)
+
 from .tokens import ACCOUNT_FIELD_MAP, ACCOUNT_RE, parse_amount, parse_date
 
 
@@ -30,32 +36,54 @@ def _parse_block(block: List[str]) -> Tuple[str, Dict[str, object]]:
     first = block[0]
     m = ACCOUNT_RE.search(first)
     number = m.group(1) if m else ""
-    account_id = number[-4:] if number else f"synthetic-{hash(' '.join(block)) & 0xffff:x}"
+    account_id = (
+        number[-4:] if number else f"synthetic-{hash(' '.join(block)) & 0xffff:x}"
+    )
     fields: Dict[str, object] = {}
     for line in block[1:]:
-        lower = line.lower()
         if ":" not in line:
             continue
         label, value = [p.strip() for p in line.split(":", 1)]
         key = ACCOUNT_FIELD_MAP.get(label.lower())
         if not key:
             continue
-        if "amount" in key or key in {"high_balance", "balance_owed", "past_due_amount", "credit_limit", "payment_amount"}:
+        if "amount" in key or key in {
+            "high_balance",
+            "balance_owed",
+            "past_due_amount",
+            "credit_limit",
+            "payment_amount",
+        }:
             fields[key] = parse_amount(value)
-        elif key.endswith("date") or key in {"last_verified", "last_payment", "date_of_last_activity"}:
+        elif key.endswith("date") or key in {
+            "last_verified",
+            "last_payment",
+            "date_of_last_activity",
+        }:
             fields[key] = parse_date(value) or value.strip()
         else:
             fields[key] = value.strip()
     return account_id, fields
 
 
-def extract(lines: List[str], *, session_id: str, bureau: str) -> List[Dict[str, object]]:
+def extract(
+    lines: List[str], *, session_id: str, bureau: str
+) -> List[Dict[str, object]]:
     """Extract accounts from ``lines`` and write to Case Store."""
 
     blocks = _split_blocks(lines)
     results: List[Dict[str, object]] = []
     for block in blocks:
         account_id, fields = _parse_block(block)
-        upsert_account_fields(session_id=session_id, account_id=account_id, bureau=bureau, fields=fields)
+        upsert_account_fields(
+            session_id=session_id, account_id=account_id, bureau=bureau, fields=fields
+        )
+        emit_account_field_coverage(
+            session_id=session_id,
+            account_id=account_id,
+            bureau=bureau,
+            fields=fields,
+        )
         results.append({"account_id": account_id, "fields": fields})
+    emit_session_field_coverage_summary(session_id=session_id)
     return results

--- a/backend/core/metrics/field_coverage.py
+++ b/backend/core/metrics/field_coverage.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Dict, List
+
+from backend.core.case_store import api as case_store
+
+logger = logging.getLogger(__name__)
+
+
+# Simple metrics interface with gauge and count methods.
+class _Metrics:
+    def gauge(
+        self, name: str, value: float, tags: Dict[str, str] | None = None
+    ) -> None:
+        logger.info("metric %s %s %s", name, value, tags)
+
+    def count(self, name: str, value: int, tags: Dict[str, str] | None = None) -> None:
+        logger.info("metric %s %s %s", name, value, tags)
+
+
+metrics = _Metrics()
+
+EXPECTED_FIELDS: Dict[str, List[str]] = {
+    "Experian": [
+        "balance_owed",
+        "credit_limit",
+        "high_balance",
+        "date_opened",
+        "account_status",
+        "past_due_amount",
+        "payment_status",
+        "two_year_payment_history",
+    ],
+    "Equifax": [
+        "balance_owed",
+        "credit_limit",
+        "high_balance",
+        "date_opened",
+        "account_status",
+        "past_due_amount",
+        "payment_status",
+        "two_year_payment_history",
+    ],
+    "TransUnion": [
+        "balance_owed",
+        "credit_limit",
+        "high_balance",
+        "date_opened",
+        "account_status",
+        "past_due_amount",
+        "payment_status",
+        "two_year_payment_history",
+    ],
+}
+
+_MAX_LOG_FIELDS = 20
+_TOP_K = 10
+
+
+def _is_filled(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return True
+
+
+def emit_account_field_coverage(
+    *, session_id: str, account_id: str, bureau: str, fields: Dict[str, object]
+) -> None:
+    try:
+        expected = EXPECTED_FIELDS.get(bureau, [])
+        missing = [f for f in expected if not _is_filled(fields.get(f))]
+        filled_count = len(expected) - len(missing)
+        expected_count = len(expected)
+        coverage_pct = round(100 * filled_count / max(1, expected_count))
+        metrics.gauge(
+            "stage1.field_coverage.account",
+            coverage_pct,
+            tags={"session_id": session_id, "account_id": account_id, "bureau": bureau},
+        )
+        if missing:
+            logger.info(
+                "field_coverage.missing %s",
+                {
+                    "session_id": session_id,
+                    "account_id": account_id,
+                    "bureau": bureau,
+                    "missing": missing[:_MAX_LOG_FIELDS],
+                },
+            )
+    except Exception:
+        logger.exception("field_coverage_account_failed")
+
+
+def emit_session_field_coverage_summary(*, session_id: str) -> None:
+    try:
+        missing_counts: Dict[str, int] = {}
+        for account_id in case_store.list_accounts(session_id):
+            case = case_store.get_account_case(session_id, account_id)
+            bureau = getattr(case.bureau, "value", str(case.bureau))
+            fields = case.fields.model_dump()
+            expected = EXPECTED_FIELDS.get(bureau, [])
+            for field in expected:
+                if not _is_filled(fields.get(field)):
+                    missing_counts[field] = missing_counts.get(field, 0) + 1
+        top_items = sorted(missing_counts.items(), key=lambda kv: kv[1], reverse=True)[
+            :_TOP_K
+        ]
+        for name, count in top_items:
+            metrics.count(
+                "stage1.field_coverage.missing.count",
+                count,
+                tags={"session_id": session_id, "field": name},
+            )
+        logger.info(
+            "field_coverage.session_summary %s",
+            {
+                "session_id": session_id,
+                "top_missing": [{"field": n, "count": c} for n, c in top_items],
+            },
+        )
+    except Exception:
+        logger.exception("field_coverage_session_failed")

--- a/tests/test_field_coverage_metrics.py
+++ b/tests/test_field_coverage_metrics.py
@@ -1,0 +1,127 @@
+import ast
+import logging
+
+from backend.core.case_store.models import AccountCase, AccountFields, Bureau
+from backend.core.metrics import field_coverage
+
+
+class FakeMetrics:
+    def __init__(self):
+        self.calls = []
+
+    def gauge(self, name, value, tags=None):
+        self.calls.append(("gauge", name, value, tags))
+
+    def count(self, name, value, tags=None):
+        self.calls.append(("count", name, value, tags))
+
+
+def test_account_coverage_basic(monkeypatch, caplog):
+    fake = FakeMetrics()
+    monkeypatch.setattr(field_coverage, "metrics", fake)
+
+    fields = {
+        "balance_owed": 100,
+        "credit_limit": 1000,
+        "high_balance": 500,
+        "date_opened": "2020-01-01",
+        "account_status": "open",
+    }
+
+    caplog.set_level(logging.INFO)
+    field_coverage.emit_account_field_coverage(
+        session_id="S1",
+        account_id="A1",
+        bureau="Experian",
+        fields=fields,
+    )
+
+    assert (
+        "gauge",
+        "stage1.field_coverage.account",
+        62,
+        {"session_id": "S1", "account_id": "A1", "bureau": "Experian"},
+    ) in fake.calls
+    missing_record = next(
+        r for r in caplog.records if "field_coverage.missing" in r.message
+    )
+    assert "past_due_amount" in missing_record.message
+    assert "payment_status" in missing_record.message
+    assert "two_year_payment_history" in missing_record.message
+
+
+def test_session_summary_top_missing(monkeypatch, caplog):
+    fake = FakeMetrics()
+    monkeypatch.setattr(field_coverage, "metrics", fake)
+
+    cases = {
+        "a1": AccountCase(
+            bureau=Bureau.Experian,
+            fields=AccountFields(
+                balance_owed=1,
+                credit_limit=2,
+                high_balance=3,
+            ),
+        ),
+        "a2": AccountCase(
+            bureau=Bureau.Equifax,
+            fields=AccountFields(
+                balance_owed=1,
+                credit_limit=2,
+            ),
+        ),
+        "a3": AccountCase(
+            bureau=Bureau.TransUnion,
+            fields=AccountFields(
+                balance_owed=1,
+                credit_limit=2,
+                high_balance=3,
+                account_status="open",
+            ),
+        ),
+    }
+
+    monkeypatch.setattr(
+        field_coverage.case_store,
+        "list_accounts",
+        lambda session_id: list(cases.keys()),
+    )
+
+    def fake_get_account_case(session_id, account_id):
+        return cases[account_id]
+
+    monkeypatch.setattr(
+        field_coverage.case_store, "get_account_case", fake_get_account_case
+    )
+
+    caplog.set_level(logging.INFO)
+    field_coverage.emit_session_field_coverage_summary(session_id="S1")
+
+    counts = {call[3]["field"]: call[2] for call in fake.calls if call[0] == "count"}
+    assert counts["date_opened"] == 3
+    assert counts["past_due_amount"] == 3
+
+    summary_record = next(
+        r for r in caplog.records if "field_coverage.session_summary" in r.message
+    )
+    payload = ast.literal_eval(summary_record.message.split(" ", 1)[1])
+    top_counts = [item["count"] for item in payload["top_missing"]]
+    assert top_counts == sorted(top_counts, reverse=True)
+
+
+def test_no_raise_on_errors(monkeypatch, caplog):
+    fake = FakeMetrics()
+    monkeypatch.setattr(field_coverage, "metrics", fake)
+
+    monkeypatch.setattr(
+        field_coverage.case_store, "list_accounts", lambda session_id: ["a1"]
+    )
+
+    def boom(session_id, account_id):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(field_coverage.case_store, "get_account_case", boom)
+
+    caplog.set_level(logging.ERROR)
+    field_coverage.emit_session_field_coverage_summary(session_id="S1")
+    assert any("field_coverage_session_failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- track per-account field coverage and session-wide missing-field metrics
- hook field coverage metrics into account extraction
- test metrics emission and robustness

## Testing
- `pre-commit run --files backend/core/metrics/field_coverage.py backend/core/logic/report_analysis/extractors/accounts.py tests/test_field_coverage_metrics.py`
- `pytest tests/test_field_coverage_metrics.py`


------
https://chatgpt.com/codex/tasks/task_b_68b721e8ba188325aba25a411b1ab0d7