### PR TITLE
chore: add project paths and improve task logging

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -47,7 +47,8 @@ def configure_worker(**_):
         logger.warning("Starting in parser-only mode: %s", exc)
 
 
-logging.basicConfig(level=logging.INFO)
+# Configure logging to emit progress information from Celery workers.
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
 log = logger
 logger.info("OPENAI_API_KEY present=%s", bool(os.getenv("OPENAI_API_KEY")))

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -3,4 +3,7 @@ from pathlib import Path
 # Absolute path to the repository root.
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-__all__ = ["PROJECT_ROOT"]
+# Location where trace artifacts are stored.
+TRACES_DIR = PROJECT_ROOT / "traces"
+
+__all__ = ["PROJECT_ROOT", "TRACES_DIR"]


### PR DESCRIPTION
## Summary
- expose TRACES_DIR next to PROJECT_ROOT for easier path computations
- configure Celery task logging with INFO-level output and readable format

## Testing
- `pytest tests/test_account_trace_bug.py` *(fails: Fatal Python error: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c1da4d5ac48325ad0d559b4f777169