### PR TITLE
Add assertions for bureau history persistence

### DIFF
--- a/tests/test_migrate_cases_to_lean.py
+++ b/tests/test_migrate_cases_to_lean.py
@@ -30,6 +30,7 @@ def test_migrate_cases_to_lean(tmp_path):
                 "triad_rows": [{"label": "Balance", "values": {"transunion": "125"}}],
             },
             "experian": {"balance_owed": "500"},
+            "equifax": {},
         },
         "triad_rows": [
             {"label": "Account #", "values": {"transunion": "1234"}},
@@ -72,6 +73,12 @@ def test_migrate_cases_to_lean(tmp_path):
     assert bureaus["transunion"]["payment_status"] == "Charge Off"
     assert "two_year_payment_history" in bureaus
     assert "seven_year_history" in bureaus
+    assert bureaus["two_year_payment_history"] == account_data[
+        "two_year_payment_history"
+    ]
+    assert bureaus["seven_year_history"] == account_data["seven_year_history"]
+    for key in ("transunion", "experian", "equifax"):
+        assert key in bureaus and isinstance(bureaus[key], dict)
 
     flat_fields = json.loads((account_dir / POINTERS["flat"]).read_text(encoding="utf-8"))
     assert flat_fields["past_due_amount"] == 125.0


### PR DESCRIPTION
## Summary
- ensure the lean builder fixture includes three bureau payloads with payment history samples
- extend lean and migration tests to assert `bureaus.json` copies Stage-A history fields without losing bureau dicts

## Testing
- pytest tests/test_problem_case_builder.py tests/test_migrate_cases_to_lean.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cacebb33f08325b17acaec7b1b3eb8