### PR TITLE
fix: make triad layout bands non-overlapping

### DIFF
--- a/tests/test_triad_layout.py
+++ b/tests/test_triad_layout.py
@@ -19,12 +19,12 @@ def test_detect_triads_with_trademark(caplog):
     assert 1 in layouts
     layout = layouts[1]
     assert layout.label_band == (0.0, 194.0)
-    assert layout.tu_band == (194.0, 356.0)
-    assert layout.xp_band == (344.0, 506.0)
-    assert layout.eq_band == (494.0, float("inf"))
+    assert layout.tu_band == (194.0, 275.0)
+    assert layout.xp_band == (275.0, 425.0)
+    assert layout.eq_band == (425.0, float("inf"))
     assert any(
         rec.message
-        == "TRIAD_LAYOUT page=1 label=(0.0,194.0) tu=(194.0,356.0) xp=(344.0,506.0) eq=(494.0,inf)"
+        == "TRIAD_LAYOUT page=1 label=(0.0,194.0) tu=(194.0,275.0) xp=(275.0,425.0) eq=(425.0,inf)"
         for rec in caplog.records
     )
 
@@ -38,9 +38,9 @@ def test_bands_from_header_tokens_any_order():
     layout = bands_from_header_tokens(tokens)
     assert layout.page == 1
     assert layout.label_band == (0.0, 194.0)
-    assert layout.tu_band == (194.0, 356.0)
-    assert layout.xp_band == (344.0, 506.0)
-    assert layout.eq_band == (494.0, float("inf"))
+    assert layout.tu_band == (194.0, 275.0)
+    assert layout.xp_band == (275.0, 425.0)
+    assert layout.eq_band == (425.0, float("inf"))
 
 
 def test_assign_band_midpoint_and_tolerance():
@@ -57,3 +57,15 @@ def test_assign_band_midpoint_and_tolerance():
     assert assign_band({"x0": 1.0, "x1": 1.2}, layout) == "label"
     # Far outside all bands on the left → ``none``
     assert assign_band({"x0": -5.0, "x1": -4.5}, layout) == "none"
+
+
+def test_assign_band_prefers_xp_on_seam():
+    layout = bands_from_header_tokens(
+        [
+            {"text": "TransUnion", "x0": 160, "x1": 240, "page": 1},
+            {"text": "Experian", "x0": 300, "x1": 400, "page": 1},
+            {"text": "Equifax", "x0": 460, "x1": 540, "page": 1},
+        ]
+    )
+    # Token on the TU/XP boundary should be assigned to XP
+    assert assign_band({"x0": 274.0, "x1": 276.0}, layout) == "xp"


### PR DESCRIPTION
## Summary
- compute non-overlapping TU/XP/EQ bands split at midpoints to prevent overlap
- assign tokens to triad bands using simple range checks
- test that XP tokens on the TU/XP seam are classified as XP

## Testing
- `pytest tests/test_triad_layout.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6d4e84088832592dc6852ee3ded13