### PR TITLE
Refactor split stage outputs into RunManifest run root

### DIFF
--- a/tests/test_split_accounts_manifest.py
+++ b/tests/test_split_accounts_manifest.py
@@ -23,38 +23,39 @@ def test_split_accounts_registers_manifest(tmp_path, monkeypatch):
     runs_root = tmp_path / "runs"
     monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
 
-    accounts_dir = tmp_path / "traces" / "blocks" / "sid123" / "accounts_table"
-    accounts_dir.mkdir(parents=True)
-    tsv_path = accounts_dir / "_debug_full.tsv"
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    tsv_path = source_dir / "_debug_full.tsv"
     _write_tsv(tsv_path)
 
-    accounts_json = accounts_dir / "accounts_from_full.json"
-
     manifest_path = runs_root / "sid123" / "manifest.json"
-    general_json = accounts_dir / "general_info_from_full.json"
 
     split_accounts_main(
         [
             "--full",
             str(tsv_path),
-            "--json_out",
-            str(accounts_json),
             "--sid",
             "sid123",
             "--manifest",
             str(manifest_path),
-            "--general_out",
-            str(general_json),
         ]
     )
 
     data = json.loads(manifest_path.read_text())
-    assert data["base_dirs"]["traces_accounts_table"] == str(accounts_dir.resolve())
+    accounts_dir = runs_root / "sid123" / "traces" / "accounts_table"
+    assert data["base_dirs"]["traces_accounts_table"] == str(
+        accounts_dir.resolve()
+    )
     art = data["artifacts"]["traces"]["accounts_table"]
+    accounts_json = accounts_dir / "accounts_from_full.json"
+    general_json = accounts_dir / "general_info_from_full.json"
+    debug_full = accounts_dir / "_debug_full.tsv"
+    per_account_dir = accounts_dir / "per_account_tsv"
     assert art["accounts_json"] == str(accounts_json.resolve())
     assert art["general_json"] == str(general_json.resolve())
-    assert art["debug_full_tsv"] == str(tsv_path.resolve())
+    assert art["debug_full_tsv"] == str(debug_full.resolve())
     expected_per_acc = accounts_dir / "per_account_tsv"
     assert art["per_account_tsv_dir"] == str(expected_per_acc.resolve())
     assert (accounts_dir / ".manifest").read_text() == str(manifest_path.resolve())
     assert general_json.exists()
+    assert per_account_dir.exists()

--- a/tests/unit/test_triad_from_tsv.py
+++ b/tests/unit/test_triad_from_tsv.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from backend.pipeline.runs import RUNS_ROOT_ENV
+
 
 def create_triad_tsv(path: Path) -> None:
     header = "page\tline\ty0\ty1\tx0\tx1\ttext\n"
