### PR TITLE
Add problem case builder

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+from backend.settings import PROJECT_ROOT
+
+logger = logging.getLogger(__name__)
+
+
+def _make_account_id(account: Mapping[str, Any], idx: int) -> str:
+    """Return a filesystem-friendly account identifier."""
+    raw = str(
+        account.get("account_id")
+        or account.get("id")
+        or account.get("account_index")
+        or idx
+    )
+    return re.sub(r"[^A-Za-z0-9._-]", "_", raw)
+
+
+def _derive_problems(
+    account: Mapping[str, Any]
+) -> tuple[list[str], list[str], float | None]:
+    """Return problem tags, reasons, and optional confidence for ``account``.
+
+    This basic implementation flags accounts missing a heading.  Future tasks
+    expand on this detection logic.
+    """
+    tags: list[str] = []
+    reasons: list[str] = []
+    confidence: float | None = None
+    if not account.get("heading_guess"):
+        tags.append("missing_heading")
+        reasons.append("missing heading")
+    return tags, reasons, confidence
+
+
+def build_problem_cases(session_id: str, root: Path | None = None) -> dict:
+    """Detect problematic accounts from ``accounts_from_full.json``.
+
+    Parameters
+    ----------
+    session_id:
+        Identifier used to locate ``traces/blocks/<sid>``.
+    root:
+        Repository root; defaults to :data:`~backend.settings.PROJECT_ROOT`.
+    """
+
+    logger.info("PROBLEM_CASES start sid=%s", session_id)
+
+    base = (root or PROJECT_ROOT) / "traces" / "blocks" / session_id / "accounts_table"
+    acc_path = base / "accounts_from_full.json"
+    accounts: list[MutableMapping[str, Any]] = []
+    if acc_path.exists():
+        try:
+            data = json.loads(acc_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                accounts = list(data.get("accounts") or [])
+            elif isinstance(data, list):
+                accounts = list(data)
+        except Exception:
+            accounts = []
+
+    total = len(accounts)
+
+    out_dir = (root or PROJECT_ROOT) / "cases" / session_id
+    accounts_out = out_dir / "accounts"
+    accounts_out.mkdir(parents=True, exist_ok=True)
+
+    summaries: list[dict[str, Any]] = []
+    for idx, acc in enumerate(accounts, start=1):
+        if not isinstance(acc, Mapping):
+            continue
+        account_id = _make_account_id(acc, idx)
+        tags, reasons, confidence = _derive_problems(acc)
+        if not tags and not reasons:
+            continue
+        case = {
+            "sid": session_id,
+            "account_id": account_id,
+            "source": "accounts_from_full",
+            "account": acc,
+            "problem_tags": tags,
+            "problem_reasons": reasons,
+        }
+        if confidence is not None:
+            case["confidence"] = confidence
+        (accounts_out / f"{account_id}.json").write_text(
+            json.dumps(case, indent=2), encoding="utf-8"
+        )
+        summaries.append(
+            {
+                "account_id": account_id,
+                "problem_tags": tags,
+                "problem_reasons": reasons,
+            }
+        )
+
+    index = {
+        "sid": session_id,
+        "total": total,
+        "problematic": len(summaries),
+        "problematic_accounts": summaries,
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.json").write_text(json.dumps(index, indent=2), encoding="utf-8")
+
+    logger.info(
+        "PROBLEM_CASES done sid=%s total=%s problematic=%s",
+        session_id,
+        total,
+        len(summaries),
+    )
+
+    return {
+        "sid": session_id,
+        "total": total,
+        "problematic": len(summaries),
+        "out_dir": str(out_dir),
+        "summaries": summaries,
+    }

--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -1,0 +1,82 @@
+import json
+import logging
+from pathlib import Path
+
+from backend.core.logic.report_analysis.problem_case_builder import build_problem_cases
+
+
+def _write_accounts(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_build_problem_cases(tmp_path, caplog):
+    sid = "S123"
+    accounts = [
+        {"account_index": 1, "heading_guess": None, "lines": []},
+        {"account_index": 2, "heading_guess": "OK", "lines": []},
+    ]
+    acc_path = (
+        tmp_path
+        / "traces"
+        / "blocks"
+        / sid
+        / "accounts_table"
+        / "accounts_from_full.json"
+    )
+    _write_accounts(acc_path, {"accounts": accounts})
+
+    caplog.set_level(logging.INFO)
+    result = build_problem_cases(sid, root=tmp_path)
+
+    assert result == {
+        "sid": sid,
+        "total": 2,
+        "problematic": 1,
+        "out_dir": str(tmp_path / "cases" / sid),
+        "summaries": [
+            {
+                "account_id": "1",
+                "problem_tags": ["missing_heading"],
+                "problem_reasons": ["missing heading"],
+            }
+        ],
+    }
+
+    case_file = tmp_path / "cases" / sid / "accounts" / "1.json"
+    assert case_file.exists()
+    case = json.loads(case_file.read_text())
+    assert case["sid"] == sid
+    assert case["problem_tags"] == ["missing_heading"]
+
+    index_file = tmp_path / "cases" / sid / "index.json"
+    assert index_file.exists()
+    index = json.loads(index_file.read_text())
+    assert index["total"] == 2
+    assert index["problematic"] == 1
+    assert index["problematic_accounts"][0]["account_id"] == "1"
+
+    assert any("PROBLEM_CASES start" in msg for msg in caplog.messages)
+    assert any("PROBLEM_CASES done" in msg for msg in caplog.messages)
+
+
+def test_build_problem_cases_top_level_list(tmp_path):
+    sid = "S234"
+    accounts = [{"account_index": 1, "heading_guess": None}]
+    acc_path = (
+        tmp_path
+        / "traces"
+        / "blocks"
+        / sid
+        / "accounts_table"
+        / "accounts_from_full.json"
+    )
+    _write_accounts(acc_path, accounts)
+
+    res = build_problem_cases(sid, root=tmp_path)
+
+    case_file = tmp_path / "cases" / sid / "accounts" / "1.json"
+    assert case_file.exists()
+    index = json.loads((tmp_path / "cases" / sid / "index.json").read_text())
+    assert index["problematic"] == 1
+    assert res["total"] == 1


### PR DESCRIPTION
## Summary
- add problem_case_builder to generate per-account case files
- support building from accounts_from_full.json and emit index summary
- tests for problem case builder

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/problem_case_builder.py tests/test_problem_case_builder.py`
- `pytest tests/test_problem_case_builder.py`


------
https://chatgpt.com/codex/tasks/task_b_68c2028fd930832586e40f8a70f78e6d