### PR TITLE
Enforce Case-First Stage-A and UI

### DIFF
--- a/backend/core/config/flags.py
+++ b/backend/core/config/flags.py
@@ -14,6 +14,8 @@ SAFE_MERGE_ENABLED = get_bool_env("SAFE_MERGE_ENABLED", False)
 NORMALIZED_OVERLAY_ENABLED = get_bool_env("NORMALIZED_OVERLAY_ENABLED", False)
 CASE_FIRST_BUILD_ENABLED = get_bool_env("CASE_FIRST_BUILD_ENABLED", False)
 ONE_CASE_PER_ACCOUNT_ENABLED = get_bool_env("ONE_CASE_PER_ACCOUNT_ENABLED", False)
+CASE_FIRST_BUILD_REQUIRED = get_bool_env("CASE_FIRST_BUILD_REQUIRED", True)
+DISABLE_PARSER_UI_SUMMARY = get_bool_env("DISABLE_PARSER_UI_SUMMARY", True)
 
 
 @dataclass(frozen=True)
@@ -22,6 +24,8 @@ class Flags:
     normalized_overlay_enabled: bool = NORMALIZED_OVERLAY_ENABLED
     case_first_build_enabled: bool = CASE_FIRST_BUILD_ENABLED
     one_case_per_account_enabled: bool = ONE_CASE_PER_ACCOUNT_ENABLED
+    case_first_build_required: bool = CASE_FIRST_BUILD_REQUIRED
+    disable_parser_ui_summary: bool = DISABLE_PARSER_UI_SUMMARY
 
 
 FLAGS = Flags()

--- a/tests/api/test_accounts_endpoint_casefirst.py
+++ b/tests/api/test_accounts_endpoint_casefirst.py
@@ -1,0 +1,56 @@
+import importlib
+
+import backend.config as config
+from backend.core.case_store import api as cs_api
+from backend.core.logic.report_analysis import problem_detection as pd
+
+
+def _setup_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setenv("SAFE_MERGE_ENABLED", "1")
+    monkeypatch.setenv("ONE_CASE_PER_ACCOUNT_ENABLED", "1")
+    monkeypatch.setenv("CASE_FIRST_BUILD_REQUIRED", "1")
+    monkeypatch.setenv("DISABLE_PARSER_UI_SUMMARY", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    import backend.core.config.flags as flags
+    importlib.reload(flags)
+    importlib.reload(cs_api)
+    importlib.reload(pd)
+    import backend.api.app as app_module
+    importlib.reload(app_module)
+    return app_module
+
+
+def _create_account(session_id):
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    fields = {"by_bureau": {"EX": {"balance_owed": 1, "payment_status": "late"}}}
+    cs_api.upsert_account_fields(session_id, "acc1", "Experian", fields)
+
+
+def test_no_cases_returns_empty(tmp_path, monkeypatch):
+    app_module = _setup_env(monkeypatch, tmp_path)
+    session_id = "sess1"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get(f"/api/accounts/{session_id}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["accounts"] == []
+
+
+def test_collects_from_case_store(tmp_path, monkeypatch):
+    app_module = _setup_env(monkeypatch, tmp_path)
+    session_id = "sess2"
+    _create_account(session_id)
+    pd.run_stage_a(session_id)
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get(f"/api/accounts/{session_id}")
+    assert resp.status_code == 200
+    accounts = resp.get_json()["accounts"]
+    assert accounts
+    assert all(a.get("source_stage") != "parser_aggregated" for a in accounts)

--- a/tests/e2e/test_casefirst_enforced.py
+++ b/tests/e2e/test_casefirst_enforced.py
@@ -1,0 +1,64 @@
+import importlib
+import importlib
+from pathlib import Path
+
+import pytest
+
+import backend.config as config
+from backend.core.case_store import api as cs_api
+from backend.core.case_store.errors import CaseStoreError
+from backend.core.logic.report_analysis import problem_detection as pd
+
+
+def _setup(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(config, "CASESTORE_DIR", tmp_path.as_posix())
+    monkeypatch.setattr(config, "ENABLE_CASESTORE_STAGEA", True)
+    monkeypatch.setenv("SAFE_MERGE_ENABLED", "1")
+    monkeypatch.setenv("ONE_CASE_PER_ACCOUNT_ENABLED", "1")
+    monkeypatch.setenv("CASE_FIRST_BUILD_REQUIRED", "1")
+    monkeypatch.setenv("DISABLE_PARSER_UI_SUMMARY", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    import backend.core.config.flags as flags
+    importlib.reload(flags)
+    importlib.reload(cs_api)
+    importlib.reload(pd)
+    import backend.api.app as app_module
+    importlib.reload(app_module)
+    return app_module
+
+
+def _create_account(session_id: str) -> None:
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    fields = {"by_bureau": {"EX": {"balance_owed": 1, "payment_status": "late"}}}
+    cs_api.upsert_account_fields(session_id, "acc1", "Experian", fields)
+
+
+def test_stage_a_requires_cases(tmp_path, monkeypatch):
+    app_module = _setup(monkeypatch, tmp_path)
+    session_id = "sessA"
+    case = cs_api.create_session_case(session_id)
+    cs_api.save_session_case(case)
+    with pytest.raises(CaseStoreError):
+        pd.run_stage_a(session_id)
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get(f"/api/accounts/{session_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["accounts"] == []
+
+
+def test_ui_uses_case_store(tmp_path, monkeypatch):
+    app_module = _setup(monkeypatch, tmp_path)
+    session_id = "sessB"
+    _create_account(session_id)
+    pd.run_stage_a(session_id)
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get(f"/api/accounts/{session_id}")
+    data = resp.get_json()
+    assert len(data["accounts"]) == 1
+    account_id = data["accounts"][0]["account_id"]
+    resp2 = client.get(f"/api/account/{session_id}/{account_id}")
+    assert resp2.status_code == 200
+    assert "by_bureau" in resp2.get_json()["fields"]


### PR DESCRIPTION
## Summary
- require Case Store cases for Stage-A evaluation and orchestrator flow
- rebuild /api/accounts endpoint to read Stage-A collectors only
- add CASE_FIRST_BUILD_REQUIRED and DISABLE_PARSER_UI_SUMMARY flags

## Testing
- `pytest tests/api/test_accounts_endpoint_casefirst.py tests/e2e/test_casefirst_enforced.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7690bb7648325bde1c5dea1e33b58