### PR TITLE
Persist session cases unconditionally

### DIFF
--- a/backend/core/logic/report_analysis/report_parsing.py
+++ b/backend/core/logic/report_analysis/report_parsing.py
@@ -388,19 +388,19 @@ def extract_pdf_page_texts(pdf_path: str | Path, max_chars: int = 20000) -> list
         import fitz  # type: ignore
     except Exception as exc:  # pragma: no cover - fitz missing
         print(f"[WARN] PyMuPDF unavailable: {exc}")
-        return []
+        fitz = None  # type: ignore
 
-    try:
-        with fitz.open(pdf_path) as doc:
-            pages = []
-            for page in doc:
-                txt = page.get_text()
-                if len(txt) > max_chars:
-                    txt = txt[:max_chars] + "\n[TRUNCATED]"
-                pages.append(txt)
-    except Exception as exc:  # pragma: no cover - runtime PDF issues
-        print(f"[WARN] Failed to extract text from {pdf_path}: {exc}")
-        return []
+    pages: list[str] = []
+    if fitz is not None:
+        try:
+            with fitz.open(pdf_path) as doc:
+                for page in doc:
+                    txt = page.get_text()
+                    if len(txt) > max_chars:
+                        txt = txt[:max_chars] + "\n[TRUNCATED]"
+                    pages.append(txt)
+        except Exception as exc:  # pragma: no cover - runtime PDF issues
+            print(f"[WARN] Failed to extract text from {pdf_path}: {exc}")
     return pages
 
 

--- a/backend/core/orchestrators.py
+++ b/backend/core/orchestrators.py
@@ -582,7 +582,7 @@ def analyze_credit_report(
         pdf_path,
         analyzed_json_path,
         client_info,
-        session_id=session_id or req_id,
+        session_id=session_id,
         request_id=req_id,
     )
     logger.info(


### PR DESCRIPTION
## Summary
- require a session_id when analyzing credit reports
- log and persist session cases at both creation and final save
- avoid premature returns in PDF page extraction

## Testing
- `pytest tests/test_parser_deterministic_flow.py::test_deterministic_flow -q`
- `pytest tests/test_ocr_fallback.py::test_no_ocr_when_disabled -q` *(fails: Segmentation fault: PyMuPDF import)*

------
https://chatgpt.com/codex/tasks/task_b_68b9d9dc11508325b952792a0a44a4b5