### PR TITLE
Register case outputs in run manifest

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping
 
+from backend.pipeline.runs import RunManifest, write_breadcrumb
 from backend.settings import PROJECT_ROOT
 
 from .keys import compute_logical_account_key
@@ -150,6 +151,12 @@ def build_problem_cases(
     accounts_dir = out_dir / "accounts"
     out_dir.mkdir(parents=True, exist_ok=True)
     accounts_dir.mkdir(parents=True, exist_ok=True)
+
+    # register directory in global run manifest and leave breadcrumb
+    m = RunManifest.for_sid(sid)
+    m.set_base_dir("cases_dir", out_dir)
+    m.set_artifact("cases", "case_dir", out_dir)
+    write_breadcrumb(m.path, out_dir / ".manifest")
 
     logger.info("PROBLEM_CASES start sid=%s total=%s out=%s", sid, total, out_dir)
 


### PR DESCRIPTION
## Summary
- record case directories in the global run manifest and drop a breadcrumb pointer
- test case builder integration with the run manifest and breadcrumb generation

## Testing
- `pre-commit run --files backend/core/logic/report_analysis/problem_case_builder.py tests/test_problem_case_builder.py`
- `pytest tests/test_problem_case_builder.py tests/test_run_manifest.py tests/test_run_manifest_cli.py`

------
https://chatgpt.com/codex/tasks/task_b_68c76c304fd88325aba4f1d9d9287e13