### PR TITLE
Use canonical pipeline entry point for account extraction

### DIFF
--- a/tests/test_stageE_case_store_only.py
+++ b/tests/test_stageE_case_store_only.py
@@ -2,13 +2,11 @@ import io
 import json
 import uuid
 
-import pytest
-
 import backend.config as config
-from backend.api.app import create_app
 from backend.api import app as app_module
+from backend.api.app import create_app
 from backend.core.case_store import api as cs_api
-from backend.core.case_store.errors import CaseStoreError, IO_ERROR
+from backend.core.case_store.errors import IO_ERROR, CaseStoreError
 
 
 class DummyResult:
@@ -16,15 +14,10 @@ class DummyResult:
         return {"problem_accounts": [{"account_id": "legacy"}]}
 
 
-class DummyTask:
-    def delay(self, *a, **k):
-        return DummyResult()
-
-
 def _setup_case(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CASESTORE_DIR", str(tmp_path))
     monkeypatch.setattr(app_module, "set_session", lambda *a, **k: None)
-    monkeypatch.setattr(app_module, "extract_problematic_accounts", DummyTask())
+    monkeypatch.setattr(app_module, "run_full_pipeline", lambda sid: DummyResult())
     monkeypatch.setattr(config, "API_INCLUDE_DECISION_META", False)
 
     session_id = "sess1"
@@ -60,7 +53,9 @@ def test_api_uses_case_store_only(tmp_path, monkeypatch):
     app = create_app()
     client = app.test_client()
     data = {"email": "a@example.com", "file": (io.BytesIO(b"%PDF-1.4"), "r.pdf")}
-    resp = client.post("/api/start-process", data=data, content_type="multipart/form-data")
+    resp = client.post(
+        "/api/start-process", data=data, content_type="multipart/form-data"
+    )
     assert resp.status_code == 200
     payload = json.loads(resp.data)
     accounts = payload["accounts"]["problem_accounts"]
@@ -75,10 +70,14 @@ def test_api_errors_when_casestore_unavailable(tmp_path, monkeypatch):
     monkeypatch.setattr(
         app_module.cs_api,
         "load_session_case",
-        lambda sid: (_ for _ in ()).throw(CaseStoreError(code=IO_ERROR, message="boom")),
+        lambda sid: (_ for _ in ()).throw(
+            CaseStoreError(code=IO_ERROR, message="boom")
+        ),
     )
     data = {"email": "a@example.com", "file": (io.BytesIO(b"%PDF-1.4"), "r.pdf")}
-    resp = client.post("/api/start-process", data=data, content_type="multipart/form-data")
+    resp = client.post(
+        "/api/start-process", data=data, content_type="multipart/form-data"
+    )
     assert resp.status_code >= 500
     payload = json.loads(resp.data)
     assert payload["status"] == "error"

--- a/tests/test_start_process.py
+++ b/tests/test_start_process.py
@@ -1,13 +1,13 @@
 import io
 import json
 
+import backend.config as config
+import backend.core.orchestrators as orch
 from backend.api import app as app_module
 from backend.api.app import create_app
 from backend.core.logic.report_analysis.report_postprocessing import _assign_issue_types
-import backend.core.orchestrators as orch
 from backend.core.orchestrators import extract_problematic_accounts_from_report
 from tests.test_extract_problematic_accounts import _mock_dependencies
-import backend.config as config
 
 
 class DummyResult:
@@ -16,11 +16,7 @@ class DummyResult:
 
 
 def test_start_process_success(monkeypatch, tmp_path):
-    class DummyTask:
-        def delay(self, *a, **k):
-            return DummyResult()
-
-    monkeypatch.setattr(app_module, "extract_problematic_accounts", DummyTask())
+    monkeypatch.setattr(app_module, "run_full_pipeline", lambda sid: DummyResult())
     monkeypatch.setattr(app_module.cs_api, "load_session_case", lambda sid: None)
     monkeypatch.setattr(orch, "collect_stageA_logical_accounts", lambda sid: [])
     called = {}
@@ -76,11 +72,7 @@ def test_start_process_emits_enriched_fields(monkeypatch, tmp_path):
         def get(self, timeout=None):
             return {"problem_accounts": [sample]}
 
-    class DummyTask:
-        def delay(self, *a, **k):
-            return DummyResult()
-
-    monkeypatch.setattr(app_module, "extract_problematic_accounts", DummyTask())
+    monkeypatch.setattr(app_module, "run_full_pipeline", lambda sid: DummyResult())
     monkeypatch.setattr(app_module, "run_credit_repair_process", lambda *a, **k: None)
     monkeypatch.setattr(app_module, "set_session", lambda *a, **k: None)
     monkeypatch.setattr(app_module.cs_api, "load_session_case", lambda sid: None)

--- a/tests/test_start_process_api_contract.py
+++ b/tests/test_start_process_api_contract.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 from jsonschema import Draft7Validator
 
-from backend.api.app import create_app
-from backend.api import app as app_module
-import backend.core.orchestrators as orch
 import backend.config as config
+import backend.core.orchestrators as orch
+from backend.api import app as app_module
+from backend.api.app import create_app
 
-SCHEMA = Draft7Validator(json.loads(Path('backend/schemas/problem_account.json').read_text()))
+SCHEMA = Draft7Validator(
+    json.loads(Path("backend/schemas/problem_account.json").read_text())
+)
 
 
 def _setup_app(monkeypatch, accounts, meta_map):
@@ -18,65 +20,68 @@ def _setup_app(monkeypatch, accounts, meta_map):
         def get(self, timeout=None):
             return {}
 
-    class DummyTask:
-        def delay(self, *a, **k):
-            return DummyResult()
-
-    monkeypatch.setattr(app_module, 'extract_problematic_accounts', DummyTask())
-    monkeypatch.setattr(app_module, 'run_credit_repair_process', lambda *a, **k: None)
-    monkeypatch.setattr(app_module, 'set_session', lambda *a, **k: None)
-    monkeypatch.setattr(app_module.cs_api, 'load_session_case', lambda sid: None)
-    monkeypatch.setattr(orch, 'collect_stageA_logical_accounts', lambda sid: accounts)
-    monkeypatch.setattr(orch, 'get_stageA_decision_meta', lambda sid, aid: meta_map.get(aid))
+    monkeypatch.setattr(app_module, "run_full_pipeline", lambda sid: DummyResult())
+    monkeypatch.setattr(app_module, "run_credit_repair_process", lambda *a, **k: None)
+    monkeypatch.setattr(app_module, "set_session", lambda *a, **k: None)
+    monkeypatch.setattr(app_module.cs_api, "load_session_case", lambda sid: None)
+    monkeypatch.setattr(orch, "collect_stageA_logical_accounts", lambda sid: accounts)
+    monkeypatch.setattr(
+        orch, "get_stageA_decision_meta", lambda sid, aid: meta_map.get(aid)
+    )
     return create_app()
 
 
 def _post_start_process(app):
     client = app.test_client()
-    data = { 'email': 'user@example.com', 'file': (io.BytesIO(b'%PDF-1.4'), 'report.pdf') }
-    return client.post('/api/start-process', data=data, content_type='multipart/form-data')
+    data = {
+        "email": "user@example.com",
+        "file": (io.BytesIO(b"%PDF-1.4"), "report.pdf"),
+    }
+    return client.post(
+        "/api/start-process", data=data, content_type="multipart/form-data"
+    )
 
 
 def _validate_accounts(records):
     for acc in records:
-        base = {k: v for k, v in acc.items() if k != 'decision_meta'}
+        base = {k: v for k, v in acc.items() if k != "decision_meta"}
         SCHEMA.validate(base)
 
 
 def test_decision_meta_included(monkeypatch):
-    monkeypatch.setattr(config, 'API_INCLUDE_DECISION_META', True)
-    monkeypatch.setattr(config, 'API_DECISION_META_MAX_FIELDS_USED', 6)
+    monkeypatch.setattr(config, "API_INCLUDE_DECISION_META", True)
+    monkeypatch.setattr(config, "API_DECISION_META_MAX_FIELDS_USED", 6)
 
     ai_acc = {
-        'account_id': 'a1',
-        'bureau': 'Equifax',
-        'primary_issue': 'late_payment',
-        'tier': 'Tier1',
-        'problem_reasons': ['reason'],
-        'confidence': 0.9,
-        'decision_source': 'ai',
+        "account_id": "a1",
+        "bureau": "Equifax",
+        "primary_issue": "late_payment",
+        "tier": "Tier1",
+        "problem_reasons": ["reason"],
+        "confidence": 0.9,
+        "decision_source": "ai",
     }
     rules_acc = {
-        'account_id': 'r1',
-        'bureau': 'TransUnion',
-        'primary_issue': 'unknown',
-        'tier': 'none',
-        'problem_reasons': ['past_due_amount: 125.00'],
-        'confidence': 0.0,
-        'decision_source': 'rules',
+        "account_id": "r1",
+        "bureau": "TransUnion",
+        "primary_issue": "unknown",
+        "tier": "none",
+        "problem_reasons": ["past_due_amount: 125.00"],
+        "confidence": 0.0,
+        "decision_source": "rules",
     }
     meta_map = {
-        'a1': {
-            'decision_source': 'ai',
-            'confidence': 0.9,
-            'tier': 'Tier1',
-            'fields_used': ['f1','f2','f3','f4','f5','f6','f7'],
+        "a1": {
+            "decision_source": "ai",
+            "confidence": 0.9,
+            "tier": "Tier1",
+            "fields_used": ["f1", "f2", "f3", "f4", "f5", "f6", "f7"],
         },
-        'r1': {
-            'decision_source': 'rules',
-            'confidence': 0.0,
-            'tier': 'none',
-            'fields_used': ['payment_status', 'balance']
+        "r1": {
+            "decision_source": "rules",
+            "confidence": 0.0,
+            "tier": "none",
+            "fields_used": ["payment_status", "balance"],
         },
     }
 
@@ -84,27 +89,27 @@ def test_decision_meta_included(monkeypatch):
     resp = _post_start_process(app)
     assert resp.status_code == 200
     payload = json.loads(resp.data)
-    records = payload['accounts']['problem_accounts']
-    assert {rec['account_id'] for rec in records} == {'a1','r1'}
+    records = payload["accounts"]["problem_accounts"]
+    assert {rec["account_id"] for rec in records} == {"a1", "r1"}
     _validate_accounts(records)
 
     for rec in records:
-        meta = rec.get('decision_meta')
+        meta = rec.get("decision_meta")
         assert meta is not None
-        assert {'decision_source','confidence','tier'} <= set(meta)
-        if 'fields_used' in meta:
-            assert len(meta['fields_used']) <= config.API_DECISION_META_MAX_FIELDS_USED
+        assert {"decision_source", "confidence", "tier"} <= set(meta)
+        if "fields_used" in meta:
+            assert len(meta["fields_used"]) <= config.API_DECISION_META_MAX_FIELDS_USED
 
-    ai_meta = next(r['decision_meta'] for r in records if r['account_id']=='a1')
-    assert ai_meta['decision_source'] == 'ai'
-    assert ai_meta['confidence'] > 0
-    assert ai_meta['tier'] in {'Tier1','Tier2','Tier3'}
-    assert ai_meta['fields_used'] == meta_map['a1']['fields_used'][:6]
+    ai_meta = next(r["decision_meta"] for r in records if r["account_id"] == "a1")
+    assert ai_meta["decision_source"] == "ai"
+    assert ai_meta["confidence"] > 0
+    assert ai_meta["tier"] in {"Tier1", "Tier2", "Tier3"}
+    assert ai_meta["fields_used"] == meta_map["a1"]["fields_used"][:6]
 
-    rules_meta = next(r['decision_meta'] for r in records if r['account_id']=='r1')
-    assert rules_meta['decision_source'] == 'rules'
-    assert rules_meta['confidence'] == 0.0
-    assert rules_meta['tier'] == 'none'
+    rules_meta = next(r["decision_meta"] for r in records if r["account_id"] == "r1")
+    assert rules_meta["decision_source"] == "rules"
+    assert rules_meta["confidence"] == 0.0
+    assert rules_meta["tier"] == "none"
 
     text = json.dumps(payload)
     assert not re.search(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", text)
@@ -114,56 +119,56 @@ def test_decision_meta_included(monkeypatch):
 
 
 def test_decision_meta_excluded_when_flag_off(monkeypatch):
-    monkeypatch.setattr(config, 'API_INCLUDE_DECISION_META', False)
+    monkeypatch.setattr(config, "API_INCLUDE_DECISION_META", False)
     ai_acc = {
-        'account_id': 'a1',
-        'bureau': 'Equifax',
-        'primary_issue': 'late_payment',
-        'tier': 'Tier1',
-        'problem_reasons': ['reason'],
-        'confidence': 0.9,
-        'decision_source': 'ai',
+        "account_id": "a1",
+        "bureau": "Equifax",
+        "primary_issue": "late_payment",
+        "tier": "Tier1",
+        "problem_reasons": ["reason"],
+        "confidence": 0.9,
+        "decision_source": "ai",
     }
     rules_acc = {
-        'account_id': 'r1',
-        'bureau': 'TransUnion',
-        'primary_issue': 'unknown',
-        'tier': 'none',
-        'problem_reasons': ['past_due_amount: 125.00'],
-        'confidence': 0.0,
-        'decision_source': 'rules',
+        "account_id": "r1",
+        "bureau": "TransUnion",
+        "primary_issue": "unknown",
+        "tier": "none",
+        "problem_reasons": ["past_due_amount: 125.00"],
+        "confidence": 0.0,
+        "decision_source": "rules",
     }
     meta_map = {
-        'a1': {'decision_source': 'ai', 'confidence': 0.9, 'tier': 'Tier1'},
-        'r1': {'decision_source': 'rules', 'confidence': 0.0, 'tier': 'none'},
+        "a1": {"decision_source": "ai", "confidence": 0.9, "tier": "Tier1"},
+        "r1": {"decision_source": "rules", "confidence": 0.0, "tier": "none"},
     }
     app = _setup_app(monkeypatch, [ai_acc, rules_acc], meta_map)
     resp = _post_start_process(app)
     assert resp.status_code == 200
     payload = json.loads(resp.data)
-    records = payload['accounts']['problem_accounts']
-    assert all('decision_meta' not in rec for rec in records)
+    records = payload["accounts"]["problem_accounts"]
+    assert all("decision_meta" not in rec for rec in records)
     _validate_accounts(records)
 
 
 def test_decision_meta_omits_fields_used(monkeypatch):
-    monkeypatch.setattr(config, 'API_INCLUDE_DECISION_META', True)
-    monkeypatch.setattr(config, 'API_DECISION_META_MAX_FIELDS_USED', 6)
+    monkeypatch.setattr(config, "API_INCLUDE_DECISION_META", True)
+    monkeypatch.setattr(config, "API_DECISION_META_MAX_FIELDS_USED", 6)
     ai_acc = {
-        'account_id': 'a1',
-        'bureau': 'Equifax',
-        'primary_issue': 'late_payment',
-        'tier': 'Tier2',
-        'problem_reasons': ['reason'],
-        'confidence': 0.8,
-        'decision_source': 'ai',
+        "account_id": "a1",
+        "bureau": "Equifax",
+        "primary_issue": "late_payment",
+        "tier": "Tier2",
+        "problem_reasons": ["reason"],
+        "confidence": 0.8,
+        "decision_source": "ai",
     }
-    meta_map = {'a1': {'decision_source': 'ai', 'confidence': 0.8, 'tier': 'Tier2'}}
+    meta_map = {"a1": {"decision_source": "ai", "confidence": 0.8, "tier": "Tier2"}}
     app = _setup_app(monkeypatch, [ai_acc], meta_map)
     resp = _post_start_process(app)
     assert resp.status_code == 200
     payload = json.loads(resp.data)
-    records = payload['accounts']['problem_accounts']
+    records = payload["accounts"]["problem_accounts"]
     _validate_accounts(records)
-    meta = records[0]['decision_meta']
-    assert 'fields_used' not in meta
+    meta = records[0]["decision_meta"]
+    assert "fields_used" not in meta


### PR DESCRIPTION
## Summary
- replace direct `extract_problematic_accounts` task usage with `run_full_pipeline` to guarantee cleanup runs first
- adjust async upload endpoint to start the unified pipeline
- update tests to stub `run_full_pipeline`

## Testing
- `pre-commit run --files backend/api/app.py tests/test_start_process_api_contract.py tests/test_start_process.py tests/test_start_process_integration.py tests/test_stageE_case_store_only.py`
- `pytest tests/test_start_process_api_contract.py tests/test_start_process.py tests/test_start_process_integration.py tests/test_stageE_case_store_only.py -q` *(fails: missing dummy.pdf and case setup)*
- `pytest tests/test_start_process_api_contract.py::test_decision_meta_included -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1eaf8325c83258df58aff5d073f78