### PR TITLE
Improve triad continuation and flexible header detection

### DIFF
--- a/tests/test_triad_layout.py
+++ b/tests/test_triad_layout.py
@@ -41,8 +41,9 @@ def test_assign_band_midpoint_and_tolerance():
     assert assign_band({"x0": 9.5, "x1": 10.5}, layout) == "label"
     # midpoint slightly past boundary but within tolerance -> label
     assert assign_band({"x0": 10.02, "x1": 10.16}, layout) == "label"
-    # midpoint beyond tolerance -> tu
-    assert assign_band({"x0": 10.2, "x1": 10.3}, layout) == "tu"
+    # still within extended tolerance -> label
+    assert assign_band({"x0": 10.2, "x1": 10.3}, layout) == "label"
+    # far enough past tolerance -> tu
+    assert assign_band({"x0": 16.1, "x1": 16.2}, layout) == "tu"
     # midpoint beyond last band plus tolerance -> none
-    assert assign_band({"x0": 40.2, "x1": 40.3}, layout) == "none"
-
+    assert assign_band({"x0": 46.5, "x1": 46.6}, layout) == "none"


### PR DESCRIPTION
## Summary
- broaden triad header detection to ignore punctuation and log matches
- handle triad continuations per-band, skipping only when no banded tokens
- widen column tolerance for token banding to reduce `none` classifications

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/triad_layout.py scripts/split_accounts_from_tsv.py tests/test_triad_layout.py tests/unit/test_triad_from_tsv.py`
- `pytest tests/test_triad_layout.py tests/unit/test_triad_from_tsv.py`


------
https://chatgpt.com/codex/tasks/task_b_68c43062e0848325a53fc1fde76dba22