### PR TITLE
Log account-number override details with new format

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -462,7 +462,7 @@ def _apply_account_number_ai_override(
         aux_with_reasons["override_reasons"] = dict(updated_reasons)
 
         logger.info(
-            "MERGE_OVERRIDE sid=<%s> accA=<%d> accB=<%d> reason=acctnum_only_triggers_ai "
+            "MERGE_OVERRIDE sid=<%s> i=<%d> j=<%d> reason=acctnum_only_triggers_ai "
             "level=<%s> masked_any=<%d> lifted_to=<%.4f>",
             sid_value,
             idx_a,


### PR DESCRIPTION
## Summary
- update the account-number override logger to use the new sid/i/j format
- extend the override test to capture logs and assert on the emitted MERGE_OVERRIDE line

## Testing
- pytest tests/report_analysis/test_account_merge.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cc43f869888325abcac37bcc58fff3