### PR TITLE
feat(core): add duplicate cleanup warning

### DIFF
--- a/backend/core/config/__init__.py
+++ b/backend/core/config/__init__.py
@@ -13,8 +13,11 @@ code, which keeps orchestrator logic straightforward and easy to test.
 # flag to determine whether the cleanup routine should run.
 from __future__ import annotations
 
+from .flags import env_bool
+
 # Whether to remove trace files after Stage-A export.  Defaulted ``False`` so
-# cleanup occurs in the Celery chain; tests may override via monkeypatching.
-CLEANUP_AFTER_EXPORT: bool = False
+# cleanup occurs in the Celery chain; tests may override via the
+# ``CLEANUP_AFTER_EXPORT`` environment variable.
+CLEANUP_AFTER_EXPORT: bool = env_bool("CLEANUP_AFTER_EXPORT", False)
 
 __all__ = ["CLEANUP_AFTER_EXPORT"]

--- a/backend/core/logic/report_analysis/orchestrator.py
+++ b/backend/core/logic/report_analysis/orchestrator.py
@@ -46,6 +46,10 @@ def run_stage_a(session_id: str, project_root: Path = Path(".")) -> dict:
         return meta
 
     if CLEANUP_AFTER_EXPORT:
+        log.warning(
+            "CLEANUP_AFTER_EXPORT enabled; duplicate cleanup may occur but is idempotent",
+            extra={"sid": session_id},
+        )
         cleanup_summary = purge_after_export(sid=session_id, project_root=project_root)
         log.info("purge_after_export", extra={"sid": session_id, **cleanup_summary})
         meta["cleanup"] = {"performed": True, "summary": cleanup_summary}


### PR DESCRIPTION
## Summary
- read CLEANUP_AFTER_EXPORT flag from environment with default false
- warn when CLEANUP_AFTER_EXPORT is enabled to note potential duplicate but idempotent cleanup

## Testing
- `pytest` *(fails: Segmentation fault in PyMuPDF)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f768df488325baa2346c70d58eb0