### PR TITLE
Add read-time by-bureau shim for legacy sessions

### DIFF
--- a/backend/core/compat/legacy_shim.py
+++ b/backend/core/compat/legacy_shim.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+from backend.analytics.analytics_tracker import emit_counter
+from backend.core.case_store.api import get_account_case, list_accounts
+from backend.core.case_store.merge import safe_deep_merge
+from backend.core.case_store.models import AccountCase, Bureau
+from backend.core.orchestrators import compute_logical_account_key
+
+logger = logging.getLogger(__name__)
+
+_BUREAU_CODES = {
+    Bureau.Experian: "EX",
+    Bureau.Equifax: "EQ",
+    Bureau.TransUnion: "TU",
+}
+
+
+def get_logical_key_for_case(case: AccountCase) -> str | None:
+    """Best-effort logical key resolution for an ``AccountCase``."""
+    summary = getattr(case, "summary", None)
+    key = getattr(summary, "logical_key", None)
+    if key:
+        return str(key)
+
+    last4 = (case.fields.account_number or "")[-4:]
+    creditor = (case.fields.creditor_type or "") or (case.fields.account_type or "")
+    opened = case.fields.date_opened or ""
+    if not any([last4, creditor, opened]):
+        return None
+    try:
+        return compute_logical_account_key(case)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def gather_cases_by_logical_key(session_id: str, logical_key: str) -> List[AccountCase]:
+    """Return all cases in ``session_id`` matching ``logical_key``."""
+    matches: List[AccountCase] = []
+    for acc_id in list_accounts(session_id):  # type: ignore[operator]
+        case = get_account_case(session_id, acc_id)  # type: ignore[operator]
+        key = get_logical_key_for_case(case)
+        if key == logical_key:
+            matches.append(case)
+    return matches
+
+
+def build_by_bureau_shim(session_id: str, account_id: str) -> Dict[str, Dict]:
+    """Synthesize a transient ``by_bureau`` map for legacy sessions."""
+    base_case = get_account_case(session_id, account_id)
+    logical_key = get_logical_key_for_case(base_case)
+    if not logical_key:
+        emit_counter("stage1.legacy_shim.missing_key")
+        return {}
+
+    cases = gather_cases_by_logical_key(session_id, logical_key)
+    by_bureau: Dict[str, Dict] = {}
+    for case in cases:
+        code = _BUREAU_CODES.get(case.bureau, case.bureau.value[:2].upper())
+        fields = case.fields.model_dump()
+        existing = by_bureau.get(code)
+        by_bureau[code] = safe_deep_merge(existing or {}, fields)
+
+    emit_counter("stage1.legacy_shim.applied")
+    try:  # pragma: no cover - best effort logging
+        logger.debug(
+            "legacy_shim.applied",
+            extra={
+                "session_id": session_id,
+                "account_id": account_id,
+                "logical_key": logical_key,
+                "present_bureaus": sorted(by_bureau.keys()),
+            },
+        )
+    except Exception:
+        logger.exception("legacy_shim_logging_failed")
+    return by_bureau

--- a/backend/core/materialize/casestore_view.py
+++ b/backend/core/materialize/casestore_view.py
@@ -4,12 +4,15 @@ from typing import Any, Dict
 
 from backend.core.case_store.api import get_account_case
 from backend.core.config.flags import FLAGS
+from backend.core.compat.legacy_shim import build_by_bureau_shim
 
 
 def build_account_view(session_id: str, account_id: str) -> dict:
     case = get_account_case(session_id, account_id)
     fields_dict: Dict[str, Any] = case.fields.model_dump()
     by_bureau = fields_dict.get("by_bureau") or {}
+    if FLAGS.one_case_per_account_enabled and not by_bureau:
+        by_bureau = build_by_bureau_shim(session_id, account_id)
 
     view_fields: Dict[str, Any] = {"by_bureau": by_bureau}
     if "normalized" in fields_dict:

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -232,6 +232,10 @@ def collect_stageA_problem_accounts(session_id: str) -> list[Mapping[str, Any]]:
 
         if FLAGS.one_case_per_account_enabled:
             by_bureau = getattr(case.fields, "by_bureau", {}) or {}
+            if not by_bureau:
+                from backend.core.compat.legacy_shim import build_by_bureau_shim
+
+                by_bureau = build_by_bureau_shim(session_id, acc_id)
             bureau_codes = list(by_bureau.keys()) or ["EX", "EQ", "TU"]
             for code in bureau_codes:
                 art = case.artifacts.get(f"stageA_detection.{code}")

