### PR TITLE
Fix 7-year history parsing and add history tracing

### DIFF
--- a/tests/unit/test_split_accounts_from_tsv.py
+++ b/tests/unit/test_split_accounts_from_tsv.py
@@ -401,3 +401,50 @@ def test_triad_moved_to_next_account(tmp_path: Path) -> None:
     texts1 = [ln["text"] for ln in acc1["lines"]]
     assert "TransUnion Experian Equifax" not in texts1
     assert acc2["lines"][0]["text"] == "TransUnion Experian Equifax"
+
+
+def create_h7y_tsv(path: Path) -> None:
+    content = (
+        "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+        "1\t1\t0\t0\t0\t0\tBANK\n"
+        "1\t2\t0\t0\t0\t0\tAccount # 123\n"
+        "1\t3\t0\t0\t0\t0\tDays Late - 7 Year History\n"
+        "1\t4\t0\t0\t10\t20\tTransunion\n"
+        "1\t4\t0\t0\t40\t50\tExperian\n"
+        "1\t4\t0\t0\t70\t80\tEquifax\n"
+        "1\t5\t0\t0\t10\t20\t30:\n"
+        "1\t5\t0\t0\t20\t25\t--\n"
+        "1\t5\t0\t0\t40\t50\t30:\n"
+        "1\t5\t0\t0\t50\t55\t1\n"
+        "1\t5\t0\t0\t70\t80\t30:\n"
+        "1\t5\t0\t0\t80\t85\t--\n"
+        "1\t6\t0\t0\t10\t20\t60:\n"
+        "1\t6\t0\t0\t20\t25\t1\n"
+        "1\t6\t0\t0\t40\t50\t60:\n"
+        "1\t6\t0\t0\t50\t55\t1\n"
+        "1\t6\t0\t0\t70\t80\t60:\n"
+        "1\t6\t0\t0\t80\t85\t--\n"
+        "1\t7\t0\t0\t10\t20\t90:\n"
+        "1\t7\t0\t0\t20\t25\t--\n"
+        "1\t7\t0\t0\t40\t50\t90:\n"
+        "1\t7\t0\t0\t50\t55\t3\n"
+        "1\t7\t0\t0\t70\t80\t90:\n"
+        "1\t7\t0\t0\t80\t85\t--\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_seven_year_history_parsing(tmp_path: Path) -> None:
+    tsv_path = tmp_path / "_debug_full.tsv"
+    json_path = tmp_path / "accounts_from_full.json"
+    create_h7y_tsv(tsv_path)
+
+    split_accounts_from_tsv.main(["--full", str(tsv_path), "--json_out", str(json_path)])
+
+    data = json.loads(json_path.read_text())
+    accounts = data["accounts"]
+    assert len(accounts) == 1
+    sev = accounts[0]["seven_year_history"]
+    assert sev["transunion"] == {"late30": 0, "late60": 1, "late90": 0}
+    assert sev["experian"] == {"late30": 1, "late60": 1, "late90": 3}
+    assert sev["equifax"] == {"late30": 0, "late60": 0, "late90": 0}


### PR DESCRIPTION
## Summary
- improve 7-year history parsing: robust header detection, X-slab mapping, and inline value capture
- add generic history trace helper for 2Y/7Y observers
- test seven-year history extraction from tokens

## Testing
- `pytest tests/unit/test_split_accounts_from_tsv.py`


------
https://chatgpt.com/codex/tasks/task_b_68c75a0e5170832595d2b6d2469ba2c5