### PR TITLE
Add basic telemetry counters with toggle

### DIFF
--- a/backend/core/config/flags.py
+++ b/backend/core/config/flags.py
@@ -16,6 +16,7 @@ CASE_FIRST_BUILD_ENABLED = get_bool_env("CASE_FIRST_BUILD_ENABLED", False)
 ONE_CASE_PER_ACCOUNT_ENABLED = get_bool_env("ONE_CASE_PER_ACCOUNT_ENABLED", False)
 CASE_FIRST_BUILD_REQUIRED = get_bool_env("CASE_FIRST_BUILD_REQUIRED", True)
 DISABLE_PARSER_UI_SUMMARY = get_bool_env("DISABLE_PARSER_UI_SUMMARY", True)
+METRICS_ENABLED = get_bool_env("METRICS_ENABLED", True)
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,7 @@ class Flags:
     one_case_per_account_enabled: bool = ONE_CASE_PER_ACCOUNT_ENABLED
     case_first_build_required: bool = CASE_FIRST_BUILD_REQUIRED
     disable_parser_ui_summary: bool = DISABLE_PARSER_UI_SUMMARY
+    metrics_enabled: bool = METRICS_ENABLED
 
 
 FLAGS = Flags()

--- a/backend/core/logic/report_analysis/problem_detection.py
+++ b/backend/core/logic/report_analysis/problem_detection.py
@@ -11,6 +11,7 @@ from backend.core.case_store.api import append_artifact, get_account_case, list_
 from backend.core.case_store.errors import CaseStoreError
 from backend.core.case_store.redaction import redact_for_ai
 from backend.core.case_store import telemetry
+from backend.core.telemetry import metrics
 from backend.core.logic.report_analysis.candidate_logger import log_stageA_candidates
 from backend.core.taxonomy.problem_taxonomy import compare_tiers, normalize_decision
 
@@ -253,6 +254,9 @@ def run_stage_a(
             by_bureau = getattr(case.fields, "by_bureau", {}) or {}
             decisions: List[dict] = []
             for bureau, bureau_fields in by_bureau.items():
+                metrics.increment(
+                    "stageA.run.count", tags={"bureau": bureau}
+                )
                 try:
                     telemetry.emit(
                         "stageA.bureau_evaluations",

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -76,6 +76,7 @@ from backend.core.pdf.extract_text import extract_text as _debug_extract_text
 from backend.core.services.ai_client import AIClient, _StubAIClient, get_ai_client
 from backend.core.taxonomy.problem_taxonomy import compare_tiers, normalize_decision
 from backend.core.telemetry.stageE_summary import emit_stageE_summary
+from backend.core.telemetry import metrics
 from backend.core.utils.text_dump import dump_text as _dump_text
 from backend.core.utils.trace_io import write_json_trace, write_text_trace
 from backend.policy.policy_loader import load_rulebook
@@ -1355,6 +1356,7 @@ def extract_problematic_accounts_from_report(
     except Exception:
         post = -1
     logger.debug("CASEBUILDER: post-count=%s", post)
+    metrics.gauge("casestore.count", post, {"session_id": session_id})
     if post == 0:
         logger.error("CASEBUILDER: produced 0 cases (will abort)")
     if FLAGS.case_first_build_required:

--- a/backend/core/telemetry/metrics.py
+++ b/backend/core/telemetry/metrics.py
@@ -1,0 +1,16 @@
+import logging
+from backend.core.config.flags import FLAGS
+
+log = logging.getLogger(__name__)
+
+def increment(name: str, value: int = 1, tags: dict | None = None) -> None:
+    """Increment a counter metric."""
+    if not getattr(FLAGS, "metrics_enabled", True):
+        return
+    log.debug("METRIC increment name=%s value=%s tags=%s", name, value, tags or {})
+
+def gauge(name: str, value: float, tags: dict | None = None) -> None:
+    """Record a gauge metric."""
+    if not getattr(FLAGS, "metrics_enabled", True):
+        return
+    log.debug("METRIC gauge     name=%s value=%s tags=%s", name, value, tags or {})


### PR DESCRIPTION
## Summary
- add `METRICS_ENABLED` flag and lightweight metrics emitter
- capture case builder activity and totals through metrics
- record case store counts and Stage-A runs via metrics

## Testing
- `pytest -q` *(fails: KeyError: 'advisor_comment', CaseStoreError and others)*

------
https://chatgpt.com/codex/tasks/task_b_68b787ca702083258020e28f7bb19d70