@@ -290,6 +292,9 @@ def test_triad_from_tsv(tmp_path: Path) -> None:
     env["RAW_TRIAD_FROM_X"] = "1"
     env["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    runs_root = tmp_path / "runs"
+    env[RUNS_ROOT_ENV] = str(runs_root)
+    sid = "sid-subprocess"
     subprocess.run(
         [
             "python",
@@ -298,6 +303,8 @@ def test_triad_from_tsv(tmp_path: Path) -> None:
             str(tsv_path),
             "--json_out",
             str(json_path),
+            "--sid",
+            sid,
         ],
         check=True,
         env=env,
@@ -324,6 +331,8 @@ def test_triad_from_tsv_with_punctuation(tmp_path: Path) -> None:
     env["RAW_TRIAD_FROM_X"] = "1"
     env["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env[RUNS_ROOT_ENV] = str(tmp_path / "runs")
+    sid = "sid-subprocess"
     subprocess.run(
         [
             "python",
@@ -332,6 +341,8 @@ def test_triad_from_tsv_with_punctuation(tmp_path: Path) -> None:
             str(tsv_path),
             "--json_out",
             str(json_path),
+            "--sid",
+            sid,
         ],
         check=True,
         env=env,
@@ -356,6 +367,8 @@ def test_cross_page_carry_and_sentinel(tmp_path: Path) -> None:
     env["RAW_TRIAD_FROM_X"] = "1"
     env["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env[RUNS_ROOT_ENV] = str(tmp_path / "runs")
+    sid = "sid-subprocess"
     subprocess.run(
         [
             "python",
@@ -364,6 +377,8 @@ def test_cross_page_carry_and_sentinel(tmp_path: Path) -> None:
             str(tsv_path),
             "--json_out",
             str(json_path),
+            "--sid",
+            sid,
         ],
         check=True,
         env=env,
@@ -390,6 +405,8 @@ def test_header_on_prev_page(tmp_path: Path) -> None:
     env["RAW_TRIAD_FROM_X"] = "1"
     env["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env[RUNS_ROOT_ENV] = str(tmp_path / "runs")
+    env["TRIAD_BAND_BY_X0"] = "0"
     subprocess.run(
         [
             "python",
@@ -398,6 +415,8 @@ def test_header_on_prev_page(tmp_path: Path) -> None:
             str(tsv_path),
             "--json_out",
             str(json_path),
+            "--sid",
+            "sid-subprocess",
         ],
         check=True,
         env=env,
@@ -420,6 +439,7 @@ def test_standalone_bureau_header_stops(tmp_path: Path) -> None:
     env["RAW_TRIAD_FROM_X"] = "1"
     env["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     subprocess.run(
         [
             "python",
@@ -428,6 +448,8 @@ def test_standalone_bureau_header_stops(tmp_path: Path) -> None:
             str(tsv_path),
             "--json_out",
             str(json_path),
+            "--sid",
+            "sid-subprocess",
         ],
         check=True,
         env=env,
@@ -449,12 +471,15 @@ def test_triad_guard_skip(tmp_path: Path, caplog) -> None:
     os.environ["RAW_TRIAD_FROM_X"] = "1"
     os.environ["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     os.environ["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    os.environ[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     sys.argv = [
         "split_accounts_from_tsv.py",
         "--full",
         str(tsv_path),
         "--json_out",
         str(json_path),
+        "--sid",
+        "sid-runpy",
     ]
     logging.basicConfig(level=logging.INFO)
     sys.modules.pop("backend.config", None)
@@ -476,12 +501,15 @@ def test_triad_guard_skip_flag_off(tmp_path: Path, caplog) -> None:
     os.environ["RAW_TRIAD_FROM_X"] = "0"
     os.environ["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     os.environ["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    os.environ[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     sys.argv = [
         "split_accounts_from_tsv.py",
         "--full",
         str(tsv_path),
         "--json_out",
         str(json_path),
+        "--sid",
+        "sid-runpy",
     ]
     logging.basicConfig(level=logging.INFO)
     sys.modules.pop("backend.config", None)
@@ -501,12 +529,15 @@ def test_triad_partial_continuation(tmp_path: Path, caplog) -> None:
     os.environ["RAW_TRIAD_FROM_X"] = "1"
     os.environ["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     os.environ["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    os.environ[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     sys.argv = [
         "split_accounts_from_tsv.py",
         "--full",
         str(tsv_path),
         "--json_out",
         str(json_path),
+        "--sid",
+        "sid-runpy",
     ]
     logging.basicConfig(level=logging.INFO)
     sys.modules.pop("backend.config", None)
@@ -529,12 +560,15 @@ def test_triad_cross_page_carry(tmp_path: Path, caplog) -> None:
     os.environ["RAW_TRIAD_FROM_X"] = "1"
     os.environ["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     os.environ["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    os.environ[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     sys.argv = [
         "split_accounts_from_tsv.py",
         "--full",
         str(tsv_path),
         "--json_out",
         str(json_path),
+        "--sid",
+        "sid-runpy",
     ]
     logging.basicConfig(level=logging.INFO)
     sys.modules.pop("backend.config", None)
@@ -559,12 +593,15 @@ def test_triad_stop_on_unlabeled_sentinels(tmp_path: Path, caplog) -> None:
     os.environ["RAW_TRIAD_FROM_X"] = "1"
     os.environ["RAW_JOIN_TOKENS_WITH_SPACE"] = "1"
     os.environ["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    os.environ[RUNS_ROOT_ENV] = str(tmp_path / "runs")
     sys.argv = [
         "split_accounts_from_tsv.py",
         "--full",
         str(tsv_path),
         "--json_out",
         str(json_path),
+        "--sid",
+        "sid-runpy",
     ]
     logging.basicConfig(level=logging.INFO)
     sys.modules.pop("backend.config", None)


### PR DESCRIPTION
## Summary
- update `scripts/split_accounts_from_tsv.py` to emit artifacts under each run's RunManifest directory, copying the source TSV into `runs/<sid>/traces/accounts_table` and registering all outputs
- refresh the Stage A tests to work with the new run-root layout via fixtures/helpers, ensuring `TRIAD` trace env setup is isolated per invocation, and adjust manifest expectations
- update triad subprocess tests to set explicit run roots and SIDs so the CLI writes into the new structure

## Testing
- pytest tests/test_split_accounts_manifest.py tests/unit/test_split_accounts_from_tsv.py tests/test_split_accounts_from_tsv.py tests/unit/test_triad_from_tsv.py
- pytest *(fails: pymupdf segfault)*

------
https://chatgpt.com/codex/tasks/task_b_68c84f6738808325aeb6780f228d2aa8