### PR TITLE
Add trace logging for triad band diagnostics

### DIFF
--- a/tests/test_split_accounts_from_tsv.py
+++ b/tests/test_split_accounts_from_tsv.py
@@ -180,6 +180,9 @@ def test_band_by_x0_three_values_single_line(tmp_path: Path, caplog):
     assert fields["transunion"]["high_balance"] == "$149,500"
     assert fields["experian"]["high_balance"] == "$149,500"
     assert fields["equifax"]["high_balance"] == "$149,500"
+    assert "TRIAD_HEADER_X0S" in caplog.text
+    assert "ROW_BANDS key=high_balance" in caplog.text
+    assert "TOK p=1 l=3 x0=172.900 -> TU text='$149,500'" in caplog.text
     # no TU rescue logs
     assert "TRIAD_TU_RESCUE" not in caplog.text
     # trace used_axis should be x0


### PR DESCRIPTION
## Summary
- add a helper that only emits band diagnostics when Stage-A tracing or debug is enabled
- log header x0s plus per-row and per-token bands so mis-banded values can be inspected quickly
- extend the X0 triad test to assert the new log signatures

## Testing
- pytest tests/test_split_accounts_from_tsv.py::test_band_by_x0_three_values_single_line -q
- pytest tests/test_split_accounts_from_tsv.py -q
- pytest tests/stagea/test_triad_space_delimited.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cb1500cbfc8325976e5d72739957ea