### PR TITLE
feat: centralize logical key generation

### DIFF
--- a/backend/core/logic/report_analysis/keys.py
+++ b/backend/core/logic/report_analysis/keys.py
@@ -1,0 +1,46 @@
+import hashlib
+from typing import Optional
+
+
+def normalize_issuer(name: str) -> str:
+    """Normalize issuer names by removing basic punctuation and collapsing spaces."""
+    if not name:
+        return ""
+    cleaned = name.replace(".", " ").replace("-", " ").replace("/", " ")
+    tokens = cleaned.split()
+    collapsed: list[str] = []
+    i = 0
+    while i < len(tokens):
+        if len(tokens[i]) == 1:
+            letters: list[str] = []
+            while i < len(tokens) and len(tokens[i]) == 1:
+                letters.append(tokens[i])
+                i += 1
+            collapsed.append("".join(letters))
+        else:
+            collapsed.append(tokens[i])
+            i += 1
+    return " ".join(collapsed).upper().strip()
+
+
+def compute_logical_account_key(
+    issuer: Optional[str],
+    last4: Optional[str],
+    account_type: Optional[str],
+    opened_date: Optional[str],
+) -> Optional[str]:
+    """Compute a stable logical key for accounts.
+
+    Returns None when there are no anchor fields (issuer, last4, opened_date).
+    """
+    issuer_norm = normalize_issuer(issuer or "")
+    acct = (account_type or "").strip().upper()
+    opened = (opened_date or "").strip()
+    last4_clean = (last4 or "").strip()
+    if not issuer_norm and not last4_clean and not opened:
+        return None
+    if last4_clean:
+        basis = f"L4:{last4_clean}|I:{issuer_norm}|T:{acct}|D:{opened}"
+    else:
+        basis = f"NO4|I:{issuer_norm}|T:{acct}|D:{opened}"
+    return hashlib.sha1(basis.encode("utf-8")).hexdigest()[:16]

--- a/tests/unit/test_logical_key.py
+++ b/tests/unit/test_logical_key.py
@@ -1,0 +1,22 @@
+from backend.core.logic.report_analysis.keys import normalize_issuer, compute_logical_account_key
+
+
+def test_normalize_issuer_variants_collapse():
+    assert normalize_issuer("U S  BANK.") == "US BANK"
+    assert normalize_issuer("u.s-bank") == "US BANK"
+    assert normalize_issuer("US BANK") == "US BANK"
+
+
+def test_key_with_last4_includes_issuer_and_is_stable():
+    k1 = compute_logical_account_key("U S BANK", "1234", "REVOLVING", "2020-01-01")
+    k2 = compute_logical_account_key("US  BANK.", "1234", "REVOLVING", "2020-01-01")
+    assert k1 == k2 and k1 is not None
+
+
+def test_key_without_last4_fallback_works():
+    k = compute_logical_account_key("US BANK", None, "REVOLVING", "2020-01-01")
+    assert k is not None and len(k) == 16
+
+
+def test_missing_everything_returns_none():
+    assert compute_logical_account_key("", None, "", "") is None


### PR DESCRIPTION
## Summary
- add issuer normalization and logical account key computation utilities
- use new logical key routine in account extractor with collision tracking
- wrap orchestrator logical key helper around new utility

## Testing
- `pytest -q tests/unit/test_logical_key.py`

------
https://chatgpt.com/codex/tasks/task_b_68b7831493388325b920356e31a61699