### PR TITLE
chore: remove deprecated text extraction flag

### DIFF
--- a/docs/casefirst-debug.md
+++ b/docs/casefirst-debug.md
@@ -30,7 +30,6 @@ $env:OPENAI_API_KEY  = "<your-key>"         # או להשאיר ריק ולכב�
 $env:OPENAI_BASE_URL = "https://api.openai.com/v1"
 
 # Parsing
-$env:USE_PYMUPDF_TEXT          = "1"
 $env:RULEBOOK_FALLBACK_ENABLED = "1"
 
 # Case-First strict mode


### PR DESCRIPTION
## Summary
- drop `USE_PYMUPDF_TEXT` from case-first debug runbook
- verify no usage of deprecated extraction flags remains

## Testing
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68bb39f0e4608325859eb88cd430acea