### PR TITLE
Handle Unknown section prefix in account splitting

### DIFF
--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -19,8 +19,8 @@ from bisect import bisect_right
 
 ACCOUNT_RE = re.compile(r"\bAccount\b.*#", re.IGNORECASE)
 STOP_MARKER_NORM = "publicinformation"
-SECTION_STARTERS = {"collection"}
-_SECTION_NAME = {"collection": "collections"}
+SECTION_STARTERS = {"collection", "unknown"}
+_SECTION_NAME = {"collection": "collections", "unknown": "unknown"}
 NOISE_URL_RE = re.compile(r"^https?://", re.IGNORECASE)
 NOISE_BANNER_RE = re.compile(
     r"^\d{1,2}/\d{1,2}/\d{2,4}.*(?:Credit\s*Report|SmartCredit)", re.IGNORECASE
@@ -320,7 +320,8 @@ def main(argv: List[str] | None = None) -> None:
         accounts = result.get("accounts") or []
         total = len(accounts)
         collections = sum(1 for a in accounts if a.get("section") == "collections")
-        regular = total - collections
+        unknown = sum(1 for a in accounts if a.get("section") == "unknown")
+        regular = total - collections - unknown
         bad_last = [
             a["account_index"]
             for a in accounts
@@ -328,7 +329,7 @@ def main(argv: List[str] | None = None) -> None:
             and _norm(a["lines"][-1]["text"]) in SECTION_STARTERS
         ]
         print(f"Total accounts: {total}")
-        print(f"collections: {collections} regular: {regular}")
+        print(f"collections: {collections} unknown: {unknown} regular: {regular}")
         if bad_last:
             print(f"Accounts ending with section starter: {bad_last}")
     print(f"Wrote accounts to {json_out}")

--- a/tests/unit/test_split_accounts_from_tsv.py
+++ b/tests/unit/test_split_accounts_from_tsv.py
@@ -116,6 +116,38 @@ def test_collection_starts_new_account(tmp_path: Path) -> None:
     assert acc2["section"] == "collections"
 
 
+def create_unknown_tsv(path: Path) -> None:
+    content = (
+        "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+        "1\t1\t0\t0\t0\t0\tAMEX\n"
+        "1\t2\t0\t0\t0\t0\tAccount # 123\n"
+        "1\t3\t0\t0\t0\t0\tLine A1\n"
+        "1\t4\t0\t0\t0\t0\tUnknown\n"
+        "1\t5\t0\t0\t0\t0\tCREDITOR XYZ\n"
+        "1\t6\t0\t0\t0\t0\tAccount # 456\n"
+        "1\t7\t0\t0\t0\t0\tLine B1\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_unknown_starts_new_account(tmp_path: Path) -> None:
+    tsv_path = tmp_path / "_debug_full.tsv"
+    json_path = tmp_path / "accounts_from_full.json"
+    create_unknown_tsv(tsv_path)
+
+    split_accounts_from_tsv.main(["--full", str(tsv_path), "--json_out", str(json_path)])
+
+    data = json.loads(json_path.read_text())
+    accounts = data["accounts"]
+    assert len(accounts) == 2
+    acc1, acc2 = accounts
+    texts1 = [ln["text"] for ln in acc1["lines"]]
+    assert "Unknown" not in texts1
+    assert acc2["section"] == "unknown"
+    assert acc2["heading_source"] == "section+heading"
+    assert acc2["heading_guess"] == "CREDITOR XYZ"
+
+
 def create_section_forward_scan_tsv(path: Path) -> None:
     content = (
         "page\tline\ty0\ty1\tx0\tx1\ttext\n"
@@ -168,6 +200,40 @@ def test_trailing_section_marker_never_in_account(tmp_path: Path) -> None:
     texts = [ln["text"] for ln in acc["lines"]]
     assert "Collection" not in texts
     assert acc["trailing_section_marker_pruned"] is True
+
+
+def create_section_prefix_end_tsv(path: Path) -> None:
+    content = (
+        "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+        "1\t1\t0\t0\t0\t0\tAMEX\n"
+        "1\t2\t0\t0\t0\t0\tAccount # 123\n"
+        "1\t3\t0\t0\t0\t0\tLine A1\n"
+        "1\t4\t0\t0\t0\t0\tCollection\n"
+        "1\t5\t0\t0\t0\t0\tCREDENCE RM\n"
+        "1\t6\t0\t0\t0\t0\tAccount # 456\n"
+        "1\t7\t0\t0\t0\t0\tLine B1\n"
+        "1\t8\t0\t0\t0\t0\tUnknown\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_no_account_ends_with_section_prefix(tmp_path: Path) -> None:
+    tsv_path = tmp_path / "_debug_full.tsv"
+    json_path = tmp_path / "accounts_from_full.json"
+    create_section_prefix_end_tsv(tsv_path)
+
+    split_accounts_from_tsv.main(["--full", str(tsv_path), "--json_out", str(json_path)])
+
+    data = json.loads(json_path.read_text())
+    accounts = data["accounts"]
+    assert len(accounts) == 2
+    for acc in accounts:
+        assert (
+            split_accounts_from_tsv._norm(acc["lines"][-1]["text"])
+            not in split_accounts_from_tsv.SECTION_STARTERS
+        )
+    assert accounts[0]["trailing_section_marker_pruned"] is True
+    assert accounts[1]["trailing_section_marker_pruned"] is True
 
 
 def create_noise_between_accounts_tsv(path: Path) -> None:


### PR DESCRIPTION
## Summary
- Treat `Unknown` lines as section prefixes like `Collection`
- Flag and section accounts that follow `Unknown` prefixes
- Ensure no account ends with `Unknown` or `Collection`

## Testing
- `pytest tests/unit/test_split_accounts_from_tsv.py`

------
https://chatgpt.com/codex/tasks/task_b_68c19076fa9c8325834ceb4967fc1334