### PR TITLE
Ensure Celery problematic account task handles builder path

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -155,8 +155,7 @@ def extract_problematic_accounts(self, sid: str) -> dict:
     log.info("PROBLEMATIC start sid=%s", sid)
     try:
         found = extract_problematic_accounts_logic(sid) or []
-        count = len(found)
-        result = {"sid": sid, "status": "ok", "found": found}
+        result = {"sid": sid, "found": found}
         safe_result = _json_safe(result)
         try:
             json.dumps(safe_result, ensure_ascii=False)
@@ -166,7 +165,7 @@ def extract_problematic_accounts(self, sid: str) -> dict:
                 e,
             )
             raise
-        log.info("PROBLEMATIC end sid=%s count=%s", sid, count)
+        log.info("PROBLEMATIC done sid=%s found=%s", sid, len(found))
         return safe_result
     except Exception:
         logger.exception("PROBLEMATIC failed sid=%s", sid)

--- a/tests/test_extract_problematic_accounts_task.py
+++ b/tests/test_extract_problematic_accounts_task.py
@@ -1,0 +1,48 @@
+import json
+import logging
+from pathlib import Path
+
+import backend.api.tasks as task_module
+from backend.api.tasks import extract_problematic_accounts
+from backend.core.case_store import storage as cs_storage
+from backend.core.logic.report_analysis import problem_case_builder
+from backend import settings
+
+
+def _write_accounts(base: Path) -> None:
+    base.parent.mkdir(parents=True, exist_ok=True)
+    data = {"accounts": [{"account_index": 1, "fields": {"past_due_amount": 50}}]}
+    base.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_extract_problematic_accounts_task_builder(tmp_path, monkeypatch, caplog):
+    sid = "S777"
+
+    # Redirect project root and case store to temporary paths
+    monkeypatch.setattr(settings, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(problem_case_builder, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(task_module, "PROJECT_ROOT", tmp_path, raising=False)
+
+    casestore_dir = tmp_path / "casestore"
+    monkeypatch.setattr("backend.config.CASESTORE_DIR", str(casestore_dir), raising=False)
+    monkeypatch.setattr(cs_storage, "CASESTORE_DIR", str(casestore_dir))
+
+    # Create Stage-A account artifacts
+    acc_path = (
+        tmp_path
+        / "traces"
+        / "blocks"
+        / sid
+        / "accounts_table"
+        / "accounts_from_full.json"
+    )
+    _write_accounts(acc_path)
+
+    caplog.set_level(logging.INFO)
+    result = extract_problematic_accounts.run(sid)
+
+    assert result["sid"] == sid
+    assert len(result["found"]) == 1
+    assert result["found"][0]["account_id"] == "account_1"
+    assert any(f"PROBLEMATIC start sid={sid}" in m for m in caplog.messages)
+    assert any(f"PROBLEMATIC done sid={sid} found=1" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- log start/end with counts for problematic account task
- return JSON-safe results without relying on Case Store
- add regression test ensuring Celery task works when only builder artifacts exist

## Testing
- `pytest tests/test_extract_problematic_accounts_task.py -q`
- `pytest tests/test_extract_problematic_accounts.py::test_extract_problematic_accounts_builder_fallback -q`
- `pytest -q` *(fails: Segmentation fault in PyMuPDF)*

------
https://chatgpt.com/codex/tasks/task_b_68c20c53f4c08325ab0553358d3b8787