### PR TITLE
Improve smoke merge summary visibility

### DIFF
--- a/tests/test_smoke_problem_candidates.py
+++ b/tests/test_smoke_problem_candidates.py
@@ -1,0 +1,137 @@
+from typing import Any, Dict, Optional
+
+from scripts.smoke_problem_candidates import _build_merge_summary
+
+
+def _make_candidate(
+    idx: int,
+    *,
+    best_index: Optional[int],
+    score: Optional[float],
+    decision: Optional[str],
+    account_decision: str,
+    reasons: Optional[Dict[str, Any]] = None,
+    aux: Optional[Dict[str, Any]] = None,
+    parts: Optional[Dict[str, Any]] = None,
+):
+    merge_tag: dict = {
+        "group_id": f"g{idx + 1}",
+        "decision": account_decision,
+        "best_match": {},
+        "parts": parts or {},
+    }
+    if best_index is not None:
+        merge_tag["best_match"] = {
+            "account_index": best_index,
+            "score": score,
+            "decision": decision,
+        }
+        if reasons:
+            merge_tag["best_match"]["reasons"] = dict(reasons)
+            merge_tag["reasons"] = dict(reasons)
+    else:
+        merge_tag["best_match"] = {}
+    if aux is not None:
+        merge_tag["aux"] = dict(aux)
+    elif reasons:
+        merge_tag["aux"] = {"override_reasons": dict(reasons)}
+    return {"merge_tag": merge_tag}
+
+
+def test_build_merge_summary_includes_override_columns():
+    candidates = [
+        _make_candidate(
+            0,
+            best_index=1,
+            score=0.42,
+            decision="ai",
+            account_decision="ai",
+            reasons={
+                "acctnum_only_triggers_ai": True,
+                "acctnum_match_level": "last4",
+            },
+            aux={
+                "acctnum_level": "last4",
+                "override_reasons": {
+                    "acctnum_only_triggers_ai": True,
+                    "acctnum_match_level": "last4",
+                },
+            },
+            parts={"acct_num": 0.7},
+        ),
+        _make_candidate(
+            1,
+            best_index=0,
+            score=0.41,
+            decision="ai",
+            account_decision="ai",
+            reasons={"balance_only_triggers_ai": True},
+            aux={
+                "acctnum_level": "none",
+                "override_reasons": {"balance_only_triggers_ai": True},
+            },
+            parts={"balance": 1.0},
+        ),
+        _make_candidate(
+            2,
+            best_index=None,
+            score=None,
+            decision=None,
+            account_decision="different",
+            aux={"acctnum_level": "none"},
+        ),
+    ]
+
+    summary = _build_merge_summary(candidates)
+    pairs = summary["pairs"]
+
+    assert len(pairs) == 3
+
+    first = pairs[0]
+    assert first["decision"] == "ai"
+    assert first["acctnum_level"] == "last4"
+    assert first["balowed_ok"] is False
+    assert any(item.startswith("acctnum_match_level=") for item in first["reasons"])
+
+    second = pairs[1]
+    assert second["balowed_ok"] is True
+    assert "balance_only_triggers_ai" in second["reasons"]
+
+    third = pairs[2]
+    assert third["decision"] is None or third["decision"] == "different"
+    assert third["reasons"] == []
+
+
+def test_build_merge_summary_only_ai_filter():
+    candidates = [
+        _make_candidate(
+            0,
+            best_index=1,
+            score=0.5,
+            decision="ai",
+            account_decision="ai",
+            aux={"acctnum_level": "exact"},
+        ),
+        _make_candidate(
+            1,
+            best_index=0,
+            score=0.5,
+            decision="ai",
+            account_decision="ai",
+            aux={"acctnum_level": "exact"},
+        ),
+        _make_candidate(
+            2,
+            best_index=None,
+            score=None,
+            decision=None,
+            account_decision="different",
+            aux={"acctnum_level": "none"},
+        ),
+    ]
+
+    summary = _build_merge_summary(candidates, only_ai=True)
+    pairs = summary["pairs"]
+
+    assert len(pairs) == 2
+    assert all(entry["decision"] == "ai" for entry in pairs)


### PR DESCRIPTION
## Summary
- expand the smoke_problem_candidates merge summary to surface override metadata and support an --only-ai filter
- add CLI plumbing for the new flag and richer table output when --show-merge is enabled
- cover the merge summary helper with tests to exercise the new columns and AI-only filtering

## Testing
- pytest tests/test_smoke_problem_candidates.py tests/test_account_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68cc4b5c7564832593fd8791aee5c383