### PR TITLE
Extend trace cleanup to purge texts directory

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -135,6 +135,7 @@ PROBLEM_DETECTION_ONLY = env_bool("PROBLEM_DETECTION_ONLY", True)
 
 # Automatic trace cleanup after Stage-A export
 PURGE_TRACE_AFTER_EXPORT = env_bool("PURGE_TRACE_AFTER_EXPORT", False)
+PURGE_TRACE_KEEP_TEXTS = env_bool("PURGE_TRACE_KEEP_TEXTS", False)
 
 # Candidate token logging
 ENABLE_CANDIDATE_TOKEN_LOGGER = env_bool("ENABLE_CANDIDATE_TOKEN_LOGGER", True)

--- a/backend/core/logic/report_analysis/block_exporter.py
+++ b/backend/core/logic/report_analysis/block_exporter.py
@@ -2796,7 +2796,10 @@ def export_account_blocks(
         project_root = Path(__file__).resolve().parents[4]
         try:
             purge_trace_except_artifacts(
-                sid=session_id, root=project_root, dry_run=False
+                sid=session_id,
+                root=project_root,
+                dry_run=False,
+                delete_texts_sid=not getattr(config, "PURGE_TRACE_KEEP_TEXTS", False),
             )
         except Exception:
             logger.exception("BLOCK: purge trace failed sid=%s", session_id)

--- a/scripts/cleanup_trace.py
+++ b/scripts/cleanup_trace.py
@@ -18,12 +18,18 @@ def main() -> int:
         default=[],
         help="Additional relative paths under the session to keep",
     )
+    parser.add_argument(
+        "--keep-texts",
+        action="store_true",
+        help="Do not delete traces/texts/<SID> directory",
+    )
     args = parser.parse_args()
     summary = purge_trace_except_artifacts(
         sid=args.sid,
         root=Path(args.root),
         keep_extra=args.keep_extra or None,
         dry_run=args.dry_run,
+        delete_texts_sid=not args.keep_texts,
     )
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0


### PR DESCRIPTION
## Summary
- extend `purge_trace_except_artifacts` with `delete_texts_sid` to optionally purge `traces/texts/<sid>` and report `texts_deleted`
- add `--keep-texts` to `scripts/cleanup_trace.py` and propagate flag to the cleanup utility
- wire up automatic purge in `block_exporter` with new `PURGE_TRACE_KEEP_TEXTS` config option

## Testing
- `pytest tests/unit/test_trace_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1bc8652848325a9c566e2fdf77824