### PR TITLE
feat(stage-a): track enriched accounts json

### DIFF
--- a/tests/test_block_exporter.py
+++ b/tests/test_block_exporter.py
@@ -156,6 +156,31 @@ def test_rerun_overwrites_files(chdir_tmp, monkeypatch, stub_layout):
     assert len(list(accounts_dir.glob("accounts_from_full*.json"))) == 1
 
 
+def test_accounts_table_index_tracks_enriched_json(chdir_tmp, monkeypatch, stub_layout):
+    monkeypatch.setattr(
+        be, "load_cached_text", lambda sid: {"full_text": _sample_text()}
+    )
+
+    orig_split = be.split_accounts_from_tsv
+
+    def _stub_split(full_tsv, json_out, write_tsv=True):
+        result = orig_split(full_tsv, json_out, write_tsv)
+        enriched = json_out.with_name(json_out.stem + ".enriched.json")
+        enriched.write_text(json_out.read_text(encoding="utf-8"), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(be, "split_accounts_from_tsv", _stub_split)
+
+    be.export_account_blocks("sess_enr", SAMPLE_PDF)
+
+    accounts_dir = Path("traces") / "blocks" / "sess_enr" / "accounts_table"
+    idx_path = accounts_dir / "_table_index.json"
+    idx = json.loads(idx_path.read_text(encoding="utf-8"))
+    extras = idx.get("extras", [])
+    paths = {e.get("type"): e.get("path") for e in extras}
+    enriched_path = accounts_dir / "accounts_from_full.enriched.json"
+    assert paths.get("accounts_from_full_enriched") == str(enriched_path)
+
 def test_load_account_blocks_reads_back(chdir_tmp, monkeypatch, stub_layout):
     monkeypatch.setattr(
         be, "load_cached_text", lambda sid: {"full_text": _sample_text()}


### PR DESCRIPTION
## Summary
- register enriched accounts JSON in Stage-A index when present
- cover index tracking of enriched JSON with tests

## Testing
- `pytest tests/test_block_exporter.py`
- `pytest` *(fails: 60 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68c3133b81d483258b3a263832f072b5