### PR TITLE
feat: compute triad bands from header tokens

### DIFF
--- a/tests/test_triad_layout.py
+++ b/tests/test_triad_layout.py
@@ -3,6 +3,7 @@ import logging
 from backend.core.logic.report_analysis.triad_layout import (
     TriadLayout,
     assign_band,
+    bands_from_header_tokens,
     detect_triads,
 )
 
@@ -18,15 +19,29 @@ def test_detect_triads_with_trademark(caplog):
         layouts = detect_triads(tokens_by_line)
     assert 1 in layouts
     layout = layouts[1]
-    assert layout.label_band == (0.0, 125.0)
-    assert layout.tu_band == (125.0, 275.0)
-    assert layout.xp_band == (275.0, 425.0)
-    assert layout.eq_band == (425.0, 575.0)
+    assert layout.label_band == (0.0, 200.0)
+    assert layout.tu_band == (200.0, 350.0)
+    assert layout.xp_band == (350.0, 500.0)
+    assert layout.eq_band == (500.0, float("inf"))
     assert any(
         rec.message
-        == "TRIAD_LAYOUT page=1 label=(0.0,125.0) tu=(125.0,275.0) xp=(275.0,425.0) eq=(425.0,575.0)"
+        == "TRIAD_LAYOUT page=1 label=(0.0,200.0) tu=(200.0,350.0) xp=(350.0,500.0) eq=(500.0,inf)"
         for rec in caplog.records
     )
+
+
+def test_bands_from_header_tokens_any_order():
+    tokens = [
+        {"text": "Equifax", "x0": 460, "x1": 540, "page": 1},
+        {"text": "TransUnion", "x0": 160, "x1": 240, "page": 1},
+        {"text": "Experian", "x0": 300, "x1": 400, "page": 1},
+    ]
+    layout = bands_from_header_tokens(tokens)
+    assert layout.page == 1
+    assert layout.label_band == (0.0, 200.0)
+    assert layout.tu_band == (200.0, 350.0)
+    assert layout.xp_band == (350.0, 500.0)
+    assert layout.eq_band == (500.0, float("inf"))
 
 
 def test_assign_band_midpoint_and_tolerance():


### PR DESCRIPTION
## Summary
- derive triad column bands directly from TransUnion/Experian/Equifax header tokens
- reuse header-derived bands in TSV splitting script
- test triad detection and band computation order stability

## Testing
- `pytest tests/test_triad_layout.py -q`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c454a9d0048325aff0109302c84b13