### PR TITLE
Extend run manifest schema for centralized artifacts

### DIFF
--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -40,6 +40,19 @@ def test_run_manifest_basic(tmp_path, monkeypatch):
     assert m.data["base_dirs"]["traces_accounts_table"] == str(base_dir.resolve())
 
 
+def test_run_manifest_ensure_run_subdir(tmp_path, monkeypatch):
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+    m = RunManifest.for_sid("sid123")
+
+    traces_dir = m.ensure_run_subdir("traces_dir", "traces")
+
+    expected = (runs_root / "sid123" / "traces").resolve()
+    assert traces_dir == expected
+    assert traces_dir.exists()
+    assert m.data["base_dirs"]["traces_dir"] == str(expected)
+
+
 def test_run_manifest_from_env_or_latest(tmp_path, monkeypatch):
     runs_root = tmp_path / "runs"
     monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))


### PR DESCRIPTION
## Summary
- initialize run manifests with canonical base directories and artifact groups for centralized runs
- ensure run subdirectories can be created and registered through a new helper that records absolute paths
- store absolute paths consistently for base directories and artifacts

## Testing
- pytest tests/test_run_manifest.py tests/test_split_accounts_manifest.py tests/test_problem_case_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68c84c1b49888325bf7f6bde90f55628