### PR TITLE
Persist analyzer issue tags to tags.json

### DIFF
--- a/tests/test_manifest_cases_registration.py
+++ b/tests/test_manifest_cases_registration.py
@@ -111,7 +111,9 @@ def test_build_problem_cases_writes_tags(tmp_path):
 
     issue_a = [tag for tag in tags_a if tag.get("kind") == "issue"][0]
     issue_b = [tag for tag in tags_b if tag.get("kind") == "issue"][0]
-    assert issue_a["value"] == issue_b["value"] == "collection"
+    assert issue_a["type"] == issue_b["type"] == "collection"
+    assert "details" not in issue_a
+    assert "details" not in issue_b
 
     pair_a = [tag for tag in tags_a if tag.get("kind") == "merge_pair"][0]
     pair_b = [tag for tag in tags_b if tag.get("kind") == "merge_pair"][0]


### PR DESCRIPTION
## Summary
- add an analyzer issue tag builder and upsert it to each account's tags.json
- preserve existing issue tags while rebuilding merge tags by reading and rewriting with write_tags
- update the manifest cases test to assert the new issue tag shape

## Testing
- pytest tests/test_manifest_cases_registration.py
- pytest tests/test_extract_problematic_accounts.py

------
https://chatgpt.com/codex/tasks/task_b_68cdc7f59fa48325b195c12ee6e05271