--- a/tests/compat/test_legacy_shim.py
+++ b/tests/compat/test_legacy_shim.py
@@ -1,0 +1,63 @@
+import importlib
+from pathlib import Path
+
+import backend.config as config
+from backend.core.case_store import api as cs_api
+import backend.core.compat.legacy_shim as shim
+
+
+BUREAU_NAMES = {"EX": "Experian", "EQ": "Equifax", "TU": "TransUnion"}
+
+
+def _setup(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(config, "CASESTORE_DIR", tmp_path.as_posix())
+    monkeypatch.setenv("SAFE_MERGE_ENABLED", "1")
+    monkeypatch.setenv("ONE_CASE_PER_ACCOUNT_ENABLED", "1")
+    import backend.core.config.flags as flags
+    importlib.reload(flags)
+    importlib.reload(cs_api)
+    importlib.reload(shim)
+
+
+def _create_legacy_cases(session_id: str, bureaus: list[str]) -> None:
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    base = {
+        "account_number": "00001234",
+        "creditor_type": "card",
+        "date_opened": "2020-01-01",
+    }
+    for idx, code in enumerate(bureaus, 1):
+        fields = dict(base)
+        fields["balance_owed"] = idx
+        cs_api.upsert_account_fields(session_id, f"acc-{code.lower()}", BUREAU_NAMES[code], fields)
+
+
+def test_build_by_bureau_shim_merges_three_bureaus(tmp_path, monkeypatch):
+    _setup(monkeypatch, tmp_path)
+    session_id = "s1"
+    _create_legacy_cases(session_id, ["EX", "EQ", "TU"])
+    result = shim.build_by_bureau_shim(session_id, "acc-ex")
+    assert set(result.keys()) == {"EX", "EQ", "TU"}
+    assert result["EX"]["balance_owed"] == 1
+    assert result["EQ"]["balance_owed"] == 2
+    assert result["TU"]["balance_owed"] == 3
+
+
+def test_build_by_bureau_shim_handles_partial_bureaus(tmp_path, monkeypatch):
+    _setup(monkeypatch, tmp_path)
+    session_id = "s2"
+    _create_legacy_cases(session_id, ["EX", "TU"])
+    result = shim.build_by_bureau_shim(session_id, "acc-ex")
+    assert set(result.keys()) == {"EX", "TU"}
+    assert "EQ" not in result
+
+
+def test_build_by_bureau_shim_no_key_returns_empty(tmp_path, monkeypatch):
+    _setup(monkeypatch, tmp_path)
+    session_id = "s3"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    cs_api.upsert_account_fields(session_id, "acc-ex", "Experian", {"balance_owed": 10})
+    result = shim.build_by_bureau_shim(session_id, "acc-ex")
+    assert result == {}

--- a/tests/e2e/test_legacy_session_view.py
+++ b/tests/e2e/test_legacy_session_view.py
@@ -1,0 +1,57 @@
+import importlib
+from pathlib import Path
+
+import backend.config as config
+from backend.core.case_store import api as cs_api
+import backend.core.compat.legacy_shim as shim
+
+BUREAU_NAMES = {"EX": "Experian", "EQ": "Equifax", "TU": "TransUnion"}
+
+
+def _setup(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(config, "CASESTORE_DIR", tmp_path.as_posix())
+    monkeypatch.setenv("SAFE_MERGE_ENABLED", "1")
+    monkeypatch.setenv("ONE_CASE_PER_ACCOUNT_ENABLED", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    import backend.core.config.flags as flags
+    importlib.reload(flags)
+    importlib.reload(cs_api)
+    importlib.reload(shim)
+    import backend.core.materialize.casestore_view as cs_view
+    importlib.reload(cs_view)
+    import backend.api.app as app_module
+    importlib.reload(app_module)
+    return app_module
+
+
+def _create_legacy_session(session_id: str) -> None:
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    base = {
+        "account_number": "00001234",
+        "creditor_type": "card",
+        "date_opened": "2020-01-01",
+    }
+    for idx, code in enumerate(["EX", "EQ", "TU"], 1):
+        fields = dict(base)
+        fields["balance_owed"] = idx
+        acc_id = f"acc-{code.lower()}"
+        cs_api.upsert_account_fields(session_id, acc_id, BUREAU_NAMES[code], fields)
+        cs_api.append_artifact(session_id, acc_id, "stageA_detection", {"tier": "none"})
+
+
+def test_api_view_uses_shim_on_legacy_case(tmp_path, monkeypatch):
+    app_module = _setup(monkeypatch, tmp_path)
+    session_id = "sess-legacy"
+    _create_legacy_session(session_id)
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get(f"/api/account/{session_id}/acc-ex")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data["fields"]["by_bureau"].keys()) == {"EX", "EQ", "TU"}
+    assert "stageA_detection" in data["artifacts"]
+    assert not any(k.startswith("stageA_detection.") for k in data["artifacts"])
+    assert data["meta"]["present_bureaus"] == ["EQ", "EX", "TU"]
+    case = cs_api.get_account_case(session_id, "acc-ex")
+    assert getattr(case.fields, "by_bureau", None) is None


### PR DESCRIPTION
## Summary
- synthesize by-bureau data for legacy sessions via new compat shim
- apply shim when building account views and collector inputs
- cover legacy shim behavior with unit and e2e tests

## Testing
- `pytest tests/compat/test_legacy_shim.py -vv`
- `pytest tests/e2e/test_legacy_session_view.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_68b74df8e1188325b3e735cd087bb1f9