### PR TITLE
Improve triad band assignment with tolerance

### DIFF
--- a/tests/test_triad_layout.py
+++ b/tests/test_triad_layout.py
@@ -1,6 +1,10 @@
 import logging
 
-from backend.core.logic.report_analysis.triad_layout import detect_triads
+from backend.core.logic.report_analysis.triad_layout import (
+    TriadLayout,
+    assign_band,
+    detect_triads,
+)
 
 
 def test_detect_triads_with_punctuation(caplog):
@@ -26,3 +30,22 @@ def test_detect_triads_with_punctuation(caplog):
         == "TRIAD_LAYOUT page=1 label=(0.0,125.0) tu=(125.0,275.0) xp=(275.0,425.0) eq=(425.0,575.0)"
         for rec in caplog.records
     )
+
+
+def test_assign_band_midpoint_and_tolerance():
+    layout = TriadLayout(
+        page=1,
+        label_band=(0.0, 10.0),
+        tu_band=(10.0, 20.0),
+        xp_band=(20.0, 30.0),
+        eq_band=(30.0, 40.0),
+    )
+    # midpoint exactly on the boundary -> label
+    assert assign_band({"x0": 9.5, "x1": 10.5}, layout) == "label"
+    # midpoint slightly past boundary but within tolerance -> label
+    assert assign_band({"x0": 10.02, "x1": 10.16}, layout) == "label"
+    # midpoint beyond tolerance -> tu
+    assert assign_band({"x0": 10.2, "x1": 10.3}, layout) == "tu"
+    # midpoint beyond last band plus tolerance -> none
+    assert assign_band({"x0": 40.2, "x1": 40.3}, layout) == "none"
+


### PR DESCRIPTION
## Summary
- add constant right-edge tolerance for triad band assignment
- document left-to-right scanning and use midpoint X
- test midpoint and tolerance handling for band assignment

## Testing
- `pytest tests/test_triad_layout.py::test_detect_triads_with_punctuation -q`
- `pytest tests/test_triad_layout.py::test_assign_band_midpoint_and_tolerance -q`
- `pytest tests/test_triad_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c33c0177148325bd06b65b36d11c5f