### PR TITLE
Add Celery trace cleanup task

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+# Absolute path to the repository root.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+__all__ = ["PROJECT_ROOT"]


### PR DESCRIPTION
## Summary
- add project root settings module
- introduce cleanup_trace_task to purge traces while keeping final artifacts

## Testing
- `pre-commit run --files backend/api/tasks.py backend/settings.py`
- `pytest` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c1d48c84ec83258f82a167a616eeae