### PR TITLE
Run merge scorer post case build and persist tags

### DIFF
--- a/tests/test_extract_problematic_accounts.py
+++ b/tests/test_extract_problematic_accounts.py
@@ -77,7 +77,9 @@ def test_extract_problematic_accounts_orchestrates(tmp_path, monkeypatch):
 
     assert len(result["found"]) == 1
     cand_id = result["found"][0]["account_id"]
-    assert (tmp_path / "cases" / sid / "accounts" / f"{cand_id}.json").exists()
+    assert (
+        tmp_path / "runs" / sid / "cases" / "accounts" / f"{cand_id}.json"
+    ).exists()
     assert result["summary"]["problematic"] == 1
 
 

--- a/tests/unit/test_trace_cleanup.py
+++ b/tests/unit/test_trace_cleanup.py
@@ -144,10 +144,10 @@ def test_keep_texts_flag(tmp_path: Path) -> None:
 
 
 def test_cases_directory_untouched(tmp_path: Path) -> None:
-    """Running cleanup must not remove any files under cases/<sid>."""
+    """Running cleanup must not remove any files under runs/<sid>/cases."""
     sid = "case"
     _setup(tmp_path, sid)
-    cases_file = tmp_path / "cases" / sid / "case.json"
+    cases_file = tmp_path / "runs" / sid / "cases" / "case.json"
     cases_file.parent.mkdir(parents=True)
     cases_file.write_text("1")
 


### PR DESCRIPTION
## Summary
- call the merge scorer during lean case builds, return the computed scores, and stop writing legacy merge tags into summaries
- persist analyzer issue tags plus merge pair/best tags in each account's tags.json and emit data only for ai/auto decisions
- exercise the new behaviour in the task and manifest tests, adjusting temporary run paths and Celery stubs to assert tag outputs

## Testing
- pytest tests/test_extract_problematic_accounts.py tests/test_extract_problematic_accounts_task.py tests/unit/test_trace_cleanup.py tests/test_manifest_cases_registration.py tests/report_analysis/test_account_merge_best_partner.py


------
https://chatgpt.com/codex/tasks/task_b_68cdc161f76c8325b688a5f03d478912