### PR TITLE
Add merge clustering stage to problematic account extraction

### DIFF
--- a/backend/core/logic/report_analysis/extract_problematic_accounts.py
+++ b/backend/core/logic/report_analysis/extract_problematic_accounts.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
+from .account_merge import DEFAULT_CFG, cluster_problematic_accounts
 from .problem_case_builder import build_problem_cases
 from .problem_extractor import detect_problem_accounts
 
@@ -41,8 +42,13 @@ def extract_problematic_accounts(
     """
 
     candidates: List[Dict[str, Any]] = detect_problem_accounts(session_id, root=root)
-    summary = build_problem_cases(session_id, candidates, root=root)
-    return {"found": candidates, "summary": summary}
+    merged_candidates = cluster_problematic_accounts(
+        candidates,
+        DEFAULT_CFG,
+        sid=session_id,
+    )
+    summary = build_problem_cases(session_id, merged_candidates, root=root)
+    return {"found": merged_candidates, "summary": summary}
 
 
 __all__ = ["extract_problematic_accounts"]


### PR DESCRIPTION
## Summary
- integrate the merge clustering helper between detection and case building so problematic accounts carry merge tags forward
- add sid-aware logging and in-place merge tagging inside the merge clustering helper

## Testing
- pytest tests/report_analysis/test_account_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68c9936154188325868d5825929ade53