### PR TITLE
Ensure Celery pipeline uses immutable signatures

### DIFF
--- a/backend/api/pipeline.py
+++ b/backend/api/pipeline.py
@@ -8,10 +8,10 @@ from backend.api.tasks import (
 
 
 def run_full_pipeline(sid: str):
-    """Run Stage-A export, cleanup traces, and extract accounts for ``sid``.
+    """Run the full "Stage-A → Cleanup → Problematic" pipeline for ``sid``.
 
-    Each task receives ``sid`` explicitly via ``.si`` to avoid relying on the
-    previous task's return value.
+    The tasks are chained in the above order using immutable signatures so each
+    step receives ``sid`` directly rather than the previous task's result.
     """
     return chain(
         stage_a_task.si(sid),


### PR DESCRIPTION
## Summary
- clarify `run_full_pipeline` to chain Stage-A → Cleanup → Problematic using immutable Celery signatures

## Testing
- `pre-commit run --files backend/api/pipeline.py`
- `pytest tests/test_trace_cleanup.py::test_purge_after_export_keeps_only_final_artifacts -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1f651ab9083259262dd2b1688427a