### PR TITLE
Handle space-delimited triad tokens via Stage-A pre-routing split

### DIFF
--- a/tests/stagea/test_triad_space_delimited.py
+++ b/tests/stagea/test_triad_space_delimited.py
@@ -28,6 +28,25 @@ def _write_triad_tail_row(tsv_path: Path, tail_text: str) -> None:
     tsv_path.write_text(header + "".join(rows), encoding="utf-8")
 
 
+def _write_triad_continuation_row(tsv_path: Path, continuation_text: str) -> None:
+    header = "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+    rows = [
+        "1\t1\t10\t11\t60\t100\tTransUnion\n",
+        "1\t1\t10\t11\t160\t200\tExperian\n",
+        "1\t1\t10\t11\t260\t300\tEquifax\n",
+        "1\t2\t20\t21\t0\t40\tAccount #\n",
+        "1\t2\t20\t21\t60\t100\t123456789\n",
+        "1\t2\t20\t21\t160\t200\t123456789\n",
+        "1\t2\t20\t21\t260\t300\t123456789\n",
+        "1\t3\t30\t31\t0\t40\tPast Due Amount:\n",
+        "1\t3\t30\t31\t60\t100\t100\n",
+        "1\t3\t30\t31\t160\t200\t200\n",
+        "1\t3\t30\t31\t260\t300\t300\n",
+        f"1\t4\t40\t41\t60\t320\t{continuation_text}\n",
+    ]
+    tsv_path.write_text(header + "".join(rows), encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     "tail_text, expected",
     [
@@ -58,3 +77,21 @@ def test_triad_space_delimited_tail_split(
         assert fields[bureau]["high_balance"] == "--"
 
     assert fields["transunion"]["account_number_display"] == "123456789"
+
+
+def test_triad_space_delimited_continuation_split(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tsv_path = tmp_path / "_space_continuation.tsv"
+    _write_triad_continuation_row(tsv_path, "400 500 600")
+
+    monkeypatch.setenv("TRIAD_BAND_BY_X0", "1")
+
+    data, _accounts_dir, _sid = _run_split(tsv_path, caplog)
+    fields = data["accounts"][0]["triad_fields"]
+
+    assert fields["transunion"]["past_due_amount"] == "100 400"
+    assert fields["experian"]["past_due_amount"] == "200 500"
+    assert fields["equifax"]["past_due_amount"] == "300 600"

--- a/tests/test_split_accounts_from_tsv.py
+++ b/tests/test_split_accounts_from_tsv.py
@@ -351,9 +351,9 @@ def test_seam_tie_break_right_to_xp(tmp_path: Path, caplog):
     tsv_path.write_text(header + "".join(rows), encoding="utf-8")
     data, accounts_dir, _ = _run_split(tsv_path, caplog)
     fields = data["accounts"][0]["triad_fields"]
-    assert fields["transunion"].get("high_balance", "") in {"", None}
+    assert fields["transunion"].get("high_balance", "") in {"", None, "--"}
     assert fields["experian"]["high_balance"] == "SEAM"
-    assert fields["equifax"].get("high_balance", "") in {"", None}
+    assert fields["equifax"].get("high_balance", "") in {"", None, "--"}
 
 
 def test_unknown_label_skipped_then_next_known_parsed(tmp_path: Path, caplog):


### PR DESCRIPTION
## Summary
- Added Stage-A debug flag and synthetic splitting helpers to pre-route multi-bureau tokens and emit header detection log.
- Extended labeled row handling to use pre-split overrides, normalize output, and log parsed rows.
- Added regression coverage for space-delimited continuation rows and adjusted seam tie test expectations.

## Testing
- pytest tests/stagea/test_triad_space_delimited.py
- pytest tests/test_split_accounts_from_tsv.py

------
https://chatgpt.com/codex/tasks/task_b_68cae51e1ab0832596409256fb8e72f0