### PR TITLE
Use cached text for block export

### DIFF
--- a/backend/core/logic/report_analysis/block_exporter.py
+++ b/backend/core/logic/report_analysis/block_exporter.py
@@ -10,8 +10,8 @@ from typing import Any, Dict, List
 from backend.core.logic.report_analysis.report_parsing import (
     build_block_fuzzy,
     detect_bureau_order,
-    extract_text_from_pdf,
 )
+from backend.core.logic.report_analysis.text_provider import load_cached_text
 from backend.core.logic.utils.text_parsing import extract_account_blocks
 
 
@@ -193,7 +193,10 @@ def export_account_blocks(
         The list of account block dictionaries, each containing ``heading`` and
         ``lines`` keys.
     """
-    text = extract_text_from_pdf(pdf_path)
+    cached = load_cached_text(session_id)
+    if not cached:
+        raise ValueError("no_cached_text_for_session")
+    text = cached["full_text"]
     blocks = extract_account_blocks(text)
 
     fbk_blocks: List[Dict[str, Any]] = []

--- a/backend/core/logic/report_analysis/text_provider.py
+++ b/backend/core/logic/report_analysis/text_provider.py
@@ -125,4 +125,4 @@ def load_cached_text(session_id: str) -> Mapping[str, Any] | None:
         pages.append(path.read_text(encoding="utf-8"))
 
     full_text = full_path.read_text(encoding="utf-8")
-    return {"pages": pages, "full": full_text, "meta": meta}
+    return {"pages": pages, "full": full_text, "full_text": full_text, "meta": meta}


### PR DESCRIPTION
## Summary
- export account blocks using cached text and error when cache missing
- provide `full_text` alias in cached text loader

## Testing
- `pytest tests/test_text_provider_basic.py -q`
- `rg -n extract_text_from_pdf backend/core/logic/report_analysis/block_exporter.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb32e1a1cc832589b677ad57628ef6