### PR TITLE
Enrich account blocks with bureau fields

### DIFF
--- a/tests/report_analysis/test_block_enrichment.py
+++ b/tests/report_analysis/test_block_enrichment.py
@@ -1,0 +1,17 @@
+from backend.core.logic.report_analysis.block_exporter import enrich_block
+
+
+def test_enrich_block_extracts_fields():
+    lines = [
+        "AMERICAN EXPRESS",
+        "Transunion Experian Equifax",
+        "Account # 1234****** 1234****** 1234******",
+        "High Balance: $261 $261 $261",
+        "Payment Status: Current Current Current",
+        "Credit Limit: $1,000 $1,000 $1,000",
+    ]
+    blk = {"heading": "AMEX", "lines": lines}
+    res = enrich_block(blk)
+    assert res["fields"]["transunion"]["payment_status"] == "Current"
+    assert "****" in res["fields"]["experian"]["account_number_display"]
+    assert res["fields"]["equifax"]["credit_limit"] == "$1,000"


### PR DESCRIPTION
## Summary
- add `enrich_block` to parse bureau-specific fields from account lines
- enrich blocks during export and persist structured `fields` per bureau
- cover block enrichment with a unit test

## Testing
- `pytest tests/report_analysis/test_block_enrichment.py -q`
- `pytest -q` *(fails: KeyError: 'stageA_detection', CaseStoreError, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68bb01c595548325a2a31833899d9796