### PR TITLE
feat: add CASEBUILDER_DEBUG flag

### DIFF
--- a/backend/core/config/flags.py
+++ b/backend/core/config/flags.py
@@ -4,19 +4,20 @@ from dataclasses import dataclass
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
-def get_bool_env(name: str, default: bool = False) -> bool:
+def env_bool(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
     if raw is None:
         return default
     return raw.strip().lower() in _TRUTHY
 
-SAFE_MERGE_ENABLED = get_bool_env("SAFE_MERGE_ENABLED", False)
-NORMALIZED_OVERLAY_ENABLED = get_bool_env("NORMALIZED_OVERLAY_ENABLED", False)
-CASE_FIRST_BUILD_ENABLED = get_bool_env("CASE_FIRST_BUILD_ENABLED", False)
-ONE_CASE_PER_ACCOUNT_ENABLED = get_bool_env("ONE_CASE_PER_ACCOUNT_ENABLED", False)
-CASE_FIRST_BUILD_REQUIRED = get_bool_env("CASE_FIRST_BUILD_REQUIRED", True)
-DISABLE_PARSER_UI_SUMMARY = get_bool_env("DISABLE_PARSER_UI_SUMMARY", True)
-METRICS_ENABLED = get_bool_env("METRICS_ENABLED", True)
+SAFE_MERGE_ENABLED = env_bool("SAFE_MERGE_ENABLED", False)
+NORMALIZED_OVERLAY_ENABLED = env_bool("NORMALIZED_OVERLAY_ENABLED", False)
+CASE_FIRST_BUILD_ENABLED = env_bool("CASE_FIRST_BUILD_ENABLED", False)
+ONE_CASE_PER_ACCOUNT_ENABLED = env_bool("ONE_CASE_PER_ACCOUNT_ENABLED", False)
+CASE_FIRST_BUILD_REQUIRED = env_bool("CASE_FIRST_BUILD_REQUIRED", True)
+DISABLE_PARSER_UI_SUMMARY = env_bool("DISABLE_PARSER_UI_SUMMARY", True)
+METRICS_ENABLED = env_bool("METRICS_ENABLED", True)
+CASEBUILDER_DEBUG = env_bool("CASEBUILDER_DEBUG", True)
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,7 @@ class Flags:
     case_first_build_required: bool = CASE_FIRST_BUILD_REQUIRED
     disable_parser_ui_summary: bool = DISABLE_PARSER_UI_SUMMARY
     metrics_enabled: bool = METRICS_ENABLED
+    casebuilder_debug: bool = CASEBUILDER_DEBUG
 
 
 FLAGS = Flags()

--- a/backend/core/logic/report_analysis/extractors/accounts.py
+++ b/backend/core/logic/report_analysis/extractors/accounts.py
@@ -33,7 +33,7 @@ _logical_ids: Dict[Tuple[str, str], str] = {}
 
 
 def _dbg(msg: str, *args: object) -> None:
-    if getattr(FLAGS, "CASEBUILDER_DEBUG", True):
+    if FLAGS.casebuilder_debug:
         logger.debug("CASEBUILDER: " + msg, *args)
 
 

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1342,12 +1342,14 @@ def extract_problematic_accounts_from_report(
         sections.get("session_id"),
         req_id,
     )
-    logger.debug("CASEBUILDER: starting session_id=%s", session_id)
+    if FLAGS.casebuilder_debug:
+        logger.debug("CASEBUILDER: starting session_id=%s", session_id)
     try:
         pre = len(list_accounts(session_id))  # type: ignore[operator]
     except Exception:
         pre = -1
-    logger.debug("CASEBUILDER: pre-count=%s", pre)
+    if FLAGS.casebuilder_debug:
+        logger.debug("CASEBUILDER: pre-count=%s", pre)
 
     build_account_cases(session_id)
 
@@ -1355,7 +1357,8 @@ def extract_problematic_accounts_from_report(
         post = len(list_accounts(session_id))  # type: ignore[operator]
     except Exception:
         post = -1
-    logger.debug("CASEBUILDER: post-count=%s", post)
+    if FLAGS.casebuilder_debug:
+        logger.debug("CASEBUILDER: post-count=%s", post)
     metrics.gauge("casestore.count", post, {"session_id": session_id})
     if post == 0:
         logger.error("CASEBUILDER: produced 0 cases (will abort)")


### PR DESCRIPTION
## Summary
- add CASEBUILDER_DEBUG flag to control builder debug logs
- gate CASEBUILDER logs on the new flag

## Testing
- `pytest tests/test_extractors_accounts.py tests/test_orchestrator_calls_ingest_report.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b789afdca48325b182d844669f6728