### PR TITLE
Run trace cleanup between Stage-A and account extraction

### DIFF
--- a/backend/api/pipeline.py
+++ b/backend/api/pipeline.py
@@ -1,0 +1,14 @@
+from backend.api.tasks import stage_a_task, cleanup_trace_task, extract_problematic_accounts
+
+
+def run_full_pipeline(sid: str):
+    """Run Stage-A export, cleanup traces, and extract accounts for ``sid``.
+
+    Each task receives ``sid`` explicitly via ``.si`` to avoid relying on the
+    previous task's return value.
+    """
+    return (
+        stage_a_task.si(sid)
+        | cleanup_trace_task.si(sid)
+        | extract_problematic_accounts.si(sid)
+    ).apply_async()

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from backend.core.logic.report_analysis.trace_cleanup import purge_after_export
+from backend.core.logic.report_analysis.orchestrator import run_stage_a
 from backend.settings import PROJECT_ROOT
 
 # Ensure the project root is always on sys.path so local modules can be
@@ -73,6 +74,14 @@ def _ensure_file(file_path: str) -> None:
         listing = os.listdir(dir_path) if os.path.exists(dir_path) else []
         logger.error("File not found: %s. Dir contents: %s", file_path, listing)
         raise FileNotFoundError(f"Required file missing: {file_path}")
+
+@app.task(bind=True, name="stage_a")
+def stage_a_task(self, sid: str) -> dict:
+    """Run Stage-A export for the given session id."""
+    log.info("STAGE_A start sid=%s", sid)
+    result = run_stage_a(sid)
+    log.info("STAGE_A done sid=%s", sid)
+    return result
 
 
 @app.task(bind=True, name="extract_problematic_accounts")


### PR DESCRIPTION
## Summary
- add a dedicated `stage_a_task` to run Stage-A export for a given session
- create `run_full_pipeline` Celery chain that runs Stage-A, cleans traces, then extracts accounts

## Testing
- `pytest tests/unit/test_trace_cleanup.py -q`
- ⚠️ `pytest tests/test_account_trace_bug.py::test_account_trace_bug -q` (segmentation fault: missing PyMuPDF dependencies)


------
https://chatgpt.com/codex/tasks/task_b_68c1d60ae6c48325b8d7e77e1a919165