### PR TITLE
feat: support hash label markers

### DIFF
--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -313,12 +313,16 @@ def split_accounts(
                     continue
                 label_clean = " ".join(label_txt.split())
                 is_account_num = label_clean == "Account #"
-                if label_txt and (label_txt.endswith(":") or is_account_num):
-                    label_core = label_txt.rstrip(":")
+                if label_txt and (
+                    label_txt.endswith(":") or label_txt.endswith("#") or is_account_num
+                ):
+                    label_core = label_txt.rstrip(":#").strip()
                     if _norm(label_core) == "twoyearpaymenthistory":
                         open_row = None
                         break
-                    key = LABEL_MAP.get(label_core)
+                    key = LABEL_MAP.get(label_txt.rstrip(":")) or LABEL_MAP.get(
+                        label_core
+                    )
                     row = {
                         "triad_row": True,
                         "label": label_core,


### PR DESCRIPTION
## Summary
- support label lines ending with `#` in triad parsing
- strip ':' and '#' when storing triad labels and attempt lookup with both forms

## Testing
- `mypy backend/core/models backend/core/logic/report_analysis` *(fails: object has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c3317d9a0c8325883970e81169119a