### PR TITLE
Add bureau histories to lean case artifacts

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -83,8 +83,8 @@ def _build_bureaus_payload_from_stagea(acc: Mapping[str, Any] | None) -> Dict[st
         acc = {}
 
     tf = _sanitize_bureaus(acc.get("triad_fields"))
-    t2y = acc.get("two_year_payment_history") or {}
-    s7y = acc.get("seven_year_history") or {}
+    t2y = acc.get("two_year_payment_history")
+    s7y = acc.get("seven_year_history")
 
     payload: Dict[str, Any] = {k: v for k, v in tf.items()}
     payload["two_year_payment_history"] = t2y

--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -122,6 +122,25 @@ def tmp_sid_fixture(tmp_path, monkeypatch):
     return sid
 
 
+def test_build_bureaus_payload_preserves_history_values():
+    account = {
+        "triad_fields": {
+            "transunion": {"payment_status": "Late", "triad_rows": [{"foo": "bar"}]}
+        },
+        "two_year_payment_history": None,
+        "seven_year_history": {"transunion": {"late30": 1, "late60": 0, "late90": 0}},
+    }
+
+    bureaus = _build_bureaus_payload_from_stagea(account)
+
+    assert bureaus["transunion"]["payment_status"] == "Late"
+    assert "triad_rows" not in bureaus["transunion"]
+    assert "two_year_payment_history" in bureaus
+    assert "seven_year_history" in bureaus
+    assert bureaus["two_year_payment_history"] is None
+    assert bureaus["seven_year_history"] is account["seven_year_history"]
+
+
 def test_lean_cases_structure(tmp_sid_fixture):
     sid = tmp_sid_fixture
 


### PR DESCRIPTION
## Summary
- ensure the bureaus payload copies two_year_payment_history and seven_year_history values verbatim from Stage-A accounts
- add a regression test covering preservation of bureau histories in lean case payloads

## Testing
- pytest tests/test_problem_case_builder.py tests/test_migrate_cases_to_lean.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cacdc23b148325aca00b37c0dae247