### PR TITLE
Log TRIAD_STOP for two-year payment history

### DIFF
--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -275,7 +275,12 @@ def split_accounts(
                 key = (line["page"], line["line"])
                 toks = tokens_by_line.get(key, [])
                 texts = [t.get("text", "") for t in toks]
-                log("TRIAD_SCAN page=%s line=%s texts=%r", line["page"], line["line"], texts)
+                log(
+                    "TRIAD_SCAN page=%s line=%s texts=%r",
+                    line["page"],
+                    line["line"],
+                    texts,
+                )
                 layout = layouts.get(line["page"])
                 band_tokens: Dict[str, List[dict]] = {
                     "label": [],
@@ -318,6 +323,11 @@ def split_accounts(
                 ):
                     label_core = label_txt.rstrip(":#").strip()
                     if _norm(label_core) == "twoyearpaymenthistory":
+                        log(
+                            "TRIAD_STOP reason=two_year_payment_history page=%s line=%s",
+                            line["page"],
+                            line["line"],
+                        )
                         open_row = None
                         break
                     key = LABEL_MAP.get(label_txt.rstrip(":")) or LABEL_MAP.get(


### PR DESCRIPTION
## Summary
- log TRIAD_STOP when encountering the two-year payment history label

## Testing
- `scripts/run_checks.sh` *(fails: Found 131 errors in 14 files (checked 60 source files))*


------
https://chatgpt.com/codex/tasks/task_b_68c33ac087c483258d3524fee776b73a