### PR TITLE
Add script bootstrap for CLI scripts

### DIFF
--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -1,0 +1,18 @@
+import os, sys
+from pathlib import Path
+
+_here = Path(__file__).resolve()
+_repo_root = _here.parent.parent  # <repo>/scripts/_bootstrap.py -> <repo>
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+# .env (optional)
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:
+    load_dotenv = None
+
+if load_dotenv:
+    env_path = _repo_root / ".env"
+    if env_path.exists():
+        load_dotenv(dotenv_path=str(env_path))

--- a/scripts/run_manifest.py
+++ b/scripts/run_manifest.py
@@ -1,3 +1,4 @@
+import scripts._bootstrap  # KEEP FIRST
 #!/usr/bin/env python3
 """CLI helpers for interacting with run manifests.
 

--- a/scripts/runs_cli.py
+++ b/scripts/runs_cli.py
@@ -1,3 +1,4 @@
+import scripts._bootstrap  # KEEP FIRST
 #!/usr/bin/env python3
 """Debug CLI for interacting with run manifests.
 

--- a/scripts/smoke_problem_cases.py
+++ b/scripts/smoke_problem_cases.py
@@ -1,3 +1,4 @@
+import scripts._bootstrap  # KEEP FIRST
 from __future__ import annotations
 
 import argparse

--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -1,3 +1,4 @@
+import scripts._bootstrap  # KEEP FIRST
 #!/usr/bin/env python3
 """Split accounts from a full token TSV dump.
 


### PR DESCRIPTION
## Summary
- add a shared bootstrap module that prepends the repo root to `sys.path` and loads an optional `.env`
- import the bootstrap module at the top of CLI helper scripts so they run correctly via `python scripts/...`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c8372087f883259b457e6027a1b15a