### PR TITLE
Handle Public Information stop marker in account splitting

### DIFF
--- a/tests/test_block_exporter.py
+++ b/tests/test_block_exporter.py
@@ -111,7 +111,9 @@ def test_export_writes_files(chdir_tmp, monkeypatch, stub_layout):
     json_path = accounts_dir / "accounts_from_full.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))
-    assert isinstance(data, list) and len(data) == 1
+    accounts = data["accounts"]
+    assert isinstance(accounts, list) and len(accounts) == 1
+    assert data["stop_marker_seen"] is False
     assert (accounts_dir / "per_account_tsv" / "_debug_account_1.tsv").exists()
 
     # Ensure index tracks artifacts and no stray copies exist

--- a/tests/unit/test_split_accounts_from_tsv.py
+++ b/tests/unit/test_split_accounts_from_tsv.py
@@ -22,17 +22,21 @@ def test_split_accounts(tmp_path: Path) -> None:
     json_path = tmp_path / "accounts_from_full.json"
     create_sample_tsv(tsv_path)
 
-    split_accounts_from_tsv.main([
-        "--full",
-        str(tsv_path),
-        "--json_out",
-        str(json_path),
-    ])
+    split_accounts_from_tsv.main(
+        [
+            "--full",
+            str(tsv_path),
+            "--json_out",
+            str(json_path),
+        ]
+    )
 
     data = json.loads(json_path.read_text())
-    assert len(data) == 2
+    accounts = data["accounts"]
+    assert len(accounts) == 2
+    assert data["stop_marker_seen"] is False
 
-    acc1, acc2 = data
+    acc1, acc2 = accounts
     assert acc1["heading_guess"] == "BANKAMERICA"
     assert acc1["line_start"] == 2
     assert acc1["line_end"] == 3
@@ -41,3 +45,39 @@ def test_split_accounts(tmp_path: Path) -> None:
     assert acc2["heading_guess"] == "TRUISTMRTG"
     assert acc2["line_start"] == 5
     assert acc2["lines"][1]["text"] == "Line B1"
+
+
+def create_stop_marker_tsv(path: Path) -> None:
+    content = (
+        "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+        "1\t1\t0\t0\t0\t0\tBANKAMERICA\n"
+        "1\t2\t0\t0\t0\t0\tAccount # 123\n"
+        "1\t3\t0\t0\t0\t0\tLine A1\n"
+        "1\t4\t0\t0\t0\t0\tPublic Information\n"
+        "1\t5\t0\t0\t0\t0\tAccount # 999\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_stop_marker(tmp_path: Path) -> None:
+    tsv_path = tmp_path / "_debug_full.tsv"
+    json_path = tmp_path / "accounts_from_full.json"
+    create_stop_marker_tsv(tsv_path)
+
+    split_accounts_from_tsv.main(
+        [
+            "--full",
+            str(tsv_path),
+            "--json_out",
+            str(json_path),
+        ]
+    )
+
+    data = json.loads(json_path.read_text())
+    accounts = data["accounts"]
+    assert data["stop_marker_seen"] is True
+    assert len(accounts) == 1
+    acc = accounts[0]
+    assert acc["line_end"] == 3
+    texts = [ln["text"] for ln in acc["lines"]]
+    assert all("Public Information" not in t for t in texts)


### PR DESCRIPTION
## Summary
- stop splitting accounts once a "Public Information" stop marker appears
- record `stop_marker_seen` and omit the marker from accounts
- update tests for new JSON structure and stop-marker behavior

## Testing
- `pre-commit run --files scripts/split_accounts_from_tsv.py tests/test_block_exporter.py tests/unit/test_split_accounts_from_tsv.py`
- `pytest tests/unit/test_split_accounts_from_tsv.py tests/test_block_exporter.py`


------
https://chatgpt.com/codex/tasks/task_b_68c09fd128ac8325a302086a8a6197ce