### PR TITLE
Add safe trace cleanup utility and CLI

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -133,6 +133,9 @@ ENABLE_CASESTORE_STAGEA = env_bool("ENABLE_CASESTORE_STAGEA", True)
 # Stage A detection mode
 PROBLEM_DETECTION_ONLY = env_bool("PROBLEM_DETECTION_ONLY", True)
 
+# Automatic trace cleanup after Stage-A export
+PURGE_TRACE_AFTER_EXPORT = env_bool("PURGE_TRACE_AFTER_EXPORT", False)
+
 # Candidate token logging
 ENABLE_CANDIDATE_TOKEN_LOGGER = env_bool("ENABLE_CANDIDATE_TOKEN_LOGGER", True)
 CANDIDATE_LOG_FORMAT = env_str("CANDIDATE_LOG_FORMAT", "jsonl")

--- a/backend/core/logic/report_analysis/block_exporter.py
+++ b/backend/core/logic/report_analysis/block_exporter.py
@@ -8,6 +8,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import backend.config as config
+
 from backend.core.logic.report_analysis.account_packager_coords import (
     package_block_raw_coords,
     write_block_raw_coords,
@@ -2787,6 +2789,17 @@ def export_account_blocks(
         str(out_dir),
         len(out_blocks),
     )
+
+    if stage_a_meta and getattr(config, "PURGE_TRACE_AFTER_EXPORT", False):
+        from .trace_cleanup import purge_trace_except_artifacts
+
+        project_root = Path(__file__).resolve().parents[4]
+        try:
+            purge_trace_except_artifacts(
+                sid=session_id, root=project_root, dry_run=False
+            )
+        except Exception:
+            logger.exception("BLOCK: purge trace failed sid=%s", session_id)
 
     return out_blocks, stage_a_meta
 

--- a/backend/core/logic/report_analysis/trace_cleanup.py
+++ b/backend/core/logic/report_analysis/trace_cleanup.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_ARTIFACTS: tuple[str, ...] = (
+    "accounts_table/_debug_full.tsv",
+    "accounts_table/accounts_from_full.json",
+    "accounts_table/general_info_from_full.json",
+)
+
+
+def _expand_dirs(paths: Iterable[Path], base: Path) -> set[Path]:
+    """Return a set of dirs that must be preserved for given paths."""
+    keep_dirs: set[Path] = {base}
+    for p in paths:
+        for parent in p.parents:
+            if parent == base:
+                break
+            keep_dirs.add(parent)
+    return keep_dirs
+
+
+def purge_trace_except_artifacts(
+    sid: str,
+    root: Path | str = Path("."),
+    keep_extra: list[str] | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Deletes everything under traces/blocks/<sid> except the 3 final artifacts listed below.
+    Returns a dict summary { 'kept': [...], 'deleted': [...], 'skipped': [...], 'root': '<abs path>' }.
+    Raises FileNotFoundError if the session folder doesn't exist.
+    Raises RuntimeError if one of the required artifacts is missing (no deletion happens).
+    """
+
+    base = Path(root) / "traces" / "blocks" / sid
+    base = base.resolve()
+    if not base.exists():
+        raise FileNotFoundError(base)
+
+    keep_rel = list(_DEFAULT_ARTIFACTS)
+    if keep_extra:
+        keep_rel.extend(keep_extra)
+
+    keep_abs = {base / Path(p) for p in keep_rel}
+
+    # Verify required artifacts exist (first three of _DEFAULT_ARTIFACTS)
+    for req in _DEFAULT_ARTIFACTS:
+        req_path = base / req
+        if not req_path.exists():
+            raise RuntimeError(f"required artifact missing: {req}")
+
+    keep_dirs = _expand_dirs(keep_abs, base)
+
+    kept = sorted(str(p.relative_to(base)) for p in keep_abs)
+    deleted: list[str] = []
+    skipped: list[str] = []
+
+    logger.info(
+        "purge_trace_except_artifacts: sid=%s root=%s dry_run=%s", sid, base, dry_run
+    )
+
+    all_paths = sorted(base.rglob("*"), key=lambda p: len(p.parts), reverse=True)
+    for path in all_paths:
+        rel = str(path.relative_to(base))
+        if path in keep_abs or path in keep_dirs:
+            logger.debug("keeping %s", path)
+            continue
+        if dry_run:
+            logger.debug("would delete %s", path)
+            skipped.append(rel)
+            continue
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            deleted.append(rel)
+            logger.debug("deleted %s", path)
+        except Exception:
+            logger.exception("failed to delete %s", path)
+            skipped.append(rel)
+
+    logger.info(
+        "purge complete: kept=%d deleted=%d skipped=%d", len(kept), len(deleted), len(skipped)
+    )
+    return {"kept": kept, "deleted": deleted, "skipped": skipped, "root": str(base)}

--- a/scripts/cleanup_trace.py
+++ b/scripts/cleanup_trace.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from backend.core.logic.report_analysis.trace_cleanup import purge_trace_except_artifacts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Safely purge trace files except final artifacts")
+    parser.add_argument("--sid", required=True, help="Session identifier")
+    parser.add_argument("--root", default=".", help="Project root path")
+    parser.add_argument("--dry-run", action="store_true", help="Preview deletions without removing files")
+    parser.add_argument(
+        "--keep-extra",
+        action="append",
+        default=[],
+        help="Additional relative paths under the session to keep",
+    )
+    args = parser.parse_args()
+    summary = purge_trace_except_artifacts(
+        sid=args.sid,
+        root=Path(args.root),
+        keep_extra=args.keep_extra or None,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_trace_cleanup.py
+++ b/tests/unit/test_trace_cleanup.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.logic.report_analysis.trace_cleanup import purge_trace_except_artifacts
+
+
+REQUIRED = {
+    "accounts_table/_debug_full.tsv",
+    "accounts_table/accounts_from_full.json",
+    "accounts_table/general_info_from_full.json",
+}
+
+
+def _setup(tmp_path: Path, sid: str) -> Path:
+    base = tmp_path / "traces" / "blocks" / sid / "accounts_table"
+    base.mkdir(parents=True)
+    for name in REQUIRED:
+        (tmp_path / "traces" / "blocks" / sid / name).write_text("x")
+    return base.parent
+
+
+def test_purge_trace_happy_path(tmp_path: Path) -> None:
+    sid = "happy"
+    base = _setup(tmp_path, sid)
+    accounts = base / "accounts_table"
+    (accounts / "extra.txt").write_text("1")
+    (base / "root_extra.txt").write_text("1")
+    subdir = base / "subdir"
+    subdir.mkdir()
+    (subdir / "file.txt").write_text("1")
+
+    res = purge_trace_except_artifacts(sid, root=tmp_path, dry_run=True)
+    assert (accounts / "extra.txt").exists()
+    assert (base / "root_extra.txt").exists()
+    assert (subdir / "file.txt").exists()
+
+    assert set(res["kept"]) == REQUIRED
+    assert res["deleted"] == []
+    assert set(res["skipped"]) == {
+        "accounts_table/extra.txt",
+        "root_extra.txt",
+        "subdir/file.txt",
+        "subdir",
+    }
+
+    res2 = purge_trace_except_artifacts(sid, root=tmp_path, dry_run=False)
+    assert not (accounts / "extra.txt").exists()
+    assert not (base / "root_extra.txt").exists()
+    assert not subdir.exists()
+    assert set(res2["deleted"]) == {
+        "accounts_table/extra.txt",
+        "root_extra.txt",
+        "subdir/file.txt",
+        "subdir",
+    }
+    assert res2["skipped"] == []
+
+
+def test_missing_artifact(tmp_path: Path) -> None:
+    sid = "missing"
+    base = tmp_path / "traces" / "blocks" / sid / "accounts_table"
+    base.mkdir(parents=True)
+    # create only two artifacts
+    (base / "_debug_full.tsv").write_text("1")
+    (base / "accounts_from_full.json").write_text("1")
+    extra = base / "extra.txt"
+    extra.write_text("1")
+
+    with pytest.raises(RuntimeError):
+        purge_trace_except_artifacts(sid, root=tmp_path)
+    assert extra.exists()
+
+
+def test_session_folder_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        purge_trace_except_artifacts("nope", root=tmp_path)
+
+
+def test_keep_extra(tmp_path: Path) -> None:
+    sid = "extra"
+    base = _setup(tmp_path, sid)
+    accounts = base / "accounts_table"
+    keep_file = accounts / "keep.json"
+    keep_file.write_text("1")
+    remove_file = accounts / "remove.txt"
+    remove_file.write_text("1")
+
+    res = purge_trace_except_artifacts(
+        sid,
+        root=tmp_path,
+        keep_extra=["accounts_table/keep.json"],
+        dry_run=False,
+    )
+    assert keep_file.exists()
+    assert not remove_file.exists()
+    assert "accounts_table/keep.json" in res["kept"]


### PR DESCRIPTION
## Summary
- implement `purge_trace_except_artifacts` to delete trace files while preserving final artifacts
- add `cleanup_trace.py` CLI and optional Stage-A hook gated by `PURGE_TRACE_AFTER_EXPORT`
- cover cleanup scenarios with comprehensive unit tests

## Testing
- `pytest tests/unit/test_trace_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1ba3eb21c8325987ef5ae6be0eef8