### PR TITLE
docs: add X-based triad parsing section

### DIFF
--- a/REPORT_ANALYSIS_AUDIT.md
+++ b/REPORT_ANALYSIS_AUDIT.md
@@ -22,3 +22,58 @@ analysis. After `TRACE_CLEANUP` the file remains under
 If a legacy Case Store session exists, the system reads problem accounts from
 that path instead. The Case Store remains supported, but `accounts_from_full.json`
 is the source of truth when it is absent.
+
+## X-based Triad Parsing
+
+Stage-A can optionally split certain rows into bureau-specific values based on
+token X positions. When enabled, the parser inspects each page for the
+`TransUnion / Experian / Equifax` header row. The horizontal midpoint of each
+title defines four bands: the label column followed by the TransUnion, Experian,
+and Equifax columns. Tokens are assigned to a band when their midpoint falls
+inside the band with a tiny right-edge tolerance so that adjacent bands do not
+leave gaps.
+
+### Special Labels and Rows
+
+* Fields normally have a trailing `:` in the label. `Account #` is treated as a
+  label as well even though it ends with `#` instead of a colon.
+* A row without a label is considered a continuation and is appended to the last
+  opened field for whichever band produced it.
+* Parsing stops when a label `Two-Year Payment History` is encountered; the raw
+  lines after that label remain untouched.
+
+### Environment Flags
+
+```
+RAW_TRIAD_FROM_X=1
+RAW_JOIN_TOKENS_WITH_SPACE=1
+```
+
+`RAW_TRIAD_FROM_X` enables X-based triad parsing and adds extra debug output.
+`RAW_JOIN_TOKENS_WITH_SPACE` keeps token order while inserting spaces between
+neighboring tokens.
+
+### Example Logs
+
+```
+[triad] bands: label=0-150 tu=150-300 xp=300-450 eq=450-600
+[triad] field: Payment Status: Current | Current | Current
+[triad] field: High Balance: 0 | 0 | 0
+```
+
+### Example JSON Output
+
+```json
+{
+  "triad": {"enabled": true, "order": ["transunion", "experian", "equifax"]},
+  "triad_fields": {
+    "transunion": {"High Balance": "0", "Payment Status": "Current"},
+    "experian": {"High Balance": "0", "Payment Status": "Current"},
+    "equifax": {"High Balance": "0", "Payment Status": "Current"}
+  },
+  "triad_rows": [
+    "High Balance: 0 0 0",
+    "Payment Status: Current Current Current"
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- document X-based triad parsing in report analysis audit docs

## Testing
- `pre-commit run --files REPORT_ANALYSIS_AUDIT.md`


------
https://chatgpt.com/codex/tasks/task_b_68c31b3ecae8832591b1021b44fd2bca