### PR TITLE
Add explicit CaseBuilder invocation with logging

### DIFF
--- a/backend/core/logic/report_analysis/extractors/accounts.py
+++ b/backend/core/logic/report_analysis/extractors/accounts.py
@@ -187,3 +187,12 @@ def extract(
         results.append({"account_id": account_id, "fields": fields})
     emit_session_field_coverage_summary(session_id=session_id)
     return results
+
+
+def build_account_cases(session_id: str) -> None:
+    """Build AccountCase records for ``session_id`` if needed."""
+
+    # The extractor writes directly to Case Store during analysis, so no
+    # additional work is required here. The function exists to provide an
+    # explicit orchestration hook and remains idempotent.
+    return None

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1310,6 +1310,7 @@ def extract_problematic_accounts_from_report(
     from backend.core.logic.report_analysis.analyze_report import (
         analyze_credit_report as analyze_report_logic,
     )
+    from backend.core.logic.report_analysis.extractors.accounts import build_account_cases
 
     session_id = session_id or "session"
     pdf_path = move_uploaded_file(Path(file_path), session_id)
@@ -1351,6 +1352,22 @@ def extract_problematic_accounts_from_report(
         sections.get("session_id"),
         req_id,
     )
+    logger.debug("CASEBUILDER: starting session_id=%s", session_id)
+    try:
+        pre = len(list_accounts(session_id))  # type: ignore[operator]
+    except Exception:
+        pre = -1
+    logger.debug("CASEBUILDER: pre-count=%s", pre)
+
+    build_account_cases(session_id)
+
+    try:
+        post = len(list_accounts(session_id))  # type: ignore[operator]
+    except Exception:
+        post = -1
+    logger.debug("CASEBUILDER: post-count=%s", post)
+    if post == 0:
+        logger.error("CASEBUILDER: produced 0 cases (will abort)")
     if FLAGS.case_first_build_required:
         try:
             count = len(list_accounts(session_id))  # type: ignore[operator]


### PR DESCRIPTION
## Summary
- call `build_account_cases` after report analysis to ensure account cases exist
- add detailed debug/error logging around case building
- provide no-op `build_account_cases` stub for extractor module

## Testing
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_returns_models -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68b77ef5e0048325be855740adb9582f