### PR TITLE
Fix canonical label mapping for Account #

### DIFF
--- a/backend/core/logic/report_analysis/canonical_labels.py
+++ b/backend/core/logic/report_analysis/canonical_labels.py
@@ -51,7 +51,7 @@ _BUREAU_HDRS = {"transunion", "experian", "equifax"}
 
 # Canonical label -> normalized field name
 LABEL_MAP = {
-    "Account #": "account_number",  # treat as field label even though it ends with '#'
+    "Account #": "account_number_display",  # treat as field label even though it ends with '#'
     "High Balance": "high_balance",
     "Last Verified": "last_verified",
     "Date of Last Activity": "date_of_last_activity",


### PR DESCRIPTION
## Summary
- map "Account #" to `account_number_display` in report analysis label map

## Testing
- `pytest tests/test_join_tokens.py`
- `pytest tests/test_block_heading_canonical.py tests/test_join_tokens.py` *(fails: Segmentation fault due to PyMuPDF import)*

------
https://chatgpt.com/codex/tasks/task_b_68c336e780e083259186575652b7b7f8