### PR TITLE
Add tests for symmetric AI adjudication artifacts

### DIFF
--- a/tests/report_analysis/test_tags_update_after_ai.py
+++ b/tests/report_analysis/test_tags_update_after_ai.py
@@ -50,3 +50,56 @@ def test_persist_ai_decision_idempotent(tmp_path):
         "source": "ai_adjudicator",
     }
 
+
+def test_persist_ai_decision_overwrites_with_new_result(tmp_path):
+    sid = "case-abc"
+    runs_root = tmp_path
+
+    first_response = {
+        "decision": "merge",
+        "confidence": 0.9,
+        "reasons": ["identical creditor"],
+    }
+
+    # Initial write with one ordering of the pair.
+    persist_ai_decision(sid, runs_root, 101, 303, first_response)
+
+    second_response = {
+        "decision": "no_merge",
+        "confidence": 0.2,
+        "reasons": ["different payment history"],
+    }
+
+    # Re-running with the reversed ordering should still update both artifacts.
+    persist_ai_decision(sid, runs_root, 303, 101, second_response)
+
+    base = runs_root / sid / "cases" / "accounts"
+    path_a = base / "101" / "ai" / "decision_pair_101_303.json"
+    path_b = base / "303" / "ai" / "decision_pair_303_101.json"
+
+    saved_a = json.loads(path_a.read_text(encoding="utf-8"))
+    saved_b = json.loads(path_b.read_text(encoding="utf-8"))
+
+    assert saved_a["decision"] == "no_merge"
+    assert saved_b["decision"] == "no_merge"
+
+    expected_tag_a = {
+        "kind": "merge_result",
+        "with": 303,
+        "decision": "no_merge",
+        "confidence": 0.2,
+        "reasons": ["different payment history"],
+        "source": "ai_adjudicator",
+    }
+    expected_tag_b = dict(expected_tag_a)
+    expected_tag_b["with"] = 101
+
+    tags_a_path = base / "101" / "tags.json"
+    tags_b_path = base / "303" / "tags.json"
+
+    tags_a = json.loads(tags_a_path.read_text(encoding="utf-8"))
+    tags_b = json.loads(tags_b_path.read_text(encoding="utf-8"))
+
+    assert tags_a == [expected_tag_a]
+    assert tags_b == [expected_tag_b]
+


### PR DESCRIPTION
## Summary
- add regression test ensuring AI packs are written symmetrically for both account orderings
- add regression test confirming AI decisions overwrite prior artifacts and tags even when the pair order flips

## Testing
- pytest tests/report_analysis/test_ai_pack.py tests/report_analysis/test_tags_update_after_ai.py -q

------
https://chatgpt.com/codex/tasks/task_b_68d038af0d0c8325a4d5231dc2768dab