### PR TITLE
Add unit tests for block exporter

### DIFF
--- a/tests/fixtures/sample_block.pdf
+++ b/tests/fixtures/sample_block.pdf
@@ -1,0 +1,46 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 595 842]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 161/Filter/FlateDecode>>
+stream
+xmM
+A5l;NN,|q6~qQif2V)		c>ˀ]l(PNCuƜ!ٛP/]5{ז$>e6	Uω$$"j,FB(>j8
+endstream
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<C2B4C28EC3800F76C2A07F0CC38042C2><49CFFE1378E7BF5BC08B50924917E1BC>]>>
+startxref
+581
+%%EOF

--- a/tests/test_block_exporter.py
+++ b/tests/test_block_exporter.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+
+import backend.core.logic.report_analysis.block_exporter as be
+
+SAMPLE_PDF = Path(__file__).parent / "fixtures" / "sample_block.pdf"
+
+
+@pytest.fixture
+def chdir_tmp(tmp_path, monkeypatch):
+    """Run tests inside a temporary directory so traces/* are isolated."""
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+
+def _sample_text():
+    return (
+        "Sample Bank\n"
+        "TransUnion Experian Equifax\n"
+        "Account # 1234 1234 1234\n"
+        "Equifax 30:0 60:0 90:0\n"
+    )
+
+
+def test_export_writes_files(chdir_tmp, monkeypatch):
+    monkeypatch.setattr(be, "extract_text_from_pdf", lambda _p: _sample_text())
+
+    be.export_account_blocks("sess1", SAMPLE_PDF)
+
+    out_dir = Path("traces") / "blocks" / "sess1"
+    assert (out_dir / "_index.json").exists()
+    assert (out_dir / "block_01.json").exists()
+
+
+def test_load_account_blocks_reads_back(chdir_tmp, monkeypatch):
+    monkeypatch.setattr(be, "extract_text_from_pdf", lambda _p: _sample_text())
+    be.export_account_blocks("sess2", SAMPLE_PDF)
+
+    blocks = be.load_account_blocks("sess2")
+    assert isinstance(blocks, list)
+    assert blocks and isinstance(blocks[0], dict)
+    first = blocks[0]
+    assert first["heading"] == "Sample Bank"
+    assert first["lines"][0] == "Sample Bank"
+
+
+def test_fail_fast_on_empty(chdir_tmp, monkeypatch):
+    monkeypatch.setattr(be, "extract_text_from_pdf", lambda _p: "")
+    empty_pdf = chdir_tmp / "empty.pdf"
+    empty_pdf.write_bytes(b"")
+    with pytest.raises(ValueError, match="No blocks extracted"):
+        be.export_account_blocks("sess3", empty_pdf)


### PR DESCRIPTION
## Summary
- add simple PDF fixture and block_exporter unit tests
- verify block export file creation, data reload, and fail-fast behavior

## Testing
- `pytest -q tests/test_block_exporter.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb0cccaea08325be4426b8ea356802