### PR TITLE
feat(api): add smoke pipeline route

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -40,6 +40,7 @@ from backend.api.session_manager import (
 )
 from backend.api.tasks import run_credit_repair_process  # noqa: F401
 from backend.api.tasks import app as celery_app, smoke_task
+from backend.api.routes_smoke import bp as smoke_bp
 from backend.api.ui_events import ui_event_bp
 from backend.core import orchestrators as orch
 from backend.core.case_store import api as cs_api
@@ -444,6 +445,7 @@ def create_app() -> Flask:
     app.register_blueprint(api_bp)
     app.register_blueprint(ai_bp)
     app.register_blueprint(ui_event_bp)
+    app.register_blueprint(smoke_bp, url_prefix="/smoke")
 
     @app.before_request
     def _load_config() -> None:

--- a/backend/api/routes_smoke.py
+++ b/backend/api/routes_smoke.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, jsonify, request
+
+from backend.api.pipeline import run_full_pipeline
+
+bp = Blueprint("smoke", __name__)
+
+
+@bp.route("/run", methods=["POST"])
+def smoke_run():
+    """Trigger the canonical pipeline for a given SID.
+
+    This endpoint expects JSON with a ``sid`` field and enqueues the
+    Stage-A → Cleanup → Problematic pipeline for that session.
+    """
+    sid = request.json.get("sid") if request.is_json else None
+    if not sid:
+        return jsonify({"error": "sid required"}), 400
+    run_full_pipeline(sid)
+    return jsonify({"sid": sid, "queued": True})

--- a/tests/api/test_smoke_route.py
+++ b/tests/api/test_smoke_route.py
@@ -1,0 +1,37 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.com/v1")
+    import backend.api.routes_smoke as routes_smoke
+    calls = {}
+
+    def dummy_run_full_pipeline(sid):
+        calls["sid"] = sid
+        return {"queued": True}
+
+    monkeypatch.setattr(routes_smoke, "run_full_pipeline", dummy_run_full_pipeline)
+    import backend.api.app as app_module
+    importlib.reload(app_module)
+    return app_module.create_app(), calls
+
+
+def test_smoke_run_success(app):
+    app_instance, calls = app
+    client = app_instance.test_client()
+    resp = client.post("/smoke/run", json={"sid": "123"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"sid": "123", "queued": True}
+    assert calls["sid"] == "123"
+
+
+def test_smoke_run_missing_sid(app):
+    app_instance, _ = app
+    client = app_instance.test_client()
+    resp = client.post("/smoke/run", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "sid required"


### PR DESCRIPTION
## Summary
- add `/smoke/run` endpoint to trigger the full pipeline from HTTP
- wire smoke blueprint into the Flask app
- cover smoke route with tests

## Testing
- `pytest tests/api/test_smoke_route.py`
- `pytest -q` *(failed: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c1efc03970832588bde89237c82356