### PR TITLE
feat: add trace cleanup CLI

### DIFF
--- a/backend/core/logic/report_analysis/README.md
+++ b/backend/core/logic/report_analysis/README.md
@@ -54,3 +54,38 @@ instructions pipelines.
 Set the environment variable `ANALYSIS_DISABLE_CACHE=1` to bypass the
 in-memory analysis cache and force a fresh analysis on each run.
 
+## Manual trace cleanup
+
+After Stage A export you can clear intermediate files for a session ID (SID)
+while keeping the final artifacts. Run the helper script:
+
+```bash
+python scripts/cleanup_trace.py --sid <SID> --root .
+```
+
+Example PowerShell usage:
+
+```powershell
+# venv + project root
+& .\.venv\Scripts\Activate.ps1
+$env:PYTHONPATH = (Get-Location).Path
+
+# Set SID
+$SID = 'PUT-YOUR-SID-HERE'
+
+# Run cleanup
+python .\scripts\cleanup_trace.py --sid $SID --root .
+
+# Verify
+$blocks = ".\traces\blocks\$SID"
+$acct   = "$blocks\accounts_table"
+$texts  = ".\traces\texts\$SID"
+
+"Remaining in accounts_table:"
+Get-ChildItem $acct -Force | Format-Table Name,Length -Auto
+"Texts dir exists? " + (Test-Path $texts)
+```
+
+Only `_debug_full.tsv`, `accounts_from_full.json`, and
+`general_info_from_full.json` remain in the `accounts_table` folder and the
+corresponding `texts/<SID>` directory is removed.

--- a/scripts/cleanup_trace.py
+++ b/scripts/cleanup_trace.py
@@ -1,11 +1,17 @@
 import argparse
 from pathlib import Path
+
 from backend.core.logic.report_analysis.trace_cleanup import purge_after_export
 
-if __name__ == "__main__":
+
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--sid", required=True)
     ap.add_argument("--root", default=".")
     args = ap.parse_args()
     summary = purge_after_export(args.sid, Path(args.root))
     print(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI wrapper for `purge_after_export` to manually clean up traces
- document PowerShell steps to run cleanup and verify results

## Testing
- `pre-commit run --files scripts/cleanup_trace.py backend/core/logic/report_analysis/README.md`
- `pytest tests/unit/test_trace_cleanup.py tests/test_trace_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1dd1d85088325a22a0435e4d01eae