### PR TITLE
Remove triad_rows from case output

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -515,7 +515,7 @@ def _build_problem_cases_legacy(
         raw_lines = list(full_acc.get("lines") or [])
         _write_json(account_dir / pointers["raw"], raw_lines)
 
-        bureaus_obj = dict(full_acc.get("triad_fields") or {})
+        bureaus_obj = _sanitize_bureaus(full_acc.get("triad_fields"))
         _write_json(account_dir / pointers["bureaus"], bureaus_obj)
 
         flat_fields, _prov = build_rule_fields_from_triad(dict(full_acc))


### PR DESCRIPTION
## Summary
- sanitize triad_fields in the legacy problem case builder so case files never persist triad_rows
- extend the problem case builder test fixture with triad_rows data and assert all emitted JSON files omit it while fields_flat keys stay normalized

## Testing
- pytest tests/test_problem_case_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68ca0cc20e5483258567a71b21f8f2a5