### PR TITLE
Guard legacy merge artefact writes behind MERGE_V2_ONLY

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -24,6 +24,7 @@ __all__ = [
     "choose_best_partner",
     "persist_merge_tags",
     "score_and_tag_best_partners",
+    "merge_v2_only_enabled",
 ]
 
 
@@ -77,6 +78,12 @@ def _read_env_choice(
         return str(default)
     lowered = str(raw).strip().lower()
     return lowered_choices.get(lowered, str(default))
+
+
+def merge_v2_only_enabled() -> bool:
+    """Return True when legacy merge artefact writes must be skipped."""
+
+    return _read_env_flag(os.environ, "MERGE_V2_ONLY", True)
 
 
 def gen_unordered_pairs(indices: List[int]) -> List[Tuple[int, int]]:
@@ -1524,6 +1531,9 @@ def _persist_merge_tag(
     manifest: Optional[RunManifest],
     merge_tag_v2: Optional[Mapping[str, Any]] = None,
 ) -> None:
+    if merge_v2_only_enabled():
+        return
+
     if runs_root_path is None or not sid or not isinstance(account_index, int):
         return
 

--- a/tests/test_migrate_cases_to_lean.py
+++ b/tests/test_migrate_cases_to_lean.py
@@ -116,7 +116,7 @@ def test_migrate_cases_to_lean(tmp_path):
     summary = json.loads((account_dir / POINTERS["summary"]).read_text(encoding="utf-8"))
     assert summary["problem_reasons"] == ["legacy-reason"]
     assert summary["problem_tags"] == ["legacy-tag"]
-    assert summary["merge_tag"]["group_id"] == "legacy"
+    assert "merge_tag" not in summary
     assert summary["primary_issue"] == "collection"
     assert summary["pointers"] == POINTERS
 


### PR DESCRIPTION
## Summary
- add a merge_v2_only_enabled helper and skip legacy merge summary persistence when MERGE_V2_ONLY is enabled
- gate problem case builder and migration paths from writing merge_tag/merge_tag_v2, removing stale fields when the flag is on
- update merge persistence tests to assert default omission and opt-in legacy behavior

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py tests/test_migrate_cases_to_lean.py

------
https://chatgpt.com/codex/tasks/task_b_68d00e4df8448325ae966c9e7487ed42