### PR TITLE
Add MERGE_V2 logging for AI adjudication packs

### DIFF
--- a/tests/report_analysis/test_account_merge_best_partner.py
+++ b/tests/report_analysis/test_account_merge_best_partner.py
@@ -19,6 +19,7 @@ def _write_account_payload(base: Path, idx: int, bureaus: dict) -> None:
         json.dumps({"account_index": idx}, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    (account_dir / "raw_lines.json").write_text("[]\n", encoding="utf-8")
 
 
 def test_best_partner_prefers_strong_match(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add MERGE_V2_PACK logging when AI packs are generated so the log captures line counts, totals, and triggers
- update AI adjudicator logging to use MERGE_V2_* prefixes, including a prompt token estimate and reasons count in the decision log
- ensure tests populate raw_lines.json fixtures to support AI pack creation during testing

## Testing
- pytest tests/report_analysis/test_ai_pack.py tests/report_analysis/test_account_merge_best_partner.py

------
https://chatgpt.com/codex/tasks/task_b_68d02cebf604832583001daed94e3fb0