### PR TITLE
Include Stage-A histories in case bureaus payload

### DIFF
--- a/scripts/migrate_cases_to_lean.py
+++ b/scripts/migrate_cases_to_lean.py
@@ -24,6 +24,9 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
 
+from backend.core.logic.report_analysis.problem_case_builder import (
+    _build_bureaus_payload_from_stagea,
+)
 from backend.core.logic.report_analysis.problem_extractor import (
     build_rule_fields_from_triad,
 )
@@ -64,18 +67,6 @@ def _ensure_list(value: Any) -> List[Any]:
     if isinstance(value, tuple):
         return list(value)
     return [value]
-
-
-def _sanitize_bureaus(data: Mapping[str, Any] | None) -> Dict[str, Any]:
-    cleaned: Dict[str, Any] = {}
-    for bureau, payload in (data or {}).items():
-        if isinstance(payload, Mapping):
-            cleaned[bureau] = {
-                key: value for key, value in payload.items() if key != "triad_rows"
-            }
-        else:
-            cleaned[bureau] = payload
-    return cleaned
 
 
 def _extract_reason_fields(
@@ -192,7 +183,7 @@ def migrate_account_dir(account_dir: Path, dry_run: bool = False) -> bool:
     account_id = account_data.get("account_id")
 
     raw_lines = list(account_data.get("lines") or [])
-    bureaus = _sanitize_bureaus(account_data.get("triad_fields"))
+    bureaus = _build_bureaus_payload_from_stagea(account_data)
     flat_fields, _prov = build_rule_fields_from_triad(dict(account_data))
 
     meta: Dict[str, Any] = {

--- a/tests/test_migrate_cases_to_lean.py
+++ b/tests/test_migrate_cases_to_lean.py
@@ -1,5 +1,8 @@
 import json
 
+from backend.core.logic.report_analysis.problem_case_builder import (
+    _build_bureaus_payload_from_stagea,
+)
 from scripts.migrate_cases_to_lean import POINTERS, migrate
 
 
@@ -65,7 +68,10 @@ def test_migrate_cases_to_lean(tmp_path):
 
     bureaus = json.loads((account_dir / POINTERS["bureaus"]).read_text(encoding="utf-8"))
     assert "triad_rows" not in json.dumps(bureaus)
+    assert bureaus == _build_bureaus_payload_from_stagea(account_data)
     assert bureaus["transunion"]["payment_status"] == "Charge Off"
+    assert "two_year_payment_history" in bureaus
+    assert "seven_year_history" in bureaus
 
     flat_fields = json.loads((account_dir / POINTERS["flat"]).read_text(encoding="utf-8"))
     assert flat_fields["past_due_amount"] == 125.0


### PR DESCRIPTION
## Summary
- add a helper to assemble sanitized Stage-A bureau payloads including payment histories
- write the enriched payload in both lean and legacy problem-case builders and reuse it in the legacy migration utility
- extend the problem-case builder and migration tests to assert the new bureau fields are emitted

## Testing
- pytest tests/test_problem_case_builder.py tests/test_migrate_cases_to_lean.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cacbfd20e883259aaa48675ab9f634