### PR TITLE
Add logging guardrails for problem extraction and case building

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -98,7 +98,9 @@ def _load_accounts(path: Path) -> List[Mapping[str, Any]]:
     return out
 
 
-def _build_account_lookup(accounts: Iterable[Mapping[str, Any]]) -> Dict[str, Mapping[str, Any]]:
+def _build_account_lookup(
+    accounts: Iterable[Mapping[str, Any]]
+) -> Dict[str, Mapping[str, Any]]:
     """Build a mapping of possible identifiers to account records."""
 
     by_key: Dict[str, Mapping[str, Any]] = {}
@@ -130,8 +132,6 @@ def build_problem_cases(
         Repository root; defaults to :data:`backend.settings.PROJECT_ROOT`.
     """
 
-    logger.info("PROBLEM_CASES start sid=%s", sid)
-
     root_path = Path(root or PROJECT_ROOT)
     acc_path = (
         root_path
@@ -150,6 +150,8 @@ def build_problem_cases(
     accounts_dir = out_dir / "accounts"
     out_dir.mkdir(parents=True, exist_ok=True)
     accounts_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("PROBLEM_CASES start sid=%s total=%s out=%s", sid, total, out_dir)
 
     for cand in candidates or []:
         if not isinstance(cand, Mapping):
@@ -198,8 +200,12 @@ def build_problem_cases(
         out_dir,
     )
 
-    return {"sid": sid, "total": total, "problematic": len(cand_list), "out": str(out_dir)}
+    return {
+        "sid": sid,
+        "total": total,
+        "problematic": len(cand_list),
+        "out": str(out_dir),
+    }
 
 
 __all__ = ["build_problem_cases"]
-

--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -1,10 +1,10 @@
 import json
-from pathlib import Path
+import logging
 
 from backend.core.logic.report_analysis.problem_case_builder import build_problem_cases
 
 
-def test_problem_case_builder(tmp_path):
+def test_problem_case_builder(tmp_path, caplog):
     """Smoke test for :func:`build_problem_cases`.
 
     The builder should read a sample ``accounts_from_full.json`` file and
@@ -36,7 +36,16 @@ def test_problem_case_builder(tmp_path):
     acc_path.write_text(json.dumps({"accounts": accounts}), encoding="utf-8")
 
     # Run the builder
-    summary = build_problem_cases(sid, root=tmp_path)
+    caplog.set_level(logging.INFO)
+    candidates = [
+        {
+            "account_id": "idx-001",
+            "account_index": 1,
+            "problem_tags": ["past_due"],
+            "problem_reasons": ["past_due_amount"],
+        }
+    ]
+    summary = build_problem_cases(sid, candidates=candidates, root=tmp_path)
 
     # Validate index.json was written with correct counts
     index_path = tmp_path / "cases" / sid / "index.json"
@@ -55,3 +64,38 @@ def test_problem_case_builder(tmp_path):
     # Returned summary should mirror disk counts
     assert summary["total"] == len(accounts)
     assert summary["problematic"] == 1
+
+    out_dir = tmp_path / "cases" / sid
+    assert any(
+        f"PROBLEM_CASES start sid={sid} total={len(accounts)} out={out_dir}" in m
+        for m in caplog.messages
+    )
+    assert any(
+        f"PROBLEM_CASES done sid={sid} total={len(accounts)} problematic=1 out={out_dir}"
+        in m
+        for m in caplog.messages
+    )
+
+
+def test_problem_case_builder_missing_accounts(tmp_path, caplog):
+    sid = "S999"
+
+    caplog.set_level(logging.INFO)
+    summary = build_problem_cases(sid, root=tmp_path)
+
+    # Index should be written with zero counts
+    index_path = tmp_path / "cases" / sid / "index.json"
+    assert index_path.exists()
+    index = json.loads(index_path.read_text())
+    assert index["total"] == 0 and index["problematic"] == 0
+    assert summary["total"] == 0 and summary["problematic"] == 0
+
+    out_dir = tmp_path / "cases" / sid
+    assert any(
+        f"PROBLEM_CASES start sid={sid} total=0 out={out_dir}" in m
+        for m in caplog.messages
+    )
+    assert any(
+        f"PROBLEM_CASES done sid={sid} total=0 problematic=0 out={out_dir}" in m
+        for m in caplog.messages
+    )

--- a/tests/test_problem_extractor.py
+++ b/tests/test_problem_extractor.py
@@ -1,0 +1,31 @@
+import logging
+from pathlib import Path
+
+from backend.core.logic.report_analysis import problem_extractor
+
+
+def test_problem_extractor_missing_accounts(tmp_path, caplog, monkeypatch):
+    sid = "S404"
+    monkeypatch.setattr(problem_extractor, "PROJECT_ROOT", tmp_path)
+
+    caplog.set_level(logging.INFO)
+    results = problem_extractor.detect_problem_accounts(sid)
+
+    assert results == []
+    acc_path = (
+        Path(tmp_path)
+        / "traces"
+        / "blocks"
+        / sid
+        / "accounts_table"
+        / "accounts_from_full.json"
+    )
+    assert any(
+        f"accounts_from_full.json missing sid={sid} path={acc_path}" in m
+        for m in caplog.messages
+    )
+    assert any(f"PROBLEM_EXTRACT start sid={sid}" in m for m in caplog.messages)
+    assert any(
+        f"PROBLEM_EXTRACT done sid={sid} total=0 problematic=0" in m
+        for m in caplog.messages
+    )


### PR DESCRIPTION
## Summary
- log missing accounts artifacts during problem extraction
- report totals and output paths when building problem cases
- cover extractor and builder edge cases with tests

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/problem_case_builder.py backend/core/logic/report_analysis/problem_extractor.py tests/test_problem_case_builder.py tests/test_problem_extractor.py`
- `pytest tests/test_problem_case_builder.py tests/test_problem_extractor.py tests/test_extract_problematic_accounts_task.py`


------
https://chatgpt.com/codex/tasks/task_b_68c2da4913788325a26e9bce0f900a46