### PR TITLE
Preserve Account # label in triad parsing

### DIFF
--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -383,13 +383,11 @@ def split_accounts(
                 if label_txt and (
                     label_txt.endswith(":") or label_txt.endswith("#") or is_account_num
                 ):
-                    label_core = label_txt.rstrip(":#").strip()
-                    key = LABEL_MAP.get(label_txt.rstrip(":")) or LABEL_MAP.get(
-                        label_core
-                    )
+                    label = label_txt.rstrip(":")
+                    key = LABEL_MAP.get(label)
                     row = {
                         "triad_row": True,
-                        "label": label_core,
+                        "label": label,
                         "key": key,
                         "values": {
                             "transunion": tu_val,


### PR DESCRIPTION
## Summary
- keep original label text (e.g. `Account #`) when building triad rows
- look up canonical key using the unnormalized label

## Testing
- `python -m py_compile scripts/split_accounts_from_tsv.py`
- `pytest` *(fails: Segmentation fault)*
- `pytest tests/test_json_utils.py`


------
https://chatgpt.com/codex/tasks/task_b_68c34e27ad888325b0a3ee2e0e36d7bc