### PR TITLE
Add merge visibility to smoke candidates CLI

### DIFF
--- a/scripts/smoke_problem_candidates.py
+++ b/scripts/smoke_problem_candidates.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any, Dict, List
 
 # Optional bootstrap to ensure repo root is on sys.path
 try:  # pragma: no cover - convenience import
@@ -13,13 +14,77 @@ except Exception:
         sys.path.insert(0, str(repo_root))
 
 from collections import Counter
+from backend.core.logic.report_analysis.account_merge import (
+    DEFAULT_CFG,
+    cluster_problematic_accounts,
+)
 from backend.core.logic.report_analysis.problem_extractor import detect_problem_accounts
+
+
+def _build_merge_summary(candidates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return clusters and pair table summaries from merge-tagged candidates."""
+
+    cluster_map: Dict[str, Dict[str, Any]] = {}
+    pairs: List[Dict[str, Any]] = []
+
+    for idx, account in enumerate(candidates):
+        merge_tag = account.get("merge_tag") or {}
+        group_id = str(merge_tag.get("group_id") or f"g{idx + 1}")
+        best_match = merge_tag.get("best_match") or {}
+        parts = merge_tag.get("parts") or {}
+
+        entry: Dict[str, Any] = {
+            "idx": idx,
+            "group": group_id,
+            "best": best_match.get("account_index"),
+            "score": best_match.get("score"),
+            "decision": merge_tag.get("decision"),
+        }
+
+        pair_decision = best_match.get("decision")
+        if pair_decision is not None and pair_decision != entry.get("decision"):
+            entry["pair_decision"] = pair_decision
+
+        if parts:
+            entry["parts"] = {key: float(value) for key, value in parts.items()}
+
+        pairs.append(entry)
+
+        cluster_entry = cluster_map.setdefault(
+            group_id,
+            {"group": group_id, "members": [], "best_matches": []},
+        )
+        cluster_entry["members"].append(idx)
+        cluster_entry["best_matches"].append(entry)
+
+    pairs.sort(key=lambda item: item["idx"])
+
+    clusters: List[Dict[str, Any]] = []
+    for group_id in sorted(cluster_map.keys()):
+        cluster_entry = cluster_map[group_id]
+        cluster_entry["members"].sort()
+        cluster_entry["best_matches"] = sorted(
+            cluster_entry["best_matches"], key=lambda item: item["idx"]
+        )
+        clusters.append(cluster_entry)
+
+    return {"clusters": clusters, "pairs": pairs}
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Smoke run problem candidate detection for a run SID")
     ap.add_argument("--sid", required=True, help="Run session id (SID) to analyze")
-    ap.add_argument("--show-all", action="store_true", help="Show all candidates instead of first 5")
+    ap.add_argument(
+        "--show-all",
+        action="store_true",
+        help="Show all candidates instead of first 5",
+    )
+    ap.add_argument(
+        "--show-merge",
+        action="store_true",
+        help="Display merge clustering summary",
+    )
+    ap.add_argument("--json-out", help="Path to write full JSON payload including merge data")
     args = ap.parse_args()
 
     out = detect_problem_accounts(args.sid)
@@ -40,17 +105,69 @@ def main() -> int:
     reason_counts = Counter(reason_keys)
     top_reasons = ", ".join(f"{k}={v}" for k, v in reason_counts.most_common(10))
 
+    merge_summary: Dict[str, Any] | None = None
+    if args.show_merge:
+        out = cluster_problematic_accounts(out, DEFAULT_CFG, sid=args.sid)
+        merge_summary = _build_merge_summary(out)
+
     payload = {
         "sid": args.sid,
         "problematic": len(out),
         "sample": out if args.show_all else out[:5],
     }
 
+    if merge_summary is not None:
+        payload["merge"] = merge_summary
+
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     if issues_line:
         print(f"issues: {issues_line}")
     if top_reasons:
         print(f"reasons: {top_reasons}")
+
+    if merge_summary is not None:
+        clusters_view: List[Dict[str, Any]] = []
+        for cluster in merge_summary["clusters"]:
+            clusters_view.append(
+                {
+                    "group": cluster["group"],
+                    "members": cluster["members"],
+                    "best_matches": [
+                        {
+                            key: entry[key]
+                            for key in ("idx", "best", "score", "decision")
+                            if key in entry
+                        }
+                        for entry in cluster["best_matches"]
+                    ],
+                }
+            )
+
+        pairs_view = [
+            {key: entry[key] for key in ("idx", "best", "score", "decision") if key in entry}
+            for entry in merge_summary["pairs"]
+        ]
+
+        print("clusters:", json.dumps(clusters_view, ensure_ascii=False, indent=2))
+        print("pairs:", json.dumps(pairs_view, ensure_ascii=False, indent=2))
+
+    json_out_path = Path(args.json_out) if args.json_out else None
+    if json_out_path is not None:
+        json_payload: Dict[str, Any] = {
+            "sid": args.sid,
+            "problematic": len(out),
+            "candidates": out,
+            "issue_counts": dict(issue_counts),
+            "reason_counts": dict(reason_counts),
+        }
+        if merge_summary is not None:
+            json_payload["merge"] = merge_summary
+
+        json_out_path.write_text(
+            json.dumps(json_payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"wrote JSON to {json_out_path}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a merge summary helper to compute clusters and pair table output
- extend smoke_problem_candidates CLI with --show-merge and --json-out options
- emit cluster and table views plus optional JSON payload for merge inspection

## Testing
- pytest tests/report_analysis/test_account_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68c99ec1eb6c832585ab2d24a4b4dfb7