### PR TITLE
Disable deduplication when feature flag is off

### DIFF
--- a/tests/test_dedup_disabled_one_to_one.py
+++ b/tests/test_dedup_disabled_one_to_one.py
@@ -1,0 +1,46 @@
+from backend.core.case_store import api, storage
+from backend.core.logic.report_analysis.extractors import accounts
+from backend.core.config.flags import Flags
+
+
+def set_flags(monkeypatch, *, debug=True):
+    monkeypatch.setattr(accounts, "FLAGS", Flags(one_case_per_account_enabled=False, casebuilder_debug=debug))
+    monkeypatch.setattr(api, "FLAGS", Flags(one_case_per_account_enabled=False))
+
+
+def setup_case(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "CASESTORE_DIR", tmp_path.as_posix())
+    session_id = "sess"
+    case = api.create_session_case(session_id)
+    api.save_session_case(case)
+    return session_id
+
+
+def test_one_block_one_case_when_dedup_off(tmp_path, monkeypatch):
+    set_flags(monkeypatch)
+    session_id = setup_case(tmp_path, monkeypatch)
+    lines = [
+        "Account # 123456789",
+        "Balance Owed: $100",
+    ]
+    blocks = accounts._split_blocks(lines)
+    accounts.extract(lines, session_id=session_id, bureau="Experian")
+    case = api.load_session_case(session_id)
+    assert len(blocks) == len(case.accounts) == 1
+
+
+def test_multiple_blocks_multiple_cases_when_dedup_off(tmp_path, monkeypatch):
+    set_flags(monkeypatch)
+    session_id = setup_case(tmp_path, monkeypatch)
+    lines = [
+        "Account # 123456789",
+        "Balance Owed: $100",
+        "",
+        "Account # 123456789",
+        "Balance Owed: $200",
+    ]
+    blocks = accounts._split_blocks(lines)
+    accounts.extract(lines, session_id=session_id, bureau="Experian")
+    case = api.load_session_case(session_id)
+    assert len(blocks) == 2
+    assert len(case.accounts) == 2

--- a/tools/verify_blocks_vs_cases.py
+++ b/tools/verify_blocks_vs_cases.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Helper to verify blocks_detected vs accounts persisted."""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.core.case_store import api
+from backend.core.logic.report_analysis.extractors import accounts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("session_id")
+    parser.add_argument("input", type=Path, help="Path to report lines text")
+    args = parser.parse_args()
+
+    lines = args.input.read_text(encoding="utf-8").splitlines()
+    block_count = len(accounts._split_blocks(lines))
+    case = api.load_session_case(args.session_id)
+    account_count = len(case.accounts)
+    print(f"VERIFY 1:1 blocks_detected={block_count} accounts_persisted={account_count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- honor ONE_CASE_PER_ACCOUNT_ENABLED flag by bypassing logical account merging
- emit CASEBUILDER debug lines for each block and add session summary log
- add helper and tests verifying 1:1 block to case mapping when dedup is off

## Testing
- `pytest -q tests/test_dedup_disabled_one_to_one.py`
- `python tools/verify_blocks_vs_cases.py bringup-demo3 sample_lines.txt`


------
https://chatgpt.com/codex/tasks/task_b_68b9f8bf415c8325b2843306a1212611