### PR TITLE
feat: purge traces after stage-a

### DIFF
--- a/backend/core/config/__init__.py
+++ b/backend/core/config/__init__.py
@@ -1,0 +1,20 @@
+"""Core configuration flags.
+
+This module exposes simple boolean switches used across the codebase.  Flags
+are defined here rather than scattering ``os.getenv`` calls throughout the
+code, which keeps orchestrator logic straightforward and easy to test.
+"""
+
+# Cleanup flag ---------------------------------------------------------------
+#
+# Stage-A export writes numerous intermediate trace files under
+# ``traces/blocks/<sid>``.  Once the three final artifacts are produced we can
+# optionally purge the rest to save disk space.  The orchestrator consults this
+# flag to determine whether the cleanup routine should run.
+from __future__ import annotations
+
+# Whether to remove trace files after Stage-A export.  Kept ``True`` by default
+# so deployments opt-in automatically; tests may override via monkeypatching.
+CLEANUP_AFTER_EXPORT: bool = True
+
+__all__ = ["CLEANUP_AFTER_EXPORT"]

--- a/backend/core/logic/report_analysis/orchestrator.py
+++ b/backend/core/logic/report_analysis/orchestrator.py
@@ -1,29 +1,55 @@
-from pathlib import Path
+from __future__ import annotations
+
 import logging
+from pathlib import Path
 
-from backend.core.settings import AUTO_PURGE_AFTER_EXPORT
-from backend.core.logic.report_analysis.trace_cleanup import purge_after_export
+from backend.core.config import CLEANUP_AFTER_EXPORT
 from backend.core.logic.report_analysis import block_exporter
+from backend.core.logic.report_analysis.trace_cleanup import purge_after_export
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
-def run_pipeline(session_id: str) -> dict:
+def run_stage_a(session_id: str, project_root: Path = Path(".")) -> dict:
+    """Run Stage-A export and optionally clean up trace artifacts.
+
+    Parameters
+    ----------
+    session_id:
+        Identifier for the trace directory under ``traces/blocks/<sid>``.
+    project_root:
+        Base directory of the repository.  Defaults to the current working
+        directory.
+
+    Returns
+    -------
+    dict
+        Metadata including artifact paths and cleanup details.
+    """
+
     stage_a = block_exporter.export_stage_a(session_id)
     if not stage_a.get("ok"):
         return {"sid": session_id, "ok": False, "where": "stage_a"}
 
-    result = {"sid": session_id, "ok": True, "artifacts": stage_a["artifacts"]}
+    meta: dict = {"sid": session_id, "ok": True, "artifacts": stage_a["artifacts"]}
 
-    if AUTO_PURGE_AFTER_EXPORT:
-        try:
-            purge_summary = purge_after_export(sid=session_id, project_root=Path("."))
-            logger.info("purge_after_export", extra={"sid": session_id, **purge_summary})
-            result["purge"] = purge_summary
-        except Exception as e:
-            logger.warning(
-                "purge_after_export_failed",
-                extra={"sid": session_id, "error": str(e)},
-            )
+    artifacts = stage_a.get("artifacts", {})
+    full_tsv = Path(artifacts.get("full_tsv", ""))
+    accounts_json = Path(artifacts.get("accounts_json", ""))
+    general_json = Path(artifacts.get("general_info_json", ""))
 
-    return result
+    blocks_dir = project_root / "traces" / "blocks" / session_id
+    assert blocks_dir.exists(), f"blocks dir not found: {blocks_dir}"
+
+    if not (full_tsv.exists() and accounts_json.exists() and general_json.exists()):
+        meta["cleanup"] = {"performed": False, "reason": "artifacts_missing"}
+        return meta
+
+    if CLEANUP_AFTER_EXPORT:
+        cleanup_summary = purge_after_export(sid=session_id, project_root=project_root)
+        log.info("purge_after_export", extra={"sid": session_id, **cleanup_summary})
+        meta["cleanup"] = {"performed": True, "summary": cleanup_summary}
+    else:
+        meta["cleanup"] = {"performed": False, "reason": "flag_off"}
+
+    return meta


### PR DESCRIPTION
## Summary
- add `CLEANUP_AFTER_EXPORT` flag
- log trace cleanup details
- orchestrate Stage-A cleanup only when artifacts exist

## Testing
- `pre-commit run --files backend/core/config/__init__.py backend/core/logic/report_analysis/trace_cleanup.py backend/core/logic/report_analysis/orchestrator.py`
- `pytest -q` (failed: Segmentation fault)

------
https://chatgpt.com/codex/tasks/task_b_68c1c74795c883259deead7f18c80fb7