### PR TITLE
Add source-aware normalized overlay with registry and metrics

### DIFF
--- a/backend/core/normalize/apply.py
+++ b/backend/core/normalize/apply.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import yaml
+
+from backend.core.metrics.field_coverage import metrics
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_CACHE: Dict[str, Any] | None = None
+_PRIORITY = ["EQ", "TU", "EX"]
+
+
+def load_registry(path: str | None = None) -> Dict[str, Any]:
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is not None:
+        return _REGISTRY_CACHE
+    p = Path(path) if path else Path(__file__).with_name("registry.yaml")
+    try:
+        with open(p) as fh:
+            _REGISTRY_CACHE = yaml.safe_load(fh) or {}
+    except Exception:
+        logger.exception("normalized_registry_load_failed")
+        _REGISTRY_CACHE = {}
+    return _REGISTRY_CACHE
+
+
+def _coerce_number(val: Any) -> Tuple[float | None, bool]:
+    try:
+        text = str(val).replace(",", "")
+        return float(text), False
+    except Exception:
+        return None, False
+
+
+def _coerce_string(val: Any) -> Tuple[str, bool]:
+    text = str(val)
+    stripped = text.strip()
+    return stripped, stripped != text
+
+
+def _coerce_date_iso(val: Any) -> Tuple[str, bool]:
+    text = str(val).strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"):
+        try:
+            d = datetime.strptime(text, fmt)
+            return d.strftime("%Y-%m-%d"), False
+        except ValueError:
+            pass
+    for fmt in ("%m/%Y", "%m-%Y"):
+        try:
+            d = datetime.strptime(text, fmt)
+            return d.strftime("%Y-%m-01"), True
+        except ValueError:
+            pass
+    for fmt in ("%Y",):
+        try:
+            d = datetime.strptime(text, fmt)
+            return d.strftime("%Y-01-01"), True
+        except ValueError:
+            pass
+    return text, False
+
+
+def build_normalized(by_bureau: Dict[str, Dict[str, Any]], registry: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    overlay: Dict[str, Dict[str, Any]] = {}
+    fields = registry.get("fields", {})
+    bureaus = registry.get("bureaus", [])
+    for field_name, cfg in fields.items():
+        sources_raw: Dict[str, Any] = {}
+        coerced_vals: Dict[str, Any] = {}
+        derived_flags: Dict[str, bool] = {}
+        labels_map = cfg.get("bureau_labels", {})
+        for bureau in bureaus:
+            raw_dict = by_bureau.get(bureau, {}) or {}
+            candidates = labels_map.get(bureau, [])
+            key = next((l for l in candidates if l in raw_dict), None)
+            if key is None:
+                continue
+            raw_value = raw_dict.get(key)
+            sources_raw[bureau] = raw_value
+            coerce_type = cfg.get("coerce", "passthrough")
+            derived = False
+            value = raw_value
+            if coerce_type == "number":
+                value, _ = _coerce_number(raw_value)
+            elif coerce_type == "string":
+                value, derived = _coerce_string(raw_value)
+            elif coerce_type == "date_iso":
+                value, derived = _coerce_date_iso(raw_value)
+            elif coerce_type == "passthrough":
+                value = raw_value
+            norm_map = cfg.get("normalize_map", {})
+            if isinstance(value, str):
+                lowered = value.lower()
+                for canon, variants in norm_map.items():
+                    var_lows = [v.lower() for v in variants]
+                    if lowered == canon.lower() or lowered in var_lows:
+                        if value != canon:
+                            derived = True
+                        value = canon
+                        break
+            coerced_vals[bureau] = value
+            derived_flags[bureau] = derived
+        if not coerced_vals:
+            overlay[field_name] = {"sources": {}, "status": "missing"}
+            continue
+        # determine value and status
+        val_map: Dict[Any, list[str]] = {}
+        for b, v in coerced_vals.items():
+            val_map.setdefault(v, []).append(b)
+        if len(val_map) == 1:
+            chosen_value = next(iter(val_map.keys()))
+            bureaus_present = list(coerced_vals.keys())
+            if len(bureaus_present) == 1 and derived_flags[bureaus_present[0]]:
+                status = "derived"
+            else:
+                status = "agreed"
+        else:
+            status = "conflict"
+            max_count = max(len(bs) for bs in val_map.values())
+            tied = [v for v, bs in val_map.items() if len(bs) == max_count]
+            if len(tied) == 1:
+                chosen_value = tied[0]
+            else:
+                chosen_value = None
+                for b in _PRIORITY:
+                    if b in coerced_vals and coerced_vals[b] in tied:
+                        chosen_value = coerced_vals[b]
+                        break
+                if chosen_value is None:
+                    chosen_value = tied[0]
+        field_entry = {"sources": sources_raw, "status": status}
+        if status != "missing":
+            field_entry["value"] = chosen_value
+        overlay[field_name] = field_entry
+    return overlay
+
+
+def compute_mapping_coverage(
+    by_bureau: Dict[str, Dict[str, Any]],
+    registry: Dict[str, Any],
+) -> Tuple[float, Dict[str, int]]:
+    mapping: Dict[str, set[str]] = {}
+    for cfg in registry.get("fields", {}).values():
+        for bureau, labels in cfg.get("bureau_labels", {}).items():
+            mapping.setdefault(bureau, set()).update(labels)
+    mapped = 0
+    total = 0
+    unmapped: Dict[str, int] = {}
+    for bureau, data in by_bureau.items():
+        for label in data.keys():
+            total += 1
+            if label in mapping.get(bureau, set()):
+                mapped += 1
+            else:
+                unmapped[label] = unmapped.get(label, 0) + 1
+    percent = round(100.0 * mapped / total, 2) if total else 0.0
+    return percent, unmapped
+
+
+def emit_mapping_coverage_metrics(
+    session_id: str,
+    account_id: str,
+    by_bureau: Dict[str, Dict[str, Any]],
+    registry: Dict[str, Any],
+) -> None:
+    try:
+        percent, unmapped = compute_mapping_coverage(by_bureau, registry)
+        metrics.gauge(
+            "stage1.normalized.registry.coverage",
+            percent,
+            tags={"session_id": session_id, "account_id": account_id},
+        )
+        top = sorted(unmapped.items(), key=lambda kv: kv[1], reverse=True)[:20]
+        for label, count in top:
+            metrics.count(
+                "stage1.normalized.registry.unmapped",
+                count,
+                tags={"session_id": session_id, "label": label},
+            )
+        if top:
+            logger.info(
+                "normalized.registry_unmapped %s",
+                {
+                    "session_id": session_id,
+                    "account_id": account_id,
+                    "top_unmapped": top,
+                },
+            )
+    except Exception:
+        logger.exception("normalized_registry_metrics_failed")

--- a/backend/core/normalize/registry.yaml
+++ b/backend/core/normalize/registry.yaml
@@ -1,0 +1,38 @@
+version: 1
+bureaus: ["EQ", "TU", "EX"]
+
+fields:
+  current_balance:
+    type: number
+    bureau_labels:
+      EQ: ["Current Balance", "Balance"]
+      TU: ["Balance"]
+      EX: ["Current Balance Amount"]
+    coerce: number
+
+  credit_limit:
+    type: number
+    bureau_labels:
+      EQ: ["Credit Limit"]
+      TU: ["Credit Limit"]
+      EX: ["Credit Limit Amount"]
+    coerce: number
+
+  opened_date:
+    type: date
+    bureau_labels:
+      EQ: ["Date Opened"]
+      TU: ["Opened"]
+      EX: ["Date Opened"]
+    coerce: date_iso
+
+  account_status:
+    type: string
+    bureau_labels:
+      EQ: ["Account Status"]
+      TU: ["Status"]
+      EX: ["Status"]
+    coerce: string
+    normalize_map:
+      "open": ["OPEN", "Open", "Active"]
+      "closed": ["CLOSED", "Closed"]

--- a/tests/test_normalized_provenance.py
+++ b/tests/test_normalized_provenance.py
@@ -1,0 +1,135 @@
+import logging
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from backend.core.case_store import api as case_store, storage
+from backend.core.config.flags import Flags
+from backend.core.normalize import apply
+from backend.core.logic.report_analysis.extractors import accounts
+
+REGISTRY: Dict[str, object] = {
+    "version": 1,
+    "bureaus": ["EQ", "TU", "EX"],
+    "fields": {
+        "current_balance": {
+            "type": "number",
+            "bureau_labels": {
+                "EQ": ["Balance"],
+                "TU": ["Balance"],
+            },
+            "coerce": "number",
+        },
+        "credit_limit": {
+            "type": "number",
+            "bureau_labels": {
+                "EQ": ["Credit Limit"],
+                "TU": ["Credit Limit"],
+            },
+            "coerce": "number",
+        },
+        "opened_date": {
+            "type": "date",
+            "bureau_labels": {
+                "EX": ["Date Opened"],
+            },
+            "coerce": "date_iso",
+        },
+        "account_status": {
+            "type": "string",
+            "bureau_labels": {
+                "EQ": ["Status"],
+            },
+            "coerce": "string",
+            "normalize_map": {"open": ["OPEN", "Open"]},
+        },
+    },
+}
+
+
+def test_agreed_values_provenance():
+    by_bureau = {"EQ": {"Balance": 100}, "TU": {"Balance": 100}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["current_balance"]
+    assert field["status"] == "agreed"
+    assert field["value"] == 100.0
+    assert field["sources"] == {"EQ": 100, "TU": 100}
+
+
+def test_conflict_with_priority_tie_break():
+    by_bureau = {"EQ": {"Balance": 100}, "TU": {"Balance": 120}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["current_balance"]
+    assert field["status"] == "conflict"
+    assert field["value"] == 100.0
+    assert field["sources"] == {"EQ": 100, "TU": 120}
+
+
+def test_derived_date_coercion():
+    by_bureau = {"EX": {"Date Opened": "03/2020"}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["opened_date"]
+    assert field["status"] == "derived"
+    assert field["value"] == "2020-03-01"
+    assert field["sources"] == {"EX": "03/2020"}
+
+
+def test_missing_field():
+    by_bureau = {"EQ": {}, "TU": {}, "EX": {}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["credit_limit"]
+    assert field["status"] == "missing"
+    assert field["sources"] == {}
+    assert "value" not in field
+
+
+def test_registry_coverage_metrics():
+    by_bureau = {
+        "EQ": {"Balance": 1, "Foo": 2},
+        "TU": {"Balance": 3, "Bar": 4},
+    }
+    pct, unmapped = apply.compute_mapping_coverage(by_bureau, REGISTRY)
+    assert pct == 50.0
+    assert unmapped == {"Foo": 1, "Bar": 1}
+
+
+def _bootstrap(monkeypatch, tmp_path: Path, session_id: str) -> str:
+    monkeypatch.setattr(storage, "CASESTORE_DIR", tmp_path.as_posix())
+    case = case_store.create_session_case(session_id)
+    case_store.save_session_case(case)
+    return session_id
+
+
+def test_flag_gates_overlay_write(tmp_path, monkeypatch):
+    account_id = "7890"
+    lines = ["Account 1234567890", "Balance: 100"]
+    monkeypatch.setattr(apply, "load_registry", lambda path=None: REGISTRY)
+
+    # flag off
+    session_off = _bootstrap(monkeypatch, tmp_path, "sess_off")
+    from backend.core.config import flags as flags_mod
+
+    off_flags = Flags(safe_merge_enabled=True, normalized_overlay_enabled=False, case_first_build_enabled=False)
+    monkeypatch.setattr(flags_mod, "FLAGS", off_flags)
+    monkeypatch.setattr(accounts, "FLAGS", off_flags)
+    accounts.extract(lines, session_id=session_off, bureau="Equifax")
+    case = case_store.get_account_case(session_off, account_id)
+    assert "normalized" not in case.fields.model_dump()
+
+    # flag on
+    session_on = _bootstrap(monkeypatch, tmp_path, "sess_on")
+    case_store.upsert_account_fields(
+        session_on,
+        account_id,
+        "Equifax",
+        {"by_bureau": {"EQ": {"Balance": 100}}},
+    )
+    on_flags = Flags(safe_merge_enabled=True, normalized_overlay_enabled=True, case_first_build_enabled=False)
+    monkeypatch.setattr(flags_mod, "FLAGS", on_flags)
+    monkeypatch.setattr(accounts, "FLAGS", on_flags)
+    accounts.extract(lines, session_id=session_on, bureau="Equifax")
+    case2 = case_store.get_account_case(session_on, account_id)
+    fields = case2.fields.model_dump()
+    assert "normalized" in fields
+    assert fields["normalized"]["current_balance"]["value"] == 100.0


### PR DESCRIPTION
## Summary
- introduce normalization registry and builder producing per-field provenance
- emit registry coverage metrics and track unmapped labels
- allow case store upserts without bureau and wire overlay generation behind flag

## Testing
- `pytest tests/test_normalized_provenance.py -q`
- `pytest tests/test_case_store_api.py::test_round_trip -q`
- `pytest tests/test_case_store_api.py::test_upsert_account_fields_redaction -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7246d0df48325941a60169466f10a