### PR TITLE
Capture issuer heading for account blocks

### DIFF
--- a/backend/core/logic/report_analysis/extractors/tokens.py
+++ b/backend/core/logic/report_analysis/extractors/tokens.py
@@ -76,3 +76,10 @@ def parse_date(text: str) -> Optional[str]:
     if m:
         return m.group(0)
     return None
+
+
+def normalize_issuer(text: str) -> str:
+    # strip punctuation at ends, collapse whitespace, uppercase
+    t = re.sub(r"\s+", " ", text.strip())
+    t = t.strip(",:;-–—.()[]{}")
+    return t.upper()

--- a/tests/test_accounts_issuer_heading.py
+++ b/tests/test_accounts_issuer_heading.py
@@ -1,0 +1,50 @@
+import pytest
+
+from backend.core.logic.report_analysis.extractors import accounts
+
+
+def _parse(lines):
+    blocks = accounts._split_blocks(lines)
+    assert blocks, "No blocks returned"
+    return accounts._parse_block(blocks[0])[1]
+
+
+def test_issuer_captured_from_heading_precedes_account_line():
+    lines = [
+        "JPMCB CARD",
+        "Account # 426290**********",
+        "Date Opened: 1.4.1995  1.4.1995  1.4.1995",
+    ]
+    blocks = accounts._split_blocks(lines)
+    assert blocks[0][0] == "__ISSUER_HEADING__: JPMCB CARD"
+    fields = _parse(lines)
+    assert fields["issuer"] == "JPMCB CARD"
+
+
+def test_issuer_normalization_uppercase_and_trim():
+    lines = [
+        " Bk of Amer, ",
+        "Account # 123456",
+    ]
+    fields = _parse(lines)
+    assert fields["issuer"] == "BK OF AMER"
+
+
+def test_no_heading_line_fallback():
+    lines = [
+        "Account # 123456",
+        "Date Opened: 2020-01-01",
+    ]
+    fields = _parse(lines)
+    assert "issuer" not in fields
+
+
+def test_issuer_not_overwritten_by_creditor_type():
+    lines = [
+        "AMEX",
+        "Account # 123456",
+        "Creditor Type: Bank Credit Cards",
+    ]
+    fields = _parse(lines)
+    assert fields["issuer"] == "AMEX"
+    assert fields["creditor_type"] == "Bank Credit Cards"


### PR DESCRIPTION
## Summary
- Preserve issuer headings when splitting account blocks
- Normalize issuer names and store in `fields['issuer']`
- Add tests for issuer heading extraction and normalization

## Testing
- `pytest -q tests/test_accounts_issuer_heading.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9e3a4eb488325b6102555e4f6bc9e