### PR TITLE
Ensure pipeline tasks run in order using Celery chain

### DIFF
--- a/backend/api/pipeline.py
+++ b/backend/api/pipeline.py
@@ -1,4 +1,10 @@
-from backend.api.tasks import stage_a_task, cleanup_trace_task, extract_problematic_accounts
+from celery import chain
+
+from backend.api.tasks import (
+    cleanup_trace_task,
+    extract_problematic_accounts,
+    stage_a_task,
+)
 
 
 def run_full_pipeline(sid: str):
@@ -7,8 +13,8 @@ def run_full_pipeline(sid: str):
     Each task receives ``sid`` explicitly via ``.si`` to avoid relying on the
     previous task's return value.
     """
-    return (
-        stage_a_task.si(sid)
-        | cleanup_trace_task.si(sid)
-        | extract_problematic_accounts.si(sid)
+    return chain(
+        stage_a_task.si(sid),
+        cleanup_trace_task.si(sid),
+        extract_problematic_accounts.si(sid),
     ).apply_async()


### PR DESCRIPTION
## Summary
- Use Celery's `chain` with immutable signatures to run the pipeline as Stage-A → Cleanup → Problematic

## Testing
- `pytest` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e512ad448325a9579783cf9bb903