### PR TITLE
chore: delegate stage-a cleanup to chain

### DIFF
--- a/backend/core/config/__init__.py
+++ b/backend/core/config/__init__.py
@@ -13,8 +13,8 @@ code, which keeps orchestrator logic straightforward and easy to test.
 # flag to determine whether the cleanup routine should run.
 from __future__ import annotations
 
-# Whether to remove trace files after Stage-A export.  Kept ``True`` by default
-# so deployments opt-in automatically; tests may override via monkeypatching.
-CLEANUP_AFTER_EXPORT: bool = True
+# Whether to remove trace files after Stage-A export.  Defaulted ``False`` so
+# cleanup occurs in the Celery chain; tests may override via monkeypatching.
+CLEANUP_AFTER_EXPORT: bool = False
 
 __all__ = ["CLEANUP_AFTER_EXPORT"]

--- a/backend/core/logic/report_analysis/orchestrator.py
+++ b/backend/core/logic/report_analysis/orchestrator.py
@@ -50,6 +50,9 @@ def run_stage_a(session_id: str, project_root: Path = Path(".")) -> dict:
         log.info("purge_after_export", extra={"sid": session_id, **cleanup_summary})
         meta["cleanup"] = {"performed": True, "summary": cleanup_summary}
     else:
-        meta["cleanup"] = {"performed": False, "reason": "flag_off"}
+        log.debug(
+            "run_stage_a: cleanup delegated to chain", extra={"sid": session_id}
+        )
+        meta["cleanup"] = {"performed": False, "reason": "delegated_to_chain"}
 
     return meta


### PR DESCRIPTION
## Summary
- disable Stage-A inline cleanup; Celery chain handles trace purging
- log when run_stage_a defers cleanup to the chain

## Testing
- `python -m pytest` (fails: Segmentation fault)


------
https://chatgpt.com/codex/tasks/task_b_68c1ee1a4e108325b42f3ae1e06910b8