### PR TITLE
Persist merge scorer decisions to tags and add MERGE_V2 logs

### DIFF
--- a/docs/analyzer_inputs.md
+++ b/docs/analyzer_inputs.md
@@ -145,18 +145,22 @@ consumers.【F:backend/core/logic/report_analysis/account_merge.py†L272-L352�
 
 ### Observability and logs
 
-- Pairwise scoring emits `MERGE_SCORE sid=<...> i=<i> j=<j> parts=<...> total=<...>`
-  followed by `MERGE_DECISION ...` for every comparison. Use ripgrep to
-  inspect them, e.g. `rg "MERGE_DECISION" runs/<sid>/ -g"*.log"`.
-- `score_all_pairs_0_100` also emits `MERGE_TRIGGER` entries whenever a
-  strong, mid, or dates-only trigger fires so reviewers can trace why a
-  pair crossed the AI threshold.【F:backend/core/logic/report_analysis/account_merge.py†L628-L670】
+- Pairwise scoring emits the detailed `MERGE_SCORE ...` / `MERGE_DECISION ...`
+  logs for every comparison. Use ripgrep to inspect them, e.g. `rg
+  "MERGE_DECISION" runs/<sid>/ -g"*.log"`.
+- Compact counterparts (`MERGE_V2_SCORE`, `MERGE_V2_TRIGGER`,
+  `MERGE_V2_DECISION`) mirror the same activity with just the essential
+  identifiers so dashboards can efficiently trace merge traffic. The
+  scorer continues to expose the richer `MERGE_TRIGGER` entries whenever a
+  strong, mid, dates, or total trigger fires.【F:backend/core/logic/report_analysis/account_merge.py†L821-L878】
 
-### Where `merge_tag` is stored
+### Where merge conclusions are stored
 
-`persist_merge_tags` writes the best-partner summary for each account to
-`runs/<sid>/cases/accounts/<account_index>/summary.json` under the
-`merge_tag` key.【F:backend/core/logic/report_analysis/account_merge.py†L900-L958】 The
-payload contains the best partner, ordered score list, and per-field
-matches that feed dashboards and audit tooling.
-【F:backend/core/logic/report_analysis/problem_case_builder.py†L224-L290】 This keeps merge context available for downstream review and auditing.
+`persist_merge_tags` returns the traditional best-partner payload for
+callers, but it now persists conclusions exclusively in
+`runs/<sid>/cases/accounts/<idx>/tags.json`. Each run rewrites the merge
+tags for AI/auto pairs (`merge_pair`) and the selected best partner
+(`merge_best`) so downstream systems can read a single source of truth
+without touching `summary.json`.【F:backend/core/logic/report_analysis/account_merge.py†L1213-L1263】 The lean case builder consumes the
+same helpers, ensuring analyzer issue tags and merge tags live together in
+each account's tags file.【F:backend/core/logic/report_analysis/problem_case_builder.py†L557-L612】

--- a/scripts/score_bureau_pairs.py
+++ b/scripts/score_bureau_pairs.py
@@ -230,7 +230,7 @@ def build_merge_tags(
     return tags
 
 
-def persist_merge_tags_to_summary(
+def persist_merge_tags_to_tags(
     sid: str,
     scores_by_idx: Mapping[int, Mapping[int, Mapping[str, Any]]],
     best_by_idx: Mapping[int, Mapping[str, Any]],
@@ -309,7 +309,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument(
         "--write-tags",
         action="store_true",
-        help="Persist merge tags back to account summaries",
+        help="Persist merge tags to per-account tags.json files",
     )
 
     args = parser.parse_args(argv)
@@ -334,7 +334,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     merge_tags = build_merge_tags(scores_by_idx, best_by_idx)
 
     if args.write_tags:
-        merge_tags = persist_merge_tags_to_summary(
+        merge_tags = persist_merge_tags_to_tags(
             sid, scores_by_idx, best_by_idx, runs_root=runs_root
         )
 


### PR DESCRIPTION
## Summary
- add compact MERGE_V2_* telemetry alongside existing merge scorer logs and keep the scoring API unchanged
- persist merge decisions exclusively into per-account tags.json files for AI/auto pairs and share the helpers with the lean case builder
- refresh CLI utilities, analyzer documentation, and tests to exercise the new tagging contract

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py tests/io/test_tags_idempotent.py

------
https://chatgpt.com/codex/tasks/task_b_68d0148c413c8325876558f9e01b8d92