### PR TITLE
Remove parser-first account path

### DIFF
--- a/backend/core/collectors/__init__.py
+++ b/backend/core/collectors/__init__.py
@@ -1,0 +1,6 @@
+from backend.core.orchestrators import (
+    collect_stageA_logical_accounts,
+    collect_stageA_problem_accounts,
+)
+
+__all__ = ["collect_stageA_logical_accounts", "collect_stageA_problem_accounts"]

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -1375,6 +1375,8 @@ def extract_problematic_accounts_from_report(
 
     force_parser = os.getenv("ANALYSIS_FORCE_PARSER_ONLY") == "1"
     if force_parser or sections.get("ai_failed"):
+        if FLAGS.case_first_build_required:
+            raise RuntimeError("parser-first path disabled")
         logger.info("analysis_falling_back_to_parser_only force=%s", force_parser)
         sections = analyze_report_logic(
             pdf_path,
@@ -1462,14 +1464,6 @@ def extract_problematic_accounts_from_report(
         # If immutability tools unavailable, proceed without mutation guard
         pass
     _log_account_snapshot("post_inject_missing_late_accounts")
-
-    from backend.core.logic.utils.names_normalization import normalize_creditor_name
-
-    parser_only = {  # noqa: F841
-        normalize_creditor_name(a.get("name", ""))
-        for a in sections.get("all_accounts", [])
-        if a.get("source_stage") == "parser_aggregated"
-    }
 
     suppress_accounts_without_issue_types = env_bool(  # noqa: F841
         "SUPPRESS_ACCOUNTS_WITHOUT_ISSUE_TYPES", False

--- a/tests/api/test_accounts_endpoint_casefirst.py
+++ b/tests/api/test_accounts_endpoint_casefirst.py
@@ -41,7 +41,10 @@ def test_accounts_empty_when_no_cases(client, monkeypatch):
 
     # Avoid calling heavy collectors
     monkeypatch.setattr(
-        "backend.core.orchestrators.collect_stageA_logical_accounts", lambda sid: []
+        "backend.api.app.collect_stageA_problem_accounts", lambda sid: []
+    )
+    monkeypatch.setattr(
+        "backend.api.app.collect_stageA_logical_accounts", lambda sid: []
     )
 
     resp = client.get("/api/accounts/s123")
@@ -61,8 +64,12 @@ def test_accounts_from_collectors_only(client, monkeypatch):
 
     # Collectors return a simple account record
     monkeypatch.setattr(
-        "backend.core.orchestrators.collect_stageA_logical_accounts",
-        lambda sid: [{"account_id": "A1", "primary_issue": "late"}],
+        "backend.api.app.collect_stageA_problem_accounts",
+        lambda sid: [{"account_id": "A1", "bureau": "EX", "primary_issue": "late"}],
+    )
+    monkeypatch.setattr(
+        "backend.api.app.collect_stageA_logical_accounts",
+        lambda sid: [{"account_id": "A1", "bureau": "EX", "primary_issue": "late"}],
     )
 
     resp = client.get("/api/accounts/s123")

--- a/tests/api/test_problem_accounts_legacy_route.py
+++ b/tests/api/test_problem_accounts_legacy_route.py
@@ -1,0 +1,33 @@
+import pytest
+from dataclasses import replace
+from types import SimpleNamespace
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from backend.api.app import create_app
+
+    dummy_cfg = SimpleNamespace(
+        ai=SimpleNamespace(api_key="test", base_url="https://example.com"),
+        celery_broker_url="redis://localhost:6379/0",
+        secret_key="test",
+        auth_tokens=[],
+        rate_limit_per_minute=60,
+    )
+    monkeypatch.setattr("backend.api.app.get_app_config", lambda: dummy_cfg)
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def test_problem_accounts_legacy_disabled(client, monkeypatch):
+    import backend.core.config.flags as flags
+
+    monkeypatch.setattr(
+        flags,
+        "FLAGS",
+        replace(flags.FLAGS, disable_parser_ui_summary=True),
+    )
+    resp = client.get("/api/problem_accounts")
+    assert resp.status_code == 410
+    assert resp.get_json() == {"ok": False, "error": "parser_first_disabled"}


### PR DESCRIPTION
## Summary
- use Case Store collectors for `/api/accounts` and drop parser artifacts
- guard orchestrator parser fallback with CASE_FIRST flag
- block legacy `/api/problem_accounts` with 410 and add tests

## Testing
- `pytest tests/api/test_accounts_endpoint_casefirst.py tests/api/test_problem_accounts_legacy_route.py tests/e2e/test_casefirst_enforced.py -q`
- `git grep -n "parser_aggregated" backend/api backend/core/collectors backend/core/logic/report_analysis/problem_detection.py backend/core/orchestrators.py`
- `git grep -n "sections" backend/api backend/core/collectors backend/core/logic/report_analysis/problem_detection.py`


------
https://chatgpt.com/codex/tasks/task_b_68b78a9cc25483258a657ac23dd5193f