### PR TITLE
test: ensure trace cleanup keeps final artifacts

### DIFF
--- a/tests/test_trace_cleanup.py
+++ b/tests/test_trace_cleanup.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from backend.core.logic.report_analysis.trace_cleanup import purge_after_export
+
+def test_purge_after_export_keeps_only_final_artifacts(tmp_path: Path) -> None:
+    root = tmp_path
+    sid = "test-sid"
+    blocks = root / "traces" / "blocks" / sid
+    texts = root / "traces" / "texts" / sid
+    acct = blocks / "accounts_table"
+    acct.mkdir(parents=True)
+    texts.mkdir(parents=True)
+
+    keep = ["_debug_full.tsv", "accounts_from_full.json", "general_info_from_full.json"]
+    for name in keep:
+        (acct / name).write_text("ok")
+
+    (acct / "noise.txt").write_text("x")
+    (blocks / "other.json").write_text("{}")
+    (texts / "dump.txt").write_text("x")
+
+    summary = purge_after_export(sid=sid, project_root=root)
+
+    kept = {p.name for p in acct.iterdir()}
+    assert kept == set(keep)
+    assert {p.name for p in blocks.iterdir()} == {"accounts_table"}
+    assert not texts.exists()
+    assert isinstance(summary, dict)


### PR DESCRIPTION
## Summary
- add unit test verifying trace cleanup removes noise and keeps final artifacts

## Testing
- `pytest -q tests/test_trace_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1dc4e66f08325aa9498d6ba6105a0