### PR TITLE
Register Stage-A trace outputs in run manifest

### DIFF
--- a/backend/pipeline/runs.py
+++ b/backend/pipeline/runs.py
@@ -38,6 +38,21 @@ class RunManifest:
         newest = max(map(Path, cands), key=lambda x: x.stat().st_mtime)
         return RunManifest(newest).load()
 
+    @staticmethod
+    def load_or_create(path: Path, sid: str | None = None) -> "RunManifest":
+        """Load an existing manifest at ``path`` or create a new one."""
+
+        manifest = RunManifest(path)
+        if path.exists():
+            return manifest.load()
+
+        effective_sid = sid or path.parent.name
+        if not effective_sid:
+            raise ValueError("sid is required to create a new manifest")
+
+        manifest.path.parent.mkdir(parents=True, exist_ok=True)
+        return manifest._load_or_create(effective_sid)
+
     def _load_or_create(self, sid: str) -> "RunManifest":
         if self.path.exists():
             return self.load()

--- a/tests/test_split_accounts_manifest.py
+++ b/tests/test_split_accounts_manifest.py
@@ -28,16 +28,33 @@ def test_split_accounts_registers_manifest(tmp_path, monkeypatch):
     tsv_path = accounts_dir / "_debug_full.tsv"
     _write_tsv(tsv_path)
 
-    general_json = accounts_dir / "general_info_from_full.json"
-    general_json.write_text("{}", encoding="utf-8")
     accounts_json = accounts_dir / "accounts_from_full.json"
 
-    split_accounts_main(["--full", str(tsv_path), "--json_out", str(accounts_json)])
-
     manifest_path = runs_root / "sid123" / "manifest.json"
+    general_json = accounts_dir / "general_info_from_full.json"
+
+    split_accounts_main(
+        [
+            "--full",
+            str(tsv_path),
+            "--json_out",
+            str(accounts_json),
+            "--sid",
+            "sid123",
+            "--manifest",
+            str(manifest_path),
+            "--general_out",
+            str(general_json),
+        ]
+    )
+
     data = json.loads(manifest_path.read_text())
     assert data["base_dirs"]["traces_accounts_table"] == str(accounts_dir.resolve())
     art = data["artifacts"]["traces"]["accounts_table"]
     assert art["accounts_json"] == str(accounts_json.resolve())
     assert art["general_json"] == str(general_json.resolve())
+    assert art["debug_full_tsv"] == str(tsv_path.resolve())
+    expected_per_acc = accounts_dir / "per_account_tsv"
+    assert art["per_account_tsv_dir"] == str(expected_per_acc.resolve())
     assert (accounts_dir / ".manifest").read_text() == str(manifest_path.resolve())
+    assert general_json.exists()


### PR DESCRIPTION
## Summary
- extend `split_accounts_from_tsv.py` with CLI options for sid/manifest/general info, generate the general info file when missing, and register all Stage-A artifacts in the run manifest
- add `RunManifest.load_or_create` to support explicit manifest paths when wiring Stage-A outputs
- expand the manifest registration test to cover the new CLI flow and artifacts

## Testing
- `pytest tests/test_split_accounts_manifest.py`
- `pytest tests/unit/test_split_accounts_from_tsv.py`


------
https://chatgpt.com/codex/tasks/task_b_68c8392df5f4832589ef8120d063186c