### PR TITLE
Add tests for Inquiries and Creditor Contacts section extraction

### DIFF
--- a/tests/unit/test_split_general_info_from_tsv.py
+++ b/tests/unit/test_split_general_info_from_tsv.py
@@ -53,6 +53,18 @@ def test_split_sections(tmp_path: Path) -> None:
         "COLLECTION CHARGEOFF",
     ]
 
+    # Inquiries should stop before Creditor Contacts.
+    assert [ln["text"] for ln in sections[4]["lines"]] == [
+        "INQUIRIES",
+        "Inq1",
+    ]
+
+    # Creditor Contacts should stop before SmartCredit.
+    assert [ln["text"] for ln in sections[5]["lines"]] == [
+        "CREDITOR CONTACTS",
+        "Contact 1",
+    ]
+
 
 def create_no_section_tsv(path: Path) -> None:
     content = (
@@ -74,3 +86,42 @@ def test_no_sections(tmp_path: Path) -> None:
 
     data = json.loads(json_path.read_text())
     assert data["sections"] == []
+
+
+def create_missing_creditor_contacts_tsv(path: Path) -> None:
+    content = (
+        "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+        "1\t1\t0\t0\t0\t0\tPERSONAL INFORMATION\n"
+        "1\t2\t0\t0\t0\t0\tName: JOHN DOE\n"
+        "1\t3\t0\t0\t0\t0\tSUMMARY\n"
+        "1\t4\t0\t0\t0\t0\tGood credit\n"
+        "1\t5\t0\t0\t0\t0\tACCOUNT HISTORY\n"
+        "1\t6\t0\t0\t0\t0\tAccount 1\n"
+        "1\t7\t0\t0\t0\t0\tCOLLECTION CHARGEOFF\n"
+        "1\t8\t0\t0\t0\t0\tPUBLIC INFORMATION\n"
+        "1\t9\t0\t0\t0\t0\tNone\n"
+        "1\t10\t0\t0\t0\t0\tINQUIRIES\n"
+        "1\t11\t0\t0\t0\t0\tInq1\n"
+        "1\t12\t0\t0\t0\t0\tSMARTCREDIT\n"
+        "1\t13\t0\t0\t0\t0\tAccount # 123\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_missing_creditor_contacts(tmp_path: Path) -> None:
+    tsv_path = tmp_path / "_debug_full.tsv"
+    json_path = tmp_path / "general_info_from_full.json"
+    create_missing_creditor_contacts_tsv(tsv_path)
+
+    split_general_info_from_tsv.main(
+        ["--full", str(tsv_path), "--json_out", str(json_path)]
+    )
+
+    data = json.loads(json_path.read_text())
+    # Inquiries and Creditor Contacts sections should be skipped.
+    assert [sec["heading"] for sec in data["sections"]] == [
+        "PERSONAL INFORMATION",
+        "SUMMARY",
+        "ACCOUNT HISTORY",
+        "PUBLIC INFORMATION",
+    ]


### PR DESCRIPTION
## Summary
- add tests ensuring `Inquiries` section stops before `Creditor Contacts` heading
- add tests ensuring `Creditor Contacts` section stops before `SmartCredit`
- add regression test for missing `Creditor Contacts` header

## Testing
- `pytest tests/unit/test_split_general_info_from_tsv.py::test_split_sections -q`
- `pytest tests/unit/test_split_general_info_from_tsv.py::test_no_sections -q`
- `pytest tests/unit/test_split_general_info_from_tsv.py::test_missing_creditor_contacts -q`
- `pytest -q` *(fails: Segmentation fault: fatal error in PyMuPDF)*

------
https://chatgpt.com/codex/tasks/task_b_68c1a54de6d48325bcb0a7fe82c0c2c1