### PR TITLE
Align merge scorer weights and balowed scoring

### DIFF
--- a/tests/test_problem_case_builder.py
+++ b/tests/test_problem_case_builder.py
@@ -372,7 +372,7 @@ def test_problem_case_builder(tmp_path, caplog, monkeypatch):
                     "decision": "auto",
                 },
                 "parts": {
-                    "acct": 1.0,
+                    "acct_num": 1.0,
                     "balowed": 0.95,
                     "dates": 0.9,
                     "status": 1.0,
@@ -534,7 +534,7 @@ def test_problem_case_builder_updates_merge_tag_only_for_existing_cases(
                     "score": 0.55,
                     "decision": "ai",
                 },
-                "parts": {"acct": 0.7},
+                "parts": {"acct_num": 0.7},
             },
         }
     ]
@@ -557,6 +557,9 @@ def test_problem_case_builder_manifest_missing_accounts_raises(tmp_path, monkeyp
     sid = "S999"
     runs_root = tmp_path / "runs"
     monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+    monkeypatch.setattr(
+        "backend.core.logic.report_analysis.problem_case_builder.LEAN", False
+    )
     RunManifest.for_sid(sid)  # create manifest without traces entries
     try:
         build_problem_cases(sid, candidates=[])

--- a/tests/test_smoke_problem_candidates.py
+++ b/tests/test_smoke_problem_candidates.py
@@ -57,7 +57,7 @@ def test_build_merge_summary_includes_override_columns():
                     "acctnum_match_level": "last4",
                 },
             },
-            parts={"acct": 0.7},
+            parts={"acct_num": 0.7},
         ),
         _make_candidate(
             1,


### PR DESCRIPTION
## Summary
- align merge scorer weight keys with balowed/acct_num naming and capture tolerance overrides from the environment
- score balance owed with normalized values, expose them in aux data, and normalize the weighted total over configured parts
- refresh merge-related tests to use the new part names and expectations

## Testing
- pytest tests/report_analysis/test_account_merge.py tests/test_account_merge.py tests/test_problem_case_builder.py tests/test_smoke_problem_candidates.py

------
https://chatgpt.com/codex/tasks/task_b_68cc686041e88325871a59d9d7a0e52e