### PR TITLE
Add AI adjudicator prompt builder

### DIFF
--- a/backend/core/logic/report_analysis/ai_adjudicator.py
+++ b/backend/core/logic/report_analysis/ai_adjudicator.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from .ai_pack import DEFAULT_MAX_LINES
+
+
+HIGHLIGHT_KEYS: tuple[str, ...] = (
+    "total",
+    "triggers",
+    "parts",
+    "matched_fields",
+    "conflicts",
+    "acctnum_level",
+)
+
+SYSTEM_MESSAGE = (
+    "You are an expert credit tradeline merge adjudicator. Review the provided "
+    "highlights and short context snippets to decide if the two accounts refer to "
+    "the same underlying obligation. Treat the token '--' as missing or "
+    "unknown data. Strong triggers represent decisive evidence and take "
+    "priority over mid triggers; mid triggers offer supporting evidence but cannot "
+    "override conflicts backed by strong signals. Creditor names may appear with "
+    "aliases, abbreviations, or formatting differences—treat reasonable variants "
+    "as referring to the same source when supported by other evidence. Respond "
+    "ONLY with strict JSON following this schema: "
+    '{"decision":"merge"|"no_merge","confidence":0..1,"reasons":[...]}. '
+    "Do not add commentary or extra keys."
+)
+
+
+def _coerce_positive_int(value: Any, default: int) -> int:
+    try:
+        number = int(str(value))
+    except Exception:
+        return default
+    return number if number > 0 else default
+
+
+def _limit_context(lines: list[Any], limit: int) -> list[str]:
+    if not lines:
+        return []
+    coerced = [str(item) if item is not None else "" for item in lines]
+    if limit <= 0:
+        return coerced
+    return coerced[:limit]
+
+
+def _extract_highlights(source: dict[str, Any] | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if not isinstance(source, dict):
+        return payload
+    for key in HIGHLIGHT_KEYS:
+        if key in source:
+            payload[key] = source[key]
+    return payload
+
+
+def _build_user_message(pack: dict, max_lines: int) -> str:
+    pair = pack.get("pair") or {}
+    ids = pack.get("ids") or {}
+    highlights = _extract_highlights(pack.get("highlights"))
+
+    context = pack.get("context") or {}
+    context_a = _limit_context(list(context.get("a") or []), max_lines)
+    context_b = _limit_context(list(context.get("b") or []), max_lines)
+
+    summary = {
+        "sid": pack.get("sid", ""),
+        "pair": {"a": pair.get("a"), "b": pair.get("b")},
+        "account_numbers": {
+            "a": ids.get("account_number_a", "--"),
+            "b": ids.get("account_number_b", "--"),
+        },
+        "highlights": highlights,
+        "context": {
+            "a": context_a,
+            "b": context_b,
+        },
+    }
+
+    return json.dumps(summary, ensure_ascii=False, sort_keys=True)
+
+
+def build_prompt_from_pack(pack: dict) -> dict[str, str]:
+    limits = pack.get("limits") or {}
+    default_limit = _coerce_positive_int(os.getenv("AI_PACK_MAX_LINES_PER_SIDE"), DEFAULT_MAX_LINES)
+    pack_limit = _coerce_positive_int(limits.get("max_lines_per_side"), default_limit)
+    max_lines = min(default_limit, pack_limit)
+
+    user_message = _build_user_message(pack, max_lines)
+
+    return {"system": SYSTEM_MESSAGE, "user": user_message}
+

--- a/tests/report_analysis/test_ai_adjudicator_prompt.py
+++ b/tests/report_analysis/test_ai_adjudicator_prompt.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+
+from backend.core.logic.report_analysis.ai_adjudicator import build_prompt_from_pack
+
+
+def test_build_prompt_from_pack_limits_context(monkeypatch):
+    monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "3")
+
+    pack = {
+        "sid": "sample-sid",
+        "pair": {"a": 11, "b": 16},
+        "ids": {
+            "account_number_a": "1234",
+            "account_number_b": "5678",
+        },
+        "highlights": {
+            "total": 81,
+            "triggers": ["strong:balance_owed", "mid:dates"],
+            "parts": {"balance_owed": 42, "account_number": 10},
+            "matched_fields": {"balance_owed": True},
+            "conflicts": ["amount_conflict:high_balance"],
+            "acctnum_level": "partial",
+            "ignored": "value",
+        },
+        "context": {
+            "a": ["Creditor A", "Account # 1234", "Balance: 500", "Extra A"],
+            "b": [
+                "Creditor B",
+                "Account # 5678",
+                "Balance: 500",
+                "Status: Open",
+            ],
+        },
+        "limits": {"max_lines_per_side": 5},
+    }
+
+    prompt = build_prompt_from_pack(pack)
+
+    assert set(prompt.keys()) == {"system", "user"}
+    assert "expert credit tradeline merge adjudicator" in prompt["system"].lower()
+    assert "decision" in prompt["system"]
+
+    user_payload = json.loads(prompt["user"])
+    assert user_payload["sid"] == "sample-sid"
+    assert user_payload["pair"] == {"a": 11, "b": 16}
+    assert user_payload["account_numbers"] == {"a": "1234", "b": "5678"}
+    assert user_payload["highlights"]["total"] == 81
+    assert "ignored" not in user_payload["highlights"]
+    assert len(user_payload["context"]["a"]) == 3
+    assert user_payload["context"]["a"][-1] == "Balance: 500"
+    assert len(user_payload["context"]["b"]) == 3
+    assert user_payload["context"]["b"][-1] == "Balance: 500"
+
+
+def test_build_prompt_from_pack_uses_pack_limit_when_lower(monkeypatch):
+    monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "8")
+
+    pack = {
+        "sid": "other-sid",
+        "pair": {"a": 1, "b": 2},
+        "highlights": {},
+        "context": {
+            "a": ["A1", "A2", "A3", "A4"],
+            "b": ["B1", "B2", "B3", "B4"],
+        },
+        "limits": {"max_lines_per_side": 2},
+    }
+
+    prompt = build_prompt_from_pack(pack)
+    payload = json.loads(prompt["user"])
+
+    assert payload["context"]["a"] == ["A1", "A2"]
+    assert payload["context"]["b"] == ["B1", "B2"]


### PR DESCRIPTION
## Summary
- add a prompt builder that produces system and user messages for the adjudicator AI
- limit highlight/context payloads in the prompt and carry forward account metadata
- cover the prompt builder with unit tests focused on truncation behavior

## Testing
- pytest tests/report_analysis/test_ai_adjudicator_prompt.py


------
https://chatgpt.com/codex/tasks/task_b_68d029805ce883259624a3de0191622d