### PR TITLE
Add unit tests for join_tokens_with_space

### DIFF
--- a/tests/test_join_tokens.py
+++ b/tests/test_join_tokens.py
@@ -1,0 +1,14 @@
+import pytest
+from backend.core.logic.report_analysis.block_exporter import join_tokens_with_space
+
+
+@pytest.mark.parametrize("tokens,expected", [
+    (["PaymentStatus:", "Collection/Chargeoff", "Collection/Chargeoff"],
+     "PaymentStatus: Collection/Chargeoff Collection/Chargeoff"),
+    (["HighBalance:", "$11,374", "$0", "$10,792"], "HighBalance: $11,374 $0 $10,792"),
+    (["Transunion", "®", "Experian", "®", "Equifax", "®"], "Transunion ® Experian ® Equifax ®"),
+    (["OK", "OK", "OK"], "OK OK OK"),
+    (["עברית", "English", "123"], "עברית English 123"),
+])
+def test_join_tokens_with_space(tokens, expected):
+    assert join_tokens_with_space(tokens) == expected


### PR DESCRIPTION
## Summary
- add parametrized tests for join_tokens_with_space to ensure correct spacing across punctuation, numerals, and mixed languages

## Testing
- `DISABLE_PDF_RENDER=true pytest tests/test_join_tokens.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c2f450a0a88325852ea17be436bba8