### PR TITLE
Stage-A: enforce triad band guard and no-bleed assembly

### DIFF
--- a/backend/core/logic/report_analysis/triad_layout.py
+++ b/backend/core/logic/report_analysis/triad_layout.py
@@ -4,12 +4,15 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, List, Literal, Tuple
 
-from backend.config import RAW_TRIAD_FROM_X
+from backend.config import RAW_TRIAD_FROM_X, env_float
 
 from .header_utils import normalize_bureau_header
 
 logger = logging.getLogger(__name__)
 triad_log = logger.info if RAW_TRIAD_FROM_X else (lambda *a, **k: None)
+
+
+TRIAD_BOUNDARY_GUARD: float = env_float("TRIAD_BOUNDARY_GUARD", 2.0)
 
 
 @dataclass

--- a/docs/triad_no_bleed.md
+++ b/docs/triad_no_bleed.md
@@ -1,0 +1,27 @@
+# Stage-A triad band guard
+
+Stage-A assembles triad rows strictly from the geometric bands detected on the
+corresponding header line. Each bureau’s column is defined by the header `x0`
+coordinates and evaluated using closed-open intervals:
+
+- label: `[0, tu_left_x0)`
+- TransUnion: `[tu_left_x0, xp_left_x0)`
+- Experian: `[xp_left_x0, eq_left_x0)`
+- Equifax: `[eq_left_x0, next_label_x0)`
+
+A small boundary guard (`TRIAD_BOUNDARY_GUARD`, default `2.0` px) is applied to
+the right side of every band. Tokens that fall within that guard distance stay
+with the bureau on the left, preventing seam-adjacent words from bleeding into
+the next bureau when minor PDF rounding shifts occur.
+
+Value assembly is geometry-only: only tokens classified into a bureau’s band on
+that row contribute to its value. Explicit dash placeholders (`--`, em-dash,
+en-dash) inside a bureau’s band become the final value for that bureau and
+remain as `"--"` while still counting as empty for presence checks. A blank
+band without a dash yields an empty string.
+
+The space-delimited tail split heuristic now runs only as a last resort when a
+labeled row has exactly one token after the label and no geometric hits for any
+bureau. When triggered, the token is split into three segments by whitespace,
+assigned to bureaus using geometry, and then the guard and dash rules above are
+applied.

--- a/traces/texts/triad_no_bleed_trace.txt
+++ b/traces/texts/triad_no_bleed_trace.txt
@@ -1,0 +1,8 @@
+ROW_BANDS key=account_type guard=2.00 headers=(tu=172.875,xp=309.000,eq=445.125) label=[0.000,172.875) tu=[172.875,307.000) xp=[309.000,443.125) eq=[445.125,498.000)
+TOK p=1 l=5 x0=182.875 -> TU text='Flexible'
+TOK p=1 l=5 x0=214.125 -> TU text='spending'
+TOK p=1 l=5 x0=246.375 -> TU text='credit'
+TOK p=1 l=5 x0=278.625 -> TU text='card'
+TOK p=1 l=5 x0=334.000 -> XP text='--'
+TOK p=1 l=5 x0=468.750 -> EQ text='--'
+TRIAD_ROW_LABELED key=account_type TU='Flexible spending credit card' XP='--' EQ='--'


### PR DESCRIPTION
## Summary
- enforce TRIAD_BOUNDARY_GUARD during Stage-A band classification and logging to avoid cross-bureau bleed
- restrict space-delimited tail splitting to the single-token fallback and honor explicit dash placeholders during value assembly
- document the guard and tail-split rules, extend triad tests, and add a sample no-bleed trace

## Testing
- pytest tests/test_stagea_banding.py
- pytest tests/stagea/test_triad_space_delimited.py
- pytest tests/test_triad_layout.py

------
https://chatgpt.com/codex/tasks/task_b_68cb2b456afc8325ae415b20c93b7f86