### PR TITLE
feat: log problem builder outputs

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -186,10 +186,11 @@ def build_problem_cases(session_id: str, root: Path | None = None) -> dict:
     (out_dir / "index.json").write_text(json.dumps(index, indent=2), encoding="utf-8")
 
     logger.info(
-        "PROBLEM_CASES done sid=%s total=%s problematic=%s",
+        "PROBLEM_CASES done sid=%s total=%s problematic=%s out=%s",
         session_id,
         total,
         len(summaries),
+        out_dir,
     )
 
     return {

--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -63,8 +63,12 @@ def test_build_problem_cases(tmp_path, caplog):
     assert index["problematic"] == 1
     assert index["problematic_accounts"][0]["account_id"] == "account_1"
 
-    assert any("PROBLEM_CASES start" in msg for msg in caplog.messages)
-    assert any("PROBLEM_CASES done" in msg for msg in caplog.messages)
+    out_dir = tmp_path / "cases" / sid
+    assert any(f"PROBLEM_CASES start sid={sid}" in msg for msg in caplog.messages)
+    assert any(
+        f"PROBLEM_CASES done sid={sid} total=2 problematic=1 out={out_dir}" in msg
+        for msg in caplog.messages
+    )
 
 
 def test_build_problem_cases_top_level_list(tmp_path):


### PR DESCRIPTION
## Summary
- include output directory in PROBLEM_CASES completion log for quick visibility of builder results
- test updated to assert start/end logs with counts and output path

## Testing
- `pytest tests/test_problem_case_builder.py tests/test_extract_problematic_accounts_task.py`
- ⚠️ `pytest` *(fails: Segmentation fault: PyMuPDF import)*

------
https://chatgpt.com/codex/tasks/task_b_68c20f1fba108325a40d2ce3679ed3d4