### PR TITLE
Fail fast when no blocks extracted from PDF

### DIFF
--- a/backend/core/logic/report_analysis/block_exporter.py
+++ b/backend/core/logic/report_analysis/block_exporter.py
@@ -83,6 +83,14 @@ def export_account_blocks(session_id: str, pdf_path: str | Path) -> List[Dict[st
         heading = (blk[0] or "").strip()
         fbk_blocks.append({"heading": heading, "lines": blk})
 
+    if not fbk_blocks:
+        logger.error(
+            "BLOCKS_FAIL_FAST: 0 blocks extracted sid=%s file=%s",
+            session_id,
+            str(pdf_path),
+        )
+        raise ValueError("No blocks extracted")
+
     blocks_by_account_fuzzy = build_block_fuzzy(fbk_blocks) if fbk_blocks else {}
     logger.warning(
         "ANZ: pre-save fbk=%d fuzzy=%d sid=%s req=%s",


### PR DESCRIPTION
## Summary
- raise `ValueError` in `export_account_blocks` when parsing extracts zero blocks and log an error with session ID and PDF path
- ensure orchestrator invokes `export_account_blocks` directly so the exception stops the pipeline

## Testing
- `pytest` *(fails: KeyError 'stageA_detection' and others)*

------
https://chatgpt.com/codex/tasks/task_b_68bafe617d5c8325965ddcd0d6139749