### PR TITLE
feat: add logical account index with feature flag

### DIFF
--- a/backend/core/case_store/models.py
+++ b/backend/core/case_store/models.py
@@ -92,6 +92,7 @@ class Summary(BaseModel):
     payments: Optional[confloat(gt=-1e18, lt=1e18)] = None
     public_records: conint(ge=0) = 0
     inquiries_2y: conint(ge=0) = 0
+    logical_index: Dict[str, str] = Field(default_factory=dict)
 
 
 class SessionCase(BaseModel):

--- a/backend/core/config/flags.py
+++ b/backend/core/config/flags.py
@@ -13,6 +13,7 @@ def get_bool_env(name: str, default: bool = False) -> bool:
 SAFE_MERGE_ENABLED = get_bool_env("SAFE_MERGE_ENABLED", False)
 NORMALIZED_OVERLAY_ENABLED = get_bool_env("NORMALIZED_OVERLAY_ENABLED", False)
 CASE_FIRST_BUILD_ENABLED = get_bool_env("CASE_FIRST_BUILD_ENABLED", False)
+ONE_CASE_PER_ACCOUNT_ENABLED = get_bool_env("ONE_CASE_PER_ACCOUNT_ENABLED", False)
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,7 @@ class Flags:
     safe_merge_enabled: bool = SAFE_MERGE_ENABLED
     normalized_overlay_enabled: bool = NORMALIZED_OVERLAY_ENABLED
     case_first_build_enabled: bool = CASE_FIRST_BUILD_ENABLED
+    one_case_per_account_enabled: bool = ONE_CASE_PER_ACCOUNT_ENABLED
 
 
 FLAGS = Flags()

--- a/tests/test_logical_index.py
+++ b/tests/test_logical_index.py
@@ -1,0 +1,61 @@
+import warnings
+from pathlib import Path
+
+import pytest
+
+from backend.core.case_store import api, storage
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+def configure(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(storage, "CASESTORE_DIR", tmp_path.as_posix())
+
+
+def bootstrap_session(monkeypatch, tmp_path: Path) -> str:
+    configure(monkeypatch, tmp_path)
+    case = api.create_session_case("sess", meta={})
+    api.save_session_case(case)
+    return case.session_id
+
+
+def test_same_logical_key_returns_same_id(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path)
+    first = api.get_or_create_logical_account_id(session_id, "key1")
+    second = api.get_or_create_logical_account_id(session_id, "key1")
+    assert first == second
+    loaded = api.load_session_case(session_id)
+    assert loaded.summary.logical_index["key1"] == first
+    assert first in loaded.accounts
+
+
+def test_new_logical_keys_generate_new_ids(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path)
+    aid1 = api.get_or_create_logical_account_id(session_id, "key1")
+    aid2 = api.get_or_create_logical_account_id(session_id, "key2")
+    assert aid1 != aid2
+    loaded = api.load_session_case(session_id)
+    assert loaded.summary.logical_index["key1"] == aid1
+    assert loaded.summary.logical_index["key2"] == aid2
+
+
+def test_cas_retry_on_conflict(tmp_path, monkeypatch):
+    session_id = bootstrap_session(monkeypatch, tmp_path)
+    real_load = api._load
+    call_counter = {"n": 0}
+
+    def fake_load(sid: str):
+        call_counter["n"] += 1
+        case = real_load(sid)
+        if call_counter["n"] == 2:
+            case.version += 1
+        return case
+
+    monkeypatch.setattr(api, "_load", fake_load)
+    aid = api.get_or_create_logical_account_id(session_id, "key1")
+    assert call_counter["n"] >= 4
+    monkeypatch.setattr(api, "_load", real_load)
+    loaded = api.load_session_case(session_id)
+    assert loaded.summary.logical_index["key1"] == aid
+    assert aid in loaded.accounts


### PR DESCRIPTION
## Summary
- add ONE_CASE_PER_ACCOUNT_ENABLED feature flag
- persist session-level logical index for account IDs
- add API helper to get or create logical account IDs
- cover logical index behavior with unit tests

## Testing
- `pytest tests/test_logical_index.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b73c2033d88325bff893fca2b8810d