### PR TITLE
Ensure merge tags use real account indices

### DIFF
--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -481,6 +481,18 @@ def test_balowed_override_triggers_ai_from_case_files(monkeypatch, tmp_path, cap
     assert override_reasons["balance_only_triggers_ai"] is True
     assert override_reasons["balance_exact_match"] is True
 
+    summary_dir = runs_root / sid / "cases" / "accounts"
+    summary7 = json.loads((summary_dir / "7" / "summary.json").read_text())
+    summary10 = json.loads((summary_dir / "10" / "summary.json").read_text())
+
+    tag7 = summary7["merge_tag"]
+    tag10 = summary10["merge_tag"]
+
+    assert tag7["best_match"]["account_index"] == 10
+    assert {entry["account_index"] for entry in tag7["score_to"]} == {10}
+    assert tag10["best_match"]["account_index"] == 7
+    assert {entry["account_index"] for entry in tag10["score_to"]} == {7}
+
 
 @pytest.mark.parametrize("trigger", ["any", "last4"])
 def test_acctnum_last4_override_honors_trigger(monkeypatch, trigger):


### PR DESCRIPTION
## Summary
- coerce merge tag entries to use the underlying account index (and optional account id) when generating score_to payloads
- ensure persisted summaries retain full merge_tag data for Stage-A case accounts
- extend the balance-owed override test to assert merge_tag contents are written for accounts 7 and 10

## Testing
- pytest tests/test_account_merge.py -q
- pytest tests/test_problem_case_builder.py -q
- pytest tests/report_analysis/test_account_merge.py -q

------
https://chatgpt.com/codex/tasks/task_b_68cc7a2d8ab0832592e54364a617c5a2