### PR TITLE
Add Stage-A banding regression tests for account 8 geometry

### DIFF
--- a/tests/test_stagea_banding.py
+++ b/tests/test_stagea_banding.py
@@ -1,0 +1,274 @@
+import importlib
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from backend.core.logic.report_analysis.triad_layout import TriadLayout
+from backend.pipeline.runs import RUNS_ROOT_ENV
+
+from tests.test_split_accounts_from_tsv import _run_split
+
+
+TU_X0 = 172.875
+XP_X0 = 309.0
+EQ_X0 = 445.125
+COLON_LEFT = TU_X0 - 0.3
+COLON_RIGHT = TU_X0 + 0.3
+
+
+def _token(line: int, x0: float, x1: float, text: str) -> dict:
+    y0 = line * 10
+    y1 = y0 + 1
+    return {
+        "page": 1,
+        "line": line,
+        "y0": y0,
+        "y1": y1,
+        "x0": x0,
+        "x1": x1,
+        "text": text,
+    }
+
+
+def _layout() -> TriadLayout:
+    return TriadLayout(
+        page=1,
+        label_band=(0.0, TU_X0),
+        tu_band=(TU_X0, XP_X0),
+        xp_band=(XP_X0, EQ_X0),
+        eq_band=(EQ_X0, float("inf")),
+        label_right_x0=TU_X0,
+        tu_left_x0=TU_X0,
+        xp_left_x0=XP_X0,
+        eq_left_x0=EQ_X0,
+    )
+
+
+def _write_tsv(path: Path, tokens: List[dict]) -> None:
+    header = "page\tline\ty0\ty1\tx0\tx1\ttext\n"
+    rows = [
+        (
+            f"{tok['page']}\t{tok['line']}\t{tok['y0']}\t{tok['y1']}\t"
+            f"{tok['x0']:.3f}\t{tok['x1']:.3f}\t{tok['text']}\n"
+        )
+        for tok in tokens
+    ]
+    path.write_text(header + "".join(rows), encoding="utf-8")
+
+
+def _account8_tokens() -> List[dict]:
+    tokens: List[dict] = []
+    # Triad header establishes the column seams directly from header x0 values.
+    tokens.append(_token(1, TU_X0, TU_X0 + 30.0, "TransUnion"))
+    tokens.append(_token(1, XP_X0, XP_X0 + 30.0, "Experian"))
+    tokens.append(_token(1, EQ_X0, EQ_X0 + 30.0, "Equifax"))
+
+    # Anchor row with a single Account # label token.
+    tokens.append(_token(2, 100.0, 170.0, "Account #"))
+    tokens.append(_token(2, TU_X0 + 10.0, TU_X0 + 50.0, "****"))
+    tokens.append(_token(2, XP_X0 + 20.0, XP_X0 + 60.0, "XP-ACC"))
+    tokens.append(_token(2, EQ_X0 + 20.0, EQ_X0 + 60.0, "EQ-ACC"))
+
+    # High Balance
+    tokens.append(_token(3, 90.0, 140.0, "High"))
+    tokens.append(_token(3, 140.0, 170.0, "Balance"))
+    tokens.append(_token(3, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(3, TU_X0 + 20.0, TU_X0 + 70.0, "$12,028"))
+    tokens.append(_token(3, XP_X0 + 20.0, XP_X0 + 70.0, "$0"))
+    tokens.append(_token(3, EQ_X0 + 20.0, EQ_X0 + 70.0, "$6,217"))
+
+    # Last Verified
+    tokens.append(_token(4, 90.0, 150.0, "Last"))
+    tokens.append(_token(4, 150.0, 190.0, "Verified"))
+    tokens.append(_token(4, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(4, TU_X0 + 20.0, TU_X0 + 70.0, "11.8.2025"))
+    tokens.append(_token(4, XP_X0 + 20.0, XP_X0 + 70.0, "--"))
+    tokens.append(_token(4, EQ_X0 + 20.0, EQ_X0 + 70.0, "--"))
+
+    # Date of Last Activity
+    tokens.append(_token(5, 60.0, 90.0, "Date"))
+    tokens.append(_token(5, 90.0, 110.0, "of"))
+    tokens.append(_token(5, 110.0, 150.0, "Last"))
+    tokens.append(_token(5, 150.0, 200.0, "Activity"))
+    tokens.append(_token(5, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(5, TU_X0 + 20.0, TU_X0 + 70.0, "30.3.2024"))
+    tokens.append(_token(5, XP_X0 + 20.0, XP_X0 + 70.0, "1.6.2025"))
+    tokens.append(_token(5, EQ_X0 + 20.0, EQ_X0 + 70.0, "1.2.2025"))
+
+    # Date Reported
+    tokens.append(_token(6, 60.0, 120.0, "Date"))
+    tokens.append(_token(6, 120.0, 170.0, "Reported"))
+    tokens.append(_token(6, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(6, TU_X0 + 20.0, TU_X0 + 70.0, "11.8.2025"))
+    tokens.append(_token(6, XP_X0 + 20.0, XP_X0 + 70.0, "4.8.2025"))
+    tokens.append(_token(6, EQ_X0 + 20.0, EQ_X0 + 70.0, "1.8.2025"))
+
+    # Date Opened
+    tokens.append(_token(7, 60.0, 120.0, "Date"))
+    tokens.append(_token(7, 120.0, 170.0, "Opened"))
+    tokens.append(_token(7, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(7, TU_X0 + 20.0, TU_X0 + 70.0, "20.11.2021"))
+    tokens.append(_token(7, XP_X0 + 20.0, XP_X0 + 70.0, "1.11.2021"))
+    tokens.append(_token(7, EQ_X0 + 20.0, EQ_X0 + 70.0, "1.11.2021"))
+
+    # Closed Date
+    tokens.append(_token(8, 80.0, 140.0, "Closed"))
+    tokens.append(_token(8, 140.0, 180.0, "Date"))
+    tokens.append(_token(8, COLON_LEFT, COLON_RIGHT, ":"))
+    tokens.append(_token(8, TU_X0 + 20.0, TU_X0 + 70.0, "30.3.2024"))
+    tokens.append(_token(8, XP_X0 + 20.0, XP_X0 + 70.0, "--"))
+    tokens.append(_token(8, EQ_X0 + 20.0, EQ_X0 + 70.0, "30.3.2024"))
+
+    return tokens
+
+
+@pytest.fixture(autouse=True)
+def _runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+
+
+@pytest.fixture
+def split_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TRIAD_BAND_BY_X0", "1")
+    monkeypatch.setenv("RAW_JOIN_TOKENS_WITH_SPACE", "1")
+    monkeypatch.setenv("RAW_TRIAD_FROM_X", "1")
+    mod = importlib.import_module("scripts.split_accounts_from_tsv")
+    return importlib.reload(mod)
+
+
+def test_tu_values_route_correctly_from_header_x0(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRIAD_BAND_BY_X0", "1")
+    tsv_path = tmp_path / "account8.tsv"
+    _write_tsv(tsv_path, _account8_tokens())
+
+    data, _accounts_dir, _sid = _run_split(tsv_path, caplog)
+    triad_fields = data["accounts"][0]["triad_fields"]
+    tu = triad_fields["transunion"]
+
+    assert tu["account_number_display"] == "****"
+    assert tu["high_balance"] == "$12,028"
+    assert tu["last_verified"] == "11.8.2025"
+    assert tu["date_of_last_activity"] == "30.3.2024"
+    assert tu["date_reported"] == "11.8.2025"
+    assert tu["date_opened"] == "20.11.2021"
+    assert tu["closed_date"] == "30.3.2024"
+
+
+def test_eq_is_capped_by_next_label_x0(split_module) -> None:
+    layout = _layout()
+    triad_fields: Dict[str, Dict[str, str]] = {
+        "transunion": {},
+        "experian": {},
+        "equifax": {},
+    }
+    triad_order = ["transunion", "experian", "equifax"]
+
+    first_row = [
+        _token(3, 90.0, 130.0, "Closed"),
+        _token(3, 130.0, 170.0, "Date"),
+        _token(3, COLON_LEFT, COLON_RIGHT, ":"),
+        _token(3, TU_X0 + 20.0, TU_X0 + 60.0, "30.3.2024"),
+        _token(3, XP_X0 + 20.0, XP_X0 + 60.0, "--"),
+        _token(3, EQ_X0 + 10.0, EQ_X0 + 60.0, "30.3.2024"),
+        _token(3, EQ_X0 + 80.0, EQ_X0 + 140.0, "Last Payment:"),
+    ]
+    row1 = split_module.process_triad_labeled_line(
+        first_row,
+        layout,
+        split_module.LABEL_MAP,
+        None,
+        triad_fields,
+        triad_order,
+    )
+    assert row1["values"]["equifax"] == "30.3.2024"
+    assert triad_fields["equifax"]["closed_date"] == "30.3.2024"
+
+    second_row = [
+        _token(4, 100.0, 170.0, "Last Payment:"),
+        _token(4, TU_X0 + 20.0, TU_X0 + 60.0, "18.6.2025"),
+        _token(4, XP_X0 + 20.0, XP_X0 + 60.0, "18.6.2025"),
+        _token(4, EQ_X0 + 10.0, EQ_X0 + 60.0, "1.2.2025"),
+    ]
+    row2 = split_module.process_triad_labeled_line(
+        second_row,
+        layout,
+        split_module.LABEL_MAP,
+        None,
+        triad_fields,
+        triad_order,
+    )
+    assert row2["values"]["equifax"] == "1.2.2025"
+
+
+def test_cleaning_empty_vs_dashes_and_masks(split_module) -> None:
+    layout = _layout()
+    triad_fields: Dict[str, Dict[str, str]] = {
+        "transunion": {},
+        "experian": {},
+        "equifax": {},
+    }
+    triad_order = ["transunion", "experian", "equifax"]
+
+    # Masked account numbers must be preserved for every bureau.
+    account_row = [
+        _token(2, 100.0, 170.0, "Account #"),
+        _token(2, TU_X0 + 20.0, TU_X0 + 60.0, "****"),
+        _token(2, XP_X0 + 20.0, XP_X0 + 60.0, "****"),
+        _token(2, EQ_X0 + 20.0, EQ_X0 + 80.0, "552433**********"),
+    ]
+    split_module.process_triad_labeled_line(
+        account_row,
+        layout,
+        split_module.LABEL_MAP,
+        None,
+        triad_fields,
+        triad_order,
+    )
+
+    # Dashes must remain dashes when present in the source.
+    dash_row = [
+        _token(3, 90.0, 140.0, "High"),
+        _token(3, 140.0, 170.0, "Balance"),
+        _token(3, COLON_LEFT, COLON_RIGHT, ":"),
+        _token(3, TU_X0 + 20.0, TU_X0 + 70.0, "$12,028"),
+        _token(3, XP_X0 + 20.0, XP_X0 + 60.0, "--"),
+        _token(3, EQ_X0 + 20.0, EQ_X0 + 60.0, "--"),
+    ]
+    split_module.process_triad_labeled_line(
+        dash_row,
+        layout,
+        split_module.LABEL_MAP,
+        None,
+        triad_fields,
+        triad_order,
+    )
+
+    # Missing tokens should stay as empty strings rather than being coerced to dashes.
+    empty_row = [
+        _token(4, 90.0, 150.0, "Credit"),
+        _token(4, 150.0, 200.0, "Limit"),
+        _token(4, COLON_LEFT, COLON_RIGHT, ":"),
+        _token(4, TU_X0 + 20.0, TU_X0 + 60.0, "$5,000"),
+        _token(4, EQ_X0 + 20.0, EQ_X0 + 60.0, "$7,500"),
+    ]
+    split_module.process_triad_labeled_line(
+        empty_row,
+        layout,
+        split_module.LABEL_MAP,
+        None,
+        triad_fields,
+        triad_order,
+    )
+
+    assert triad_fields["transunion"]["account_number_display"] == "****"
+    assert triad_fields["experian"]["account_number_display"] == "****"
+    assert triad_fields["equifax"]["account_number_display"] == "552433**********"
+    assert triad_fields["experian"]["high_balance"] == "--"
+    assert triad_fields["equifax"]["high_balance"] == "--"
+    assert triad_fields["experian"]["credit_limit"] == ""


### PR DESCRIPTION
## Summary
- add a regression-focused Stage-A banding test module that reconstructs the account-8 layout
- verify transunion values route correctly from header x0 coordinates and that Equifax is capped by the next label
- assert the cleaning path keeps empty strings, dashes, and masked values intact

## Testing
- `pytest tests/test_stagea_banding.py`


------
https://chatgpt.com/codex/tasks/task_b_68cb17af40ec832585b1a2db6d91dd3f