### PR TITLE
Support masked account-number overrides

### DIFF
--- a/docs/account_merge.md
+++ b/docs/account_merge.md
@@ -12,7 +12,7 @@ paths, including the new account-number trigger.
 
 | Env var | Default | Description |
 | --- | --- | --- |
-| `MERGE_ACCTNUM_TRIGGER_AI` | `any` | Minimum account-number match level that can lift a low overall score into the AI band. Accepted values: `off`, `exact`, `last4`, `any`. |
+| `MERGE_ACCTNUM_TRIGGER_AI` | `any` | Minimum account-number match level that can lift a low overall score into the AI band. Accepted values: `off`, `exact`, `last4`, `masked`, `any`. |
 | `MERGE_ACCTNUM_MIN_SCORE` | `0.31` | Floor used when forcing an AI decision for account-number matches. The lifted score is the max of the part score, this floor, and `MERGE_AI_HARD_MIN`. |
 | `MERGE_ACCTNUM_REQUIRE_MASKED` | `0` | When set to `1`, the override only fires if at least one side used a masked account number (e.g., `XXXX1234`). |
 
@@ -29,6 +29,8 @@ pair receives an `acctnum_level`:
 
 - `exact` – The normalized digits are identical.
 - `last4` – The normalized digits differ overall but share the same last four.
+- `masked` – Both sides only provide masked characters (e.g., `XXXX` or `****`) with the
+  same mask pattern.
 - `none` – No usable match.
 
 We also track `acctnum_masked_any`, a boolean indicating whether *either* side
@@ -47,7 +49,8 @@ weighted score is computed.
    - `off` disables the override.
    - `exact` requires an `acctnum_level` of `exact`.
    - `last4` only requires `acctnum_level == "last4"`.
-   - `any` accepts either `exact` or `last4`.
+   - `masked` accepts `acctnum_level` values of `masked`, `last4`, or `exact`.
+   - `any` accepts `exact`, `last4`, or `masked`.
 4. When `MERGE_ACCTNUM_REQUIRE_MASKED=1`, the override only activates if
    `acctnum_masked_any` is `True`.
 5. Eligible matches lift the score to `max(current_score, MERGE_ACCTNUM_MIN_SCORE, MERGE_AI_HARD_MIN)`

--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -371,10 +371,12 @@ def test_acctnum_exact_override_forces_ai(monkeypatch, caplog):
     assert best["decision"] == "ai"
     assert best["score"] == pytest.approx(0.45)
     assert first_tag["parts"]["acct_num"] == pytest.approx(1.0)
-    assert first_tag["reasons"]["acctnum_only_triggers_ai"] is True
-    assert first_tag["reasons"]["acctnum_match_level"] == "exact"
-    assert best["reasons"]["acctnum_only_triggers_ai"] is True
-    assert best["reasons"]["acctnum_match_level"] == "exact"
+    first_reasons = first_tag["reasons"]
+    assert isinstance(first_reasons, list)
+    assert {"kind": "acctnum", "level": "exact", "masked_any": False} in first_reasons
+    best_reasons = best["reasons"]
+    assert isinstance(best_reasons, list)
+    assert {"kind": "acctnum", "level": "exact", "masked_any": False} in best_reasons
     assert first_tag["aux"]["override_reasons"]["acctnum_only_triggers_ai"] is True
 
     override_messages = _extract_override_log_messages(caplog.records)
@@ -486,8 +488,9 @@ def test_acctnum_last4_override_honors_trigger(monkeypatch, trigger):
     assert first_tag["decision"] == "ai"
     assert best["decision"] == "ai"
     assert best["score"] == pytest.approx(0.43)
-    assert best["reasons"]["acctnum_only_triggers_ai"] is True
-    assert best["reasons"]["acctnum_match_level"] == "last4"
+    best_reasons = best["reasons"]
+    assert isinstance(best_reasons, list)
+    assert {"kind": "acctnum", "level": "last4", "masked_any": True} in best_reasons
     assert first_tag["aux"]["override_reasons"]["acctnum_match_level"] == "last4"
 
 
@@ -589,7 +592,7 @@ def test_acctnum_override_emits_logs_and_builds_ai_pack(monkeypatch, caplog, tmp
 
     assert saved["decision"] == "ai"
     assert saved["acctnum"] == {"level": "exact", "masked_any": False}
-    assert saved["reasons"]["acctnum_only_triggers_ai"] is True
+    assert {"kind": "acctnum", "level": "exact", "masked_any": False} in saved["reasons"]
     assert pack_path.exists()
 
 


### PR DESCRIPTION
## Summary
- normalize masked account numbers and lift eligible pairs into the AI band while recording structured acctnum reasons and logs
- surface reason lists through AI decision packs and merge-tag summaries, and teach smoke summaries to format mixed reason sources
- document the new masked trigger option and expand tests to cover masked matching and reason list handling

## Testing
- pytest tests/report_analysis/test_account_merge.py tests/test_account_merge.py tests/test_smoke_problem_candidates.py

------
https://chatgpt.com/codex/tasks/task_b_68cc70a4b230832595b9cab2f53f93f3