### PR TITLE
Add merge adjudication ENV validation defaults

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Uni
 
 from backend.core.io.tags import read_tags, upsert_tag, write_tags
 from backend.core.logic.report_analysis.ai_pack import build_ai_pack_for_pair
+from backend.core.logic.report_analysis import config as merge_config
 
 __all__ = [
     "load_bureaus",
@@ -85,7 +86,7 @@ def _read_env_choice(
 def merge_v2_only_enabled() -> bool:
     """Return True when legacy merge artefact writes must be skipped."""
 
-    return _read_env_flag(os.environ, "MERGE_V2_ONLY", True)
+    return merge_config.get_merge_v2_only()
 
 
 def gen_unordered_pairs(indices: List[int]) -> List[Tuple[int, int]]:

--- a/backend/core/logic/report_analysis/ai_pack.py
+++ b/backend/core/logic/report_analysis/ai_pack.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Iterable, Mapping
 
+from . import config as merge_config
+
 WANTED_CONTEXT_KEYS: list[str] = [
     "Account #",
     "High Balance:",
@@ -211,10 +213,7 @@ def build_ai_pack_for_pair(
     raw_lines_a = _load_raw_lines(raw_a_path)
     raw_lines_b = _load_raw_lines(raw_b_path)
 
-    max_lines = _coerce_positive_int(
-        os.getenv("AI_PACK_MAX_LINES_PER_SIDE", DEFAULT_MAX_LINES),
-        DEFAULT_MAX_LINES,
-    )
+    max_lines = merge_config.get_ai_pack_max_lines_per_side()
 
     context_a = extract_context_raw(raw_lines_a, WANTED_CONTEXT_KEYS, max_lines)
     context_b = extract_context_raw(raw_lines_b, WANTED_CONTEXT_KEYS, max_lines)

--- a/backend/core/logic/report_analysis/config.py
+++ b/backend/core/logic/report_analysis/config.py
@@ -1,0 +1,147 @@
+"""Environment-backed configuration for merge adjudication helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Iterable
+
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_AI_PACK_MAX_LINES_PER_SIDE = 20
+_MIN_AI_PACK_MAX_LINES_PER_SIDE = 5
+_DEFAULT_AI_MODEL = "gpt-4o-mini"
+_DEFAULT_AI_REQUEST_TIMEOUT = 30
+_DEFAULT_MERGE_V2_ONLY = True
+
+_WARNED_KEYS: set[str] = set()
+
+
+def _warn_once(key: str, raw: object, default: object, reason: str) -> None:
+    """Emit a structured warning for an invalid environment value once."""
+
+    if key in _WARNED_KEYS:
+        return
+
+    _WARNED_KEYS.add(key)
+    payload = {
+        "key": key,
+        "value": "" if raw is None else str(raw),
+        "default": default,
+        "reason": reason,
+    }
+    logger.warning("MERGE_V2_CONFIG_DEFAULT %s", json.dumps(payload, sort_keys=True))
+
+
+def _parse_int(key: str, raw: object, default: int, *, min_value: int | None = None) -> int:
+    try:
+        value = int(str(raw).strip())
+    except Exception:
+        _warn_once(key, raw, default, "invalid_int")
+        return default
+
+    if min_value is not None and value < min_value:
+        _warn_once(key, raw, default, f"min_{min_value}")
+        return default
+
+    return value
+
+
+def _read_int(
+    key: str,
+    default: int,
+    *,
+    min_value: int | None = None,
+    fallback_keys: Iterable[str] = (),
+) -> int:
+    raw = os.getenv(key)
+    if raw is not None:
+        return _parse_int(key, raw, default, min_value=min_value)
+
+    for fallback in fallback_keys:
+        fallback_raw = os.getenv(fallback)
+        if fallback_raw is not None:
+            return _parse_int(fallback, fallback_raw, default, min_value=min_value)
+
+    return default
+
+
+def _read_str(key: str, default: str, *, fallback_keys: Iterable[str] = ()) -> str:
+    raw = os.getenv(key)
+    if raw is not None:
+        value = str(raw).strip()
+        if value:
+            return value
+        _warn_once(key, raw, default, "empty")
+        return default
+
+    for fallback in fallback_keys:
+        fallback_raw = os.getenv(fallback)
+        if fallback_raw is None:
+            continue
+        value = str(fallback_raw).strip()
+        if value:
+            return value
+        _warn_once(fallback, fallback_raw, default, "empty")
+        return default
+
+    return default
+
+
+def _read_bool(key: str, default: bool) -> bool:
+    raw = os.getenv(key)
+    if raw is None:
+        return bool(default)
+
+    lowered = str(raw).strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+
+    _warn_once(key, raw, bool(default), "invalid_bool")
+    return bool(default)
+
+
+def get_ai_pack_max_lines_per_side() -> int:
+    """Return the per-side context limit for AI packs."""
+
+    return _read_int(
+        "AI_PACK_MAX_LINES_PER_SIDE",
+        _DEFAULT_AI_PACK_MAX_LINES_PER_SIDE,
+        min_value=_MIN_AI_PACK_MAX_LINES_PER_SIDE,
+    )
+
+
+def get_ai_model() -> str:
+    """Return the chat completion model identifier."""
+
+    return _read_str("AI_MODEL", _DEFAULT_AI_MODEL, fallback_keys=("AI_MODEL_ID",))
+
+
+def get_ai_request_timeout() -> int:
+    """Return the HTTP request timeout (seconds) for AI adjudication."""
+
+    return _read_int(
+        "AI_REQUEST_TIMEOUT",
+        _DEFAULT_AI_REQUEST_TIMEOUT,
+        min_value=1,
+        fallback_keys=("AI_REQUEST_TIMEOUT_S",),
+    )
+
+
+def get_merge_v2_only() -> bool:
+    """Return whether legacy merge artifacts should be skipped."""
+
+    return _read_bool("MERGE_V2_ONLY", _DEFAULT_MERGE_V2_ONLY)
+
+
+__all__ = [
+    "get_ai_pack_max_lines_per_side",
+    "get_ai_model",
+    "get_ai_request_timeout",
+    "get_merge_v2_only",
+]

--- a/tests/report_analysis/test_ai_adjudicator.py
+++ b/tests/report_analysis/test_ai_adjudicator.py
@@ -19,14 +19,13 @@ def _sample_pack() -> dict:
 
 def _enable_ai(monkeypatch) -> None:
     monkeypatch.setattr(config, "ENABLE_AI_ADJUDICATOR", True)
-    monkeypatch.setattr(config, "AI_MODEL_ID", "gpt-test")
     monkeypatch.setattr(config, "AI_TEMPERATURE_DEFAULT", 0.0)
     monkeypatch.setattr(config, "AI_MAX_TOKENS", 256)
-    monkeypatch.setattr(config, "AI_REQUEST_TIMEOUT_S", 5)
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
-    monkeypatch.setenv("AI_REQUEST_TIMEOUT_S", "3.5")
+    monkeypatch.setenv("AI_MODEL", "gpt-test")
+    monkeypatch.setenv("AI_REQUEST_TIMEOUT", "3")
 
 
 def test_adjudicate_pair_disabled(monkeypatch, tmp_path):
@@ -134,7 +133,7 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     assert captured["headers"]["Authorization"] == "Bearer test-key"
     assert captured["payload"]["model"] == "gpt-test"
     assert captured["payload"]["response_format"] == {"type": "json_object"}
-    assert captured["timeout"] == 3.5
+    assert captured["timeout"] == 3.0
 
     ai_adjudicator.persist_ai_decision("case-123", tmp_path, 11, 16, resp)
 

--- a/tests/report_analysis/test_ai_adjudicator_prompt.py
+++ b/tests/report_analysis/test_ai_adjudicator_prompt.py
@@ -6,7 +6,7 @@ from backend.core.logic.report_analysis.ai_adjudicator import build_prompt_from_
 
 
 def test_build_prompt_from_pack_limits_context(monkeypatch):
-    monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "3")
+    monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "9")
 
     pack = {
         "sid": "sample-sid",
@@ -33,7 +33,7 @@ def test_build_prompt_from_pack_limits_context(monkeypatch):
                 "Status: Open",
             ],
         },
-        "limits": {"max_lines_per_side": 5},
+        "limits": {"max_lines_per_side": 3},
     }
 
     prompt = build_prompt_from_pack(pack)

--- a/tests/report_analysis/test_report_config.py
+++ b/tests/report_analysis/test_report_config.py
@@ -1,0 +1,42 @@
+import json
+import logging
+
+from backend.core.logic.report_analysis import config as merge_config
+
+
+def test_invalid_env_values_fall_back_to_defaults(monkeypatch, caplog):
+    monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "3")
+    monkeypatch.setenv("AI_MODEL", " ")
+    monkeypatch.setenv("AI_REQUEST_TIMEOUT", "zero")
+    monkeypatch.setenv("MERGE_V2_ONLY", "maybe")
+
+    with caplog.at_level(
+        logging.WARNING, logger="backend.core.logic.report_analysis.config"
+    ):
+        assert merge_config.get_ai_pack_max_lines_per_side() == 20
+        assert merge_config.get_ai_model() == "gpt-4o-mini"
+        assert merge_config.get_ai_request_timeout() == 30
+        assert merge_config.get_merge_v2_only() is True
+
+        # Repeat to confirm warnings are only emitted once per key
+        assert merge_config.get_ai_pack_max_lines_per_side() == 20
+        assert merge_config.get_ai_model() == "gpt-4o-mini"
+        assert merge_config.get_ai_request_timeout() == 30
+        assert merge_config.get_merge_v2_only() is True
+
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("MERGE_V2_CONFIG_DEFAULT ")
+    ]
+
+    assert len(warning_messages) == 4
+
+    payloads = [json.loads(message.split(" ", 1)[1]) for message in warning_messages]
+    keys = {payload["key"] for payload in payloads}
+    assert keys == {
+        "AI_PACK_MAX_LINES_PER_SIDE",
+        "AI_MODEL",
+        "AI_REQUEST_TIMEOUT",
+        "MERGE_V2_ONLY",
+    }


### PR DESCRIPTION
## Summary
- add a report-analysis config helper that validates AI merge ENV knobs and emits single MERGE_V2 warnings when falling back to defaults
- route AI pack generation, adjudication, and merge gating through the validated config values
- extend and adjust tests to cover invalid ENV fallbacks, updated context limits, and timeout/model overrides

## Testing
- pytest tests/report_analysis/test_report_config.py -q
- pytest tests/report_analysis/test_ai_pack.py -q
- pytest tests/report_analysis/test_ai_adjudicator_prompt.py -q
- pytest tests/report_analysis/test_ai_adjudicator.py -q
- pytest tests/report_analysis/test_account_merge_best_partner.py -q


------
https://chatgpt.com/codex/tasks/task_b_68d03635dc988325ac36f92717da0b04