### PR TITLE
feat: optionally keep per-account TSVs

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+load_dotenv()
+
 from backend.core.logic.report_analysis.block_exporter import export_stage_a
 from backend.core.logic.report_analysis.extract_problematic_accounts import (
     extract_problematic_accounts as orchestrate_problem_accounts,
@@ -25,8 +27,6 @@ from backend.settings import PROJECT_ROOT
 # directory.
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
-
-load_dotenv()
 
 from celery import Celery, shared_task, signals
 

--- a/backend/core/logic/report_analysis/README.md
+++ b/backend/core/logic/report_analysis/README.md
@@ -89,3 +89,10 @@ Get-ChildItem $acct -Force | Format-Table Name,Length -Auto
 Only `_debug_full.tsv`, `accounts_from_full.json`, and
 `general_info_from_full.json` remain in the `accounts_table` folder and the
 corresponding `texts/<SID>` directory is removed.
+
+### Preserving per-account TSVs
+
+By default the cleanup routine removes the per-account TSVs under
+`accounts_table/per_account_tsv`. Set `KEEP_PER_ACCOUNT_TSV=1` in the
+environment to whitelist this directory and retain the TSVs for debugging
+purposes.


### PR DESCRIPTION
## Summary
- allow preserving `accounts_table/per_account_tsv` when `KEEP_PER_ACCOUNT_TSV=1`
- load `.env` before importing cleanup routines so workers honor the flag
- document `KEEP_PER_ACCOUNT_TSV` in trace-analysis README

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/trace_cleanup.py backend/api/tasks.py backend/core/logic/report_analysis/README.md`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68c47ccb0e14832595ec36f222d281e0