### PR TITLE
Adjust stage A cleaning to preserve dash placeholders

### DIFF
--- a/backend/core/logic/report_analysis/account_packager.py
+++ b/backend/core/logic/report_analysis/account_packager.py
@@ -5,7 +5,14 @@ from pathlib import Path
 import json
 import re
 
-from .normalize_fields import LABELS, LABEL_TO_KEY, CANONICAL_KEYS, ensure_all_keys, clean_value
+from .normalize_fields import (
+    LABELS,
+    LABEL_TO_KEY,
+    CANONICAL_KEYS,
+    ensure_all_keys,
+    clean_value,
+    is_effectively_blank,
+)
 
 
 def _mid_x(t: dict) -> float:
@@ -130,7 +137,13 @@ def package_account_block(block: dict, index_headline: str | None) -> dict:
         out_fields[b] = ensure_all_keys(fields.get(b) or {})
 
     # Presence flags: any non-empty value
-    presence = {b: any(str(v or "").strip() for v in out_fields.get(b, {}).values()) for b in ("transunion", "experian", "equifax")}
+    presence = {
+        b: any(
+            not is_effectively_blank(v)
+            for v in out_fields.get(b, {}).values()
+        )
+        for b in ("transunion", "experian", "equifax")
+    }
 
     # Layout section (optional)
     layout_tokens: List[dict] = list(blk.get("layout_tokens") or [])

--- a/backend/core/logic/report_analysis/column_reader.py
+++ b/backend/core/logic/report_analysis/column_reader.py
@@ -123,7 +123,7 @@ def extract_bureau_table(block: dict) -> Dict[str, Dict[str, str]]:
          b) Determine row-Y as median(midY of tokens on that line).
          c) Collect non-label tokens within Y-band [rowY-3, rowY+3].
          d) For each bureau, keep tokens whose midX is within that bureau’s (xL,xR).
-         e) Sort by X; join with spaces; cleanup: convert --/—/- → ""; merge hard-wraps for next Y band within ΔY ≤ 6.
+         e) Sort by X; join with spaces; cleanup: normalize dash placeholders to "--" and leave blanks empty; merge hard-wraps for next Y band within ΔY ≤ 6.
       2) Build dict for each bureau with all 22 keys present (empty string if missing).
     """
 

--- a/tests/stagea/test_triad_space_delimited.py
+++ b/tests/stagea/test_triad_space_delimited.py
@@ -104,7 +104,7 @@ def test_triad_space_delimited_tail_split(
     assert "TRIAD_TAIL_SPACE_SPLIT" in caplog.text
 
     for bureau in ("transunion", "experian", "equifax"):
-        assert fields[bureau]["high_balance"] == "--"
+        assert fields[bureau]["high_balance"] == ""
 
     assert fields["transunion"]["account_number_display"] == "123456789"
 


### PR DESCRIPTION
## Summary
- preserve dash placeholder tokens by enhancing clean_value, adding dash/blank helpers, and updating presence checks
- refresh triad parsing logic to normalize tail splits, adjust seam tie-breaking, and log x0 fallback usage while keeping placeholders intact
- update stage A tests to expect empty strings for missing values and retain real dash placeholders

## Testing
- pytest tests/stagea/test_triad_space_delimited.py tests/test_split_accounts_from_tsv.py

------
https://chatgpt.com/codex/tasks/task_b_68cb07e8d7e083258e5141aee8d13e26