### PR TITLE
Add bootstrap helper for CLI scripts

### DIFF
--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -2,16 +2,15 @@ import os, sys
 from pathlib import Path
 
 _here = Path(__file__).resolve()
-_repo_root = _here.parent.parent  # <repo>/scripts/_bootstrap.py -> <repo>
+_repo_root = _here.parent.parent  # <repo>
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-# .env (optional)
+# Optional: load .env
 try:
     from dotenv import load_dotenv  # type: ignore
 except Exception:
     load_dotenv = None
-
 if load_dotenv:
     env_path = _repo_root / ".env"
     if env_path.exists():

--- a/scripts/run_manifest.py
+++ b/scripts/run_manifest.py
@@ -1,10 +1,19 @@
-import scripts._bootstrap  # KEEP FIRST
+try:  # pragma: no cover - import shim
+    import scripts._bootstrap  # KEEP FIRST
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _repo_root = _Path(__file__).resolve().parent.parent
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+    import scripts._bootstrap  # type: ignore  # KEEP FIRST
+
 #!/usr/bin/env python3
 """CLI helpers for interacting with run manifests.
 
 Allows ops to set or get artifact paths in the global run registry.
 """
-from __future__ import annotations
 
 import argparse
 from pathlib import Path

--- a/scripts/runs_cli.py
+++ b/scripts/runs_cli.py
@@ -1,4 +1,14 @@
-import scripts._bootstrap  # KEEP FIRST
+try:  # pragma: no cover - import shim
+    import scripts._bootstrap  # KEEP FIRST
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _repo_root = _Path(__file__).resolve().parent.parent
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+    import scripts._bootstrap  # type: ignore  # KEEP FIRST
+
 #!/usr/bin/env python3
 """Debug CLI for interacting with run manifests.
 
@@ -6,7 +16,6 @@ This utility mirrors ``scripts/run_manifest.py`` but under a more explicit name
 and with an extra ``print`` command that dumps the manifest JSON.  It operates
 on the global run registry located under ``runs/<SID>/manifest.json``.
 """
-from __future__ import annotations
 
 import argparse
 import json

--- a/scripts/smoke_problem_cases.py
+++ b/scripts/smoke_problem_cases.py
@@ -1,5 +1,13 @@
-import scripts._bootstrap  # KEEP FIRST
-from __future__ import annotations
+try:  # pragma: no cover - import shim
+    import scripts._bootstrap  # KEEP FIRST
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _repo_root = _Path(__file__).resolve().parent.parent
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+    import scripts._bootstrap  # type: ignore  # KEEP FIRST
 
 import argparse
 import json

--- a/scripts/split_accounts_from_tsv.py
+++ b/scripts/split_accounts_from_tsv.py
@@ -1,3 +1,14 @@
+try:  # pragma: no cover - import shim
+    import scripts._bootstrap  # KEEP FIRST
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _repo_root = _Path(__file__).resolve().parent.parent
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+    import scripts._bootstrap  # type: ignore  # KEEP FIRST
+
 #!/usr/bin/env python3
 """Split accounts from a full token TSV dump.
 
@@ -6,9 +17,6 @@ account boundaries based on lines that contain the exact string ``Account #``.
 Each account is emitted to a structured JSON file and, optionally, into
 individual TSV files for debugging.
 """
-from __future__ import annotations
-
-import scripts._bootstrap  # KEEP FIRST
 
 import argparse
 import csv


### PR DESCRIPTION
## Summary
- add `scripts/_bootstrap.py` helper to expose the repo root and optional `.env`
- ensure CLI utilities import the bootstrap shim before other imports with a fallback for direct execution

## Testing
- python scripts/runs_cli.py --help
- python scripts/run_manifest.py --help

------
https://chatgpt.com/codex/tasks/task_b_68c84426d0cc832580b13e93288ae977