### PR TITLE
Add environment overrides for account merge configuration

### DIFF
--- a/tests/report_analysis/test_account_merge.py
+++ b/tests/report_analysis/test_account_merge.py
@@ -6,6 +6,7 @@ from backend.core.logic.report_analysis.account_merge import (
     DEFAULT_CFG,
     cluster_problematic_accounts,
     decide_merge,
+    load_config_from_env,
     score_accounts,
 )
 
@@ -69,6 +70,16 @@ def test_score_accounts_returns_weighted_score_and_parts():
 )
 def test_decide_merge_respects_thresholds(value, expected):
     assert decide_merge(value, DEFAULT_CFG) == expected
+
+
+def test_load_config_from_env_respects_overrides(monkeypatch):
+    monkeypatch.setenv("MERGE_AUTO_MIN", "0.91")
+    monkeypatch.setenv("MERGE_W_ACCT", "0.45")
+
+    cfg = load_config_from_env()
+
+    assert cfg.thresholds["auto_merge_min"] == 0.91
+    assert cfg.weights["acct_num"] == 0.45
 
 
 def test_cluster_problematic_accounts_builds_clusters():


### PR DESCRIPTION
## Summary
- load merge thresholds and weights from environment variables with default fallbacks
- expose a helper to build merge configs from the current environment and log invalid overrides
- extend account merge tests to cover environment-driven configuration overrides

## Testing
- pytest tests/report_analysis/test_account_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68c999139af08325ba14711c6471a19d