### PR TITLE
feat: derive stable account ids for problem cases

### DIFF
--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 from backend.core.logic.report_analysis.problem_case_builder import build_problem_cases
+from backend.core.logic.report_analysis.keys import compute_logical_account_key
 
 
 def _write_accounts(path: Path, data) -> None:
@@ -36,14 +37,14 @@ def test_build_problem_cases(tmp_path, caplog):
         "out_dir": str(tmp_path / "cases" / sid),
         "summaries": [
             {
-                "account_id": "1",
+                "account_id": "account_1",
                 "problem_tags": ["missing_heading"],
                 "problem_reasons": ["missing heading"],
             }
         ],
     }
 
-    case_file = tmp_path / "cases" / sid / "accounts" / "1.json"
+    case_file = tmp_path / "cases" / sid / "accounts" / "account_1.json"
     assert case_file.exists()
     case = json.loads(case_file.read_text())
     assert case["sid"] == sid
@@ -54,7 +55,7 @@ def test_build_problem_cases(tmp_path, caplog):
     index = json.loads(index_file.read_text())
     assert index["total"] == 2
     assert index["problematic"] == 1
-    assert index["problematic_accounts"][0]["account_id"] == "1"
+    assert index["problematic_accounts"][0]["account_id"] == "account_1"
 
     assert any("PROBLEM_CASES start" in msg for msg in caplog.messages)
     assert any("PROBLEM_CASES done" in msg for msg in caplog.messages)
@@ -75,8 +76,40 @@ def test_build_problem_cases_top_level_list(tmp_path):
 
     res = build_problem_cases(sid, root=tmp_path)
 
-    case_file = tmp_path / "cases" / sid / "accounts" / "1.json"
+    case_file = tmp_path / "cases" / sid / "accounts" / "account_1.json"
     assert case_file.exists()
     index = json.loads((tmp_path / "cases" / sid / "index.json").read_text())
     assert index["problematic"] == 1
     assert res["total"] == 1
+
+
+def test_account_id_uses_logical_key(tmp_path):
+    sid = "S345"
+    account = {
+        "account_index": 1,
+        "heading_guess": None,
+        "fields": {
+            "issuer": "Real Bank",
+            "account_last4": "1234",
+            "account_type": "REVOLVING",
+            "opened_date": "2020-01-01",
+        },
+    }
+    acc_path = (
+        tmp_path
+        / "traces"
+        / "blocks"
+        / sid
+        / "accounts_table"
+        / "accounts_from_full.json"
+    )
+    _write_accounts(acc_path, {"accounts": [account]})
+
+    res = build_problem_cases(sid, root=tmp_path)
+
+    expected = compute_logical_account_key(
+        "Real Bank", "1234", "REVOLVING", "2020-01-01"
+    )
+    assert res["summaries"][0]["account_id"] == expected
+    case_file = tmp_path / "cases" / sid / "accounts" / f"{expected}.json"
+    assert case_file.exists()


### PR DESCRIPTION
## Summary
- compute stable logical identifiers for problem-case accounts
- test account-id derivation and fallback behavior

## Testing
- `pytest tests/test_problem_case_builder.py`


------
https://chatgpt.com/codex/tasks/task_b_68c203cb001083259e2a0f87dc607bf7