### PR TITLE
Add global run registry CLI and Stage-A manifest wiring

### DIFF
--- a/scripts/run_manifest.py
+++ b/scripts/run_manifest.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""CLI helpers for interacting with run manifests.
+
+Allows ops to set or get artifact paths in the global run registry.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from backend.pipeline.runs import RunManifest
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description="Run manifest helper")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("get", help="Get an artifact path")
+    g.add_argument("sid")
+    g.add_argument("group")
+    g.add_argument("key")
+
+    sa = sub.add_parser("set-artifact", help="Set an artifact path")
+    sa.add_argument("sid")
+    sa.add_argument("group")
+    sa.add_argument("key")
+    sa.add_argument("value")
+
+    sb = sub.add_parser("set-base-dir", help="Set a base directory")
+    sb.add_argument("sid")
+    sb.add_argument("label")
+    sb.add_argument("path")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "get":
+        m = RunManifest.for_sid(args.sid)
+        print(m.get(args.group, args.key))
+    elif args.cmd == "set-artifact":
+        m = RunManifest.for_sid(args.sid)
+        m.set_artifact(args.group, args.key, Path(args.value))
+    elif args.cmd == "set-base-dir":
+        m = RunManifest.for_sid(args.sid)
+        m.set_base_dir(args.label, Path(args.path))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_run_manifest_cli.py
+++ b/tests/test_run_manifest_cli.py
@@ -1,0 +1,23 @@
+from backend.pipeline.runs import RUNS_ROOT_ENV, RunManifest
+from scripts.run_manifest import main
+
+
+def test_run_manifest_cli_basic(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+    sid = "cli-test"
+
+    sample_dir = tmp_path / "data"
+    sample_dir.mkdir()
+    sample_file = sample_dir / "foo.txt"
+    sample_file.write_text("hi", encoding="utf-8")
+
+    main(["set-base-dir", sid, "data_dir", str(sample_dir)])
+    main(["set-artifact", sid, "data", "foo", str(sample_file)])
+    main(["get", sid, "data", "foo"])
+    out = capsys.readouterr().out.strip()
+    assert out == str(sample_file.resolve())
+
+    m = RunManifest.for_sid(sid)
+    assert m.data["base_dirs"]["data_dir"] == str(sample_dir.resolve())
+    assert m.get("data", "foo") == str(sample_file.resolve())

--- a/tests/test_split_accounts_manifest.py
+++ b/tests/test_split_accounts_manifest.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from backend.pipeline.runs import RUNS_ROOT_ENV
+from scripts.split_accounts_from_tsv import main as split_accounts_main
+
+
+def _write_tsv(path: Path) -> None:
+    header = "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+    rows = [
+        "1\t1\t10\t11\t60\t100\tTransUnion\n",
+        "1\t1\t10\t11\t160\t200\tExperian\n",
+        "1\t1\t10\t11\t260\t300\tEquifax\n",
+        "1\t2\t20\t21\t0\t20\tAccount #\n",
+        "1\t2\t20\t21\t60\t100\t208743***\n",
+        "1\t2\t20\t21\t160\t200\t208743***\n",
+        "1\t2\t20\t21\t260\t300\t208743***\n",
+    ]
+    path.write_text(header + "".join(rows), encoding="utf-8")
+
+
+def test_split_accounts_registers_manifest(tmp_path, monkeypatch):
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+
+    accounts_dir = tmp_path / "traces" / "blocks" / "sid123" / "accounts_table"
+    accounts_dir.mkdir(parents=True)
+    tsv_path = accounts_dir / "_debug_full.tsv"
+    _write_tsv(tsv_path)
+
+    general_json = accounts_dir / "general_info_from_full.json"
+    general_json.write_text("{}", encoding="utf-8")
+    accounts_json = accounts_dir / "accounts_from_full.json"
+
+    split_accounts_main(["--full", str(tsv_path), "--json_out", str(accounts_json)])
+
+    manifest_path = runs_root / "sid123" / "manifest.json"
+    data = json.loads(manifest_path.read_text())
+    assert data["base_dirs"]["traces_accounts_table"] == str(accounts_dir.resolve())
+    art = data["artifacts"]["traces"]["accounts_table"]
+    assert art["accounts_json"] == str(accounts_json.resolve())
+    assert art["general_json"] == str(general_json.resolve())
+    assert (accounts_dir / ".manifest").read_text() == str(manifest_path.resolve())


### PR DESCRIPTION
## Summary
- integrate Stage-A account splitting script with global run manifest and breadcrumb pointer
- add `run_manifest` CLI for querying and updating run artifacts
- test CLI and manifest registration

## Testing
- `pre-commit run --files scripts/split_accounts_from_tsv.py scripts/run_manifest.py tests/test_run_manifest_cli.py tests/test_split_accounts_manifest.py`
- `pytest tests/test_run_manifest.py tests/test_run_manifest_cli.py tests/test_split_accounts_manifest.py`

------
https://chatgpt.com/codex/tasks/task_b_68c76a171bf083258c87630a3a758980