### PR TITLE
Add merge AI pack builder and CLI script

### DIFF
--- a/backend/core/logic/report_analysis/ai_packs.py
+++ b/backend/core/logic/report_analysis/ai_packs.py
@@ -1,0 +1,508 @@
+"""AI adjudication pack builder for merge V2 flows."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+from backend.core.io.tags import read_tags
+from backend.core.logic.report_analysis.account_merge import get_merge_cfg
+from backend.core.logic.report_analysis.keys import normalize_issuer
+
+
+logger = logging.getLogger(__name__)
+
+
+SYSTEM_PROMPT = (
+    "You are an adjudicator deciding if A & B are the same account.\n"
+    "Consider high-precision cues (account number last4/exact, exact balances with tolerances, dates);"
+    " also consider lender/brand name strings.\n"
+    "Use the numeric summary as a strong hint but override if raw context contradicts it.\n"
+    "Decisions allowed: merge, same_debt, different.\n"
+    "same_debt when details show the same obligation/story (brand, amounts, dates consistent) but identifiers"
+    " differ/are missing (e.g., OC vs CA).\n"
+    "Be conservative when critical fields conflict.\n"
+    "Return strict JSON only: {\"decision\":\"merge|same_debt|different\",\"reason\":\"short natural language\"}."
+)
+
+MAX_CONTEXT_LINE_LENGTH = 240
+
+
+FIELD_ORDER: Sequence[str] = (
+    "Account #",
+    "Balance Owed",
+    "Last Payment",
+    "Past Due Amount",
+    "High Balance",
+    "Creditor Type",
+    "Account Type",
+    "Payment Amount",
+    "Credit Limit",
+    "Last Verified",
+    "Date of Last Activity",
+    "Date Reported",
+    "Date Opened",
+    "Closed Date",
+)
+
+REMARK_PREFIXES: Sequence[str] = ("Creditor Remarks", "Remarks")
+
+SKIP_KEYWORDS: Sequence[str] = (
+    "two-year payment history",
+    "two year payment history",
+    "days late - 7 year history",
+    "days late-7 year history",
+)
+
+HEADER_BUREAU_LINE_RE = re.compile(
+    r"(transunion|experian|equifax).*(transunion|experian|equifax)", re.IGNORECASE
+)
+PAGINATION_RE = re.compile(r"^page\s+\d+\s+of\s+\d+", re.IGNORECASE)
+ACCOUNT_NUMBER_RE = re.compile(r"Account #\s*(.*)", re.IGNORECASE)
+
+LENDER_DROP_TOKENS = {
+    "LLC",
+    "INC",
+    "CORP",
+    "NA",
+    "N A",
+    "BANKCARD",
+    "CARD",
+    "CARDS",
+    "SERV",
+    "SERVICE",
+    "SERVICES",
+    "SVCS",
+    "CACS",
+}
+
+
+@dataclass(frozen=True)
+class _PairTag:
+    source_idx: int
+    kind: str
+    payload: Mapping[str, object]
+
+
+def _coerce_text(entry: object) -> str:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, Mapping):
+        value = entry.get("text")
+        if isinstance(value, str):
+            return value
+        if value is not None:
+            return str(value)
+    if entry is None:
+        return ""
+    return str(entry)
+
+
+def _normalize_line(text: str) -> str:
+    norm = text or ""
+    norm = norm.replace("\u2013", "-").replace("\u2014", "-")
+    norm = re.sub(r"\s+", " ", norm).strip()
+    if len(norm) > MAX_CONTEXT_LINE_LENGTH:
+        norm = norm[: MAX_CONTEXT_LINE_LENGTH - 3].rstrip() + "..."
+    return norm
+
+
+def _is_only_dashes(text: str) -> bool:
+    if not text:
+        return True
+    return re.sub(r"[-\s]", "", text) == ""
+
+
+def _load_raw_lines(path: Path) -> List[object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    raise ValueError(f"raw_lines payload must be a list: {path}")
+
+
+def _normalize_lender_display(raw: str) -> str:
+    issuer = normalize_issuer(raw or "")
+    if not issuer:
+        return ""
+    tokens: List[str] = []
+    for token in issuer.split():
+        adjusted = "BANK" if token == "BK" else token
+        if adjusted in LENDER_DROP_TOKENS:
+            continue
+        tokens.append(adjusted)
+    if not tokens:
+        tokens = issuer.split()
+    normalized = " ".join(tokens)
+    return normalized.strip()
+
+
+def _line_matches_label(line: str, label: str) -> bool:
+    normalized_line = line.lower()
+    normalized_label = label.lower().rstrip(":")
+    return normalized_line.startswith(normalized_label)
+
+
+def _is_skip_line(line: str) -> bool:
+    lowered = line.lower()
+    if any(keyword in lowered for keyword in SKIP_KEYWORDS):
+        return True
+    if PAGINATION_RE.match(lowered):
+        return True
+    if HEADER_BUREAU_LINE_RE.search(line):
+        return True
+    return False
+
+
+def _find_header_line(lines: Sequence[str]) -> str | None:
+    for line in lines:
+        if not line or _is_only_dashes(line):
+            continue
+        if _is_skip_line(line):
+            continue
+        if any(_line_matches_label(line, label) for label in FIELD_ORDER):
+            continue
+        if any(line.lower().startswith(prefix.lower()) for prefix in REMARK_PREFIXES):
+            continue
+        return line
+    return None
+
+
+def _collect_field_lines(lines: Sequence[str]) -> Dict[str, str]:
+    results: Dict[str, str] = {}
+    for line in lines:
+        if not line or _is_only_dashes(line):
+            continue
+        if _is_skip_line(line):
+            continue
+        for label in FIELD_ORDER:
+            if label in results:
+                continue
+            if _line_matches_label(line, label):
+                results[label] = line
+                break
+    return results
+
+
+def _collect_remarks(lines: Sequence[str]) -> List[str]:
+    remarks: List[str] = []
+    for line in lines:
+        if not line or _is_only_dashes(line):
+            continue
+        for prefix in REMARK_PREFIXES:
+            if line.lower().startswith(prefix.lower()):
+                remarks.append(line)
+                break
+    return remarks
+
+
+def _extract_account_number(lines: Iterable[str]) -> str | None:
+    for line in lines:
+        match = ACCOUNT_NUMBER_RE.search(line)
+        if not match:
+            continue
+        tail = match.group(1).strip()
+        if not tail:
+            continue
+        parts = [part.strip(" -:") for part in re.split(r"--", tail)]
+        for part in parts:
+            cleaned = part.strip()
+            if cleaned and not _is_only_dashes(cleaned):
+                return cleaned
+    return None
+
+
+def _build_account_context(lines: Sequence[str], max_lines: int) -> List[str]:
+    limit = max_lines if max_lines and max_lines > 0 else 0
+    if limit <= 0:
+        return []
+
+    header = _find_header_line(lines)
+    context: List[str] = []
+    seen: set[str] = set()
+
+    if header:
+        context.append(header)
+        seen.add(header)
+        normalized = _normalize_lender_display(header)
+        if normalized:
+            normalized_line = f"Lender normalized: {normalized}"
+            if normalized_line not in seen:
+                context.append(normalized_line)
+                seen.add(normalized_line)
+
+    field_lines = _collect_field_lines(lines)
+    for label in FIELD_ORDER:
+        line = field_lines.get(label)
+        if not line:
+            continue
+        if line in seen:
+            continue
+        context.append(line)
+        seen.add(line)
+        if len(context) >= limit:
+            return context[:limit]
+
+    remark_lines = _collect_remarks(lines)
+    for line in remark_lines:
+        if line in seen:
+            continue
+        context.append(line)
+        seen.add(line)
+        if len(context) >= limit:
+            break
+
+    return context[:limit]
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    try:
+        return int(str(value))
+    except Exception:
+        return default
+
+
+def _select_primary_tag(entries: Sequence[_PairTag]) -> Mapping[str, object] | None:
+    if not entries:
+        return None
+    best_entry = None
+    best_score = None
+    for entry in entries:
+        payload = entry.payload
+        total = _safe_int(payload.get("total"))
+        score = (total, 1 if entry.kind == "merge_pair" else 0)
+        if best_score is None or score > best_score:
+            best_entry = entry
+            best_score = score
+    return best_entry.payload if best_entry else None
+
+
+def _build_highlights(tag_payload: Mapping[str, object]) -> Mapping[str, object]:
+    aux = tag_payload.get("aux") if isinstance(tag_payload.get("aux"), Mapping) else {}
+    parts = tag_payload.get("parts") if isinstance(tag_payload.get("parts"), Mapping) else {}
+    conflicts = (
+        list(tag_payload.get("conflicts"))
+        if isinstance(tag_payload.get("conflicts"), Sequence)
+        else []
+    )
+
+    return {
+        "total": _safe_int(tag_payload.get("total")),
+        "strong": bool(tag_payload.get("strong")),
+        "mid_sum": _safe_int(tag_payload.get("mid") or tag_payload.get("mid_sum")),
+        "parts": dict(parts),
+        "matched_fields": dict(aux.get("matched_fields", {})) if isinstance(aux, Mapping) else {},
+        "conflicts": conflicts,
+        "acctnum_level": str(aux.get("acctnum_level", "none")) if isinstance(aux, Mapping) else "none",
+    }
+
+
+def _tolerance_hint() -> Mapping[str, float | int]:
+    cfg = get_merge_cfg()
+    tolerances = cfg.tolerances if isinstance(cfg.tolerances, Mapping) else {}
+
+    def _get_float(key: str, default: float) -> float:
+        raw = tolerances.get(key)
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _get_int(key: str, default: int) -> int:
+        raw = tolerances.get(key)
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return int(default)
+
+    return {
+        "amount_abs_usd": _get_float("AMOUNT_TOL_ABS", 50.0),
+        "amount_ratio": _get_float("AMOUNT_TOL_RATIO", 0.01),
+        "last_payment_day_tol": _get_int("LAST_PAYMENT_DAY_TOL", 7),
+    }
+
+
+def _load_account_payload(
+    accounts_root: Path,
+    account_idx: int,
+    cache: MutableMapping[int, Mapping[str, object]],
+    max_lines: int,
+) -> Mapping[str, object]:
+    if account_idx in cache:
+        return cache[account_idx]
+
+    raw_path = accounts_root / str(account_idx) / "raw_lines.json"
+    if not raw_path.exists():
+        raise FileNotFoundError(f"raw_lines.json not found for account {account_idx}")
+
+    raw_lines = _load_raw_lines(raw_path)
+    normalized_lines = [_normalize_line(_coerce_text(line)) for line in raw_lines]
+    context = _build_account_context(normalized_lines, max_lines)
+    account_number = _extract_account_number(normalized_lines)
+
+    payload = {"context": context, "account_number": account_number, "lines": normalized_lines}
+    cache[account_idx] = payload
+    return payload
+
+
+def _collect_pair_entries(accounts_root: Path) -> tuple[Dict[tuple[int, int], List[_PairTag]], Dict[int, set[int]]]:
+    pair_entries: Dict[tuple[int, int], List[_PairTag]] = {}
+    best_partners: Dict[int, set[int]] = {}
+
+    for entry in sorted(accounts_root.iterdir(), key=lambda item: item.name):
+        if not entry.is_dir():
+            continue
+        try:
+            idx = int(entry.name)
+        except ValueError:
+            continue
+
+        tags_path = entry / "tags.json"
+        tags = read_tags(tags_path)
+        for tag in tags:
+            if not isinstance(tag, Mapping):
+                continue
+            kind = str(tag.get("kind"))
+            decision = str(tag.get("decision", "")).lower()
+            if decision != "ai":
+                continue
+            partner = tag.get("with")
+            try:
+                partner_idx = int(partner)
+            except (TypeError, ValueError):
+                continue
+            pair_key = tuple(sorted((idx, partner_idx)))
+            pair_entries.setdefault(pair_key, []).append(
+                _PairTag(source_idx=idx, kind=kind, payload=tag)
+            )
+            if kind == "merge_best":
+                best_partners.setdefault(idx, set()).add(partner_idx)
+
+    return pair_entries, best_partners
+
+
+def _should_include_pair(
+    pair: tuple[int, int],
+    best_partners: Mapping[int, set[int]],
+    only_merge_best: bool,
+) -> bool:
+    if not only_merge_best:
+        return True
+    a, b = pair
+    best_a = best_partners.get(a, set())
+    best_b = best_partners.get(b, set())
+    return (b in best_a) or (a in best_b)
+
+
+def build_merge_ai_packs(
+    sid: str,
+    runs_root: Path | str,
+    *,
+    only_merge_best: bool = True,
+    max_lines_per_side: int = 20,
+) -> List[Mapping[str, object]]:
+    """Build merge AI packs for ``sid``.
+
+    Parameters
+    ----------
+    sid:
+        The session identifier.
+    runs_root:
+        Root directory containing the ``runs/<sid>`` layout.
+    only_merge_best:
+        When ``True`` include only pairs that appear as ``merge_best`` partners.
+    max_lines_per_side:
+        Maximum number of context lines per account.
+    """
+
+    sid_str = str(sid)
+    runs_root_path = Path(runs_root)
+    accounts_root = runs_root_path / sid_str / "cases" / "accounts"
+
+    if not accounts_root.exists():
+        raise FileNotFoundError(
+            f"cases/accounts directory not found for sid={sid_str!r} under {runs_root_path}"
+        )
+
+    pair_entries, best_partners = _collect_pair_entries(accounts_root)
+    tolerance_hint = _tolerance_hint()
+
+    cache: Dict[int, Mapping[str, object]] = {}
+    packs: List[Mapping[str, object]] = []
+
+    for pair in sorted(pair_entries.keys()):
+        if not _should_include_pair(pair, best_partners, only_merge_best):
+            continue
+
+        entries = pair_entries.get(pair, [])
+        primary_tag = _select_primary_tag(entries)
+        if primary_tag is None:
+            logger.warning("MERGE_V2_PACK_MISSING_TAG sid=%s pair=%s", sid_str, pair)
+            continue
+
+        a_idx, b_idx = pair
+
+        try:
+            account_a = _load_account_payload(accounts_root, a_idx, cache, max_lines_per_side)
+            account_b = _load_account_payload(accounts_root, b_idx, cache, max_lines_per_side)
+        except FileNotFoundError as exc:
+            logger.warning(
+                "MERGE_V2_PACK_MISSING_LINES sid=%s pair=%s error=%s",
+                sid_str,
+                pair,
+                exc,
+            )
+            continue
+
+        context_a = list(account_a.get("context", []))
+        context_b = list(account_b.get("context", []))
+        highlights = _build_highlights(primary_tag)
+
+        ids_payload = {
+            "account_number_a": account_a.get("account_number") or "--",
+            "account_number_b": account_b.get("account_number") or "--",
+        }
+
+        summary = dict(highlights)
+
+        user_payload = {
+            "sid": sid_str,
+            "pair": {"a": a_idx, "b": b_idx},
+            "ids": ids_payload,
+            "numeric_match_summary": summary,
+            "tolerances_hint": dict(tolerance_hint),
+            "limits": {"max_lines_per_side": max_lines_per_side},
+            "context": {"a": context_a, "b": context_b},
+            "output_contract": {
+                "decision": ["merge", "same_debt", "different"],
+                "reason": "short natural language",
+            },
+        }
+
+        pack = {
+            "sid": sid_str,
+            "pair": {"a": a_idx, "b": b_idx},
+            "ids": ids_payload,
+            "highlights": summary,
+            "tolerances_hint": dict(tolerance_hint),
+            "limits": {"max_lines_per_side": max_lines_per_side},
+            "context": {"a": context_a, "b": context_b},
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": json.dumps(user_payload, ensure_ascii=False, sort_keys=True),
+                },
+            ],
+        }
+
+        packs.append(pack)
+
+    return packs
+
+
+__all__ = ["build_merge_ai_packs"]
+

--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -1,0 +1,107 @@
+"""Build AI adjudication packs for merge V2."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:  # pragma: no cover - convenience bootstrap
+    import scripts._bootstrap  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - fallback for direct execution
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from backend.core.logic.report_analysis.ai_packs import build_merge_ai_packs
+from backend.pipeline.runs import RunManifest
+
+
+def _write_pack(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2)
+    path.write_text(serialized + "\n", encoding="utf-8")
+
+
+def _resolve_out_dir(base: Path, sid: str, out_dir_arg: str | None) -> Path:
+    if out_dir_arg:
+        return Path(out_dir_arg)
+    return base / sid / "ai_packs"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sid", required=True, help="Session identifier")
+    parser.add_argument(
+        "--runs-root",
+        default="runs",
+        help="Root directory containing runs/<SID> outputs",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Optional output directory for packs (defaults to runs/<SID>/ai_packs)",
+    )
+    parser.add_argument(
+        "--max-lines-per-side",
+        type=int,
+        default=20,
+        help="Maximum number of context lines per account",
+    )
+    parser.add_argument(
+        "--only-merge-best",
+        dest="only_merge_best",
+        action="store_true",
+        help="Include only pairs marked as merge_best (default)",
+    )
+    parser.add_argument(
+        "--include-all-pairs",
+        dest="only_merge_best",
+        action="store_false",
+        help="Include all AI pairs regardless of merge_best",
+    )
+    parser.set_defaults(only_merge_best=True)
+
+    args = parser.parse_args(argv)
+
+    sid = str(args.sid)
+    runs_root = Path(args.runs_root)
+    out_dir = _resolve_out_dir(runs_root, sid, args.out_dir)
+
+    packs = build_merge_ai_packs(
+        sid,
+        runs_root,
+        only_merge_best=bool(args.only_merge_best),
+        max_lines_per_side=int(args.max_lines_per_side),
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    index: list[dict[str, object]] = []
+    for pack in packs:
+        pair = pack.get("pair") or {}
+        try:
+            a_idx = int(pair.get("a"))
+            b_idx = int(pair.get("b"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Pack is missing pair indices") from exc
+        filename = f"{a_idx:03d}-{b_idx:03d}.json"
+        path = out_dir / filename
+        _write_pack(path, pack)
+        index.append({"a": a_idx, "b": b_idx, "file": str(path.resolve())})
+
+    manifest = RunManifest.for_sid(sid)
+    manifest.set_artifact("ai", "packs_dir", out_dir.resolve())
+    ai_group = manifest.data.setdefault("artifacts", {}).setdefault("ai", {})
+    ai_group["pairs"] = index
+    manifest.save()
+
+    print(f"[BUILD] wrote {len(packs)} packs to {out_dir}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -1,0 +1,155 @@
+import json
+from pathlib import Path
+
+from backend.core.logic.report_analysis.ai_packs import build_merge_ai_packs
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_raw_lines(path: Path, lines: list[str]) -> None:
+    payload = [{"text": text} for text in lines]
+    _write_json(path, payload)
+
+
+def _merge_pair_tag(partner: int) -> dict:
+    return {
+        "tag": "merge_pair",
+        "kind": "merge_pair",
+        "source": "merge_scorer",
+        "with": partner,
+        "decision": "ai",
+        "total": 59,
+        "mid": 20,
+        "dates_all": False,
+        "parts": {"balance_owed": 31, "account_number": 28},
+        "aux": {
+            "acctnum_level": "last4",
+            "matched_fields": {"balance_owed": True, "last_payment": True},
+        },
+        "conflicts": ["credit_limit:conflict"],
+        "strong": True,
+    }
+
+
+def _merge_best_tag(partner: int) -> dict:
+    return {
+        "tag": "merge_best",
+        "kind": "merge_best",
+        "source": "merge_scorer",
+        "with": partner,
+        "decision": "ai",
+        "total": 59,
+        "mid": 20,
+        "parts": {"balance_owed": 31, "account_number": 28},
+        "aux": {
+            "acctnum_level": "last4",
+            "matched_fields": {"balance_owed": True, "last_payment": True},
+        },
+        "conflicts": ["credit_limit:conflict"],
+        "strong": True,
+    }
+
+
+def test_build_merge_ai_packs_curates_context_and_prompt(tmp_path: Path) -> None:
+    sid = "sample-sid"
+    runs_root = tmp_path
+    accounts_root = runs_root / sid / "cases" / "accounts"
+
+    account_a_dir = accounts_root / "11"
+    account_b_dir = accounts_root / "16"
+
+    _write_raw_lines(
+        account_a_dir / "raw_lines.json",
+        [
+            "US BK CACS",
+            "Transunion ® Experian ® Equifax ®",
+            "Account # 409451****** -- 409451******",
+            "Balance Owed: $12,091 -- $12,091",
+            "Two-Year Payment History: 111100001111",
+            "Creditor Remarks: Late due to pandemic",
+        ],
+    )
+
+    _write_raw_lines(
+        account_b_dir / "raw_lines.json",
+        [
+            "U S BANK",
+            "Account # -- 409451******",
+            "Balance Owed: -- $12,091 --",
+            "Past Due Amount: --",
+            "Last Payment: 13.9.2024",
+            "Days Late - 7 Year History: 0000000",
+        ],
+    )
+
+    _write_json(account_a_dir / "tags.json", [_merge_pair_tag(16), _merge_best_tag(16)])
+    _write_json(account_b_dir / "tags.json", [_merge_best_tag(11)])
+
+    packs = build_merge_ai_packs(sid, runs_root, max_lines_per_side=6)
+
+    assert len(packs) == 1
+    pack = packs[0]
+
+    assert pack["pair"] == {"a": 11, "b": 16}
+    context_a = pack["context"]["a"]
+    assert context_a[0] == "US BK CACS"
+    assert context_a[1] == "Lender normalized: US BANK"
+    assert "Two-Year Payment History" not in " ".join(context_a)
+    assert pack["ids"]["account_number_a"] == "409451******"
+    assert pack["ids"]["account_number_b"] == "409451******"
+    assert pack["highlights"]["total"] == 59
+    assert pack["highlights"]["matched_fields"]["balance_owed"] is True
+    assert pack["limits"]["max_lines_per_side"] == 6
+    assert set(pack["tolerances_hint"].keys()) == {
+        "amount_abs_usd",
+        "amount_ratio",
+        "last_payment_day_tol",
+    }
+
+    messages = pack["messages"]
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert "adjudicator" in messages[0]["content"]
+
+    user_payload = json.loads(messages[1]["content"])
+    assert user_payload["pair"] == {"a": 11, "b": 16}
+    assert user_payload["numeric_match_summary"]["total"] == 59
+    assert user_payload["output_contract"]["decision"] == [
+        "merge",
+        "same_debt",
+        "different",
+    ]
+
+
+def test_build_merge_ai_packs_only_merge_best_filter(tmp_path: Path) -> None:
+    sid = "filter-sid"
+    runs_root = tmp_path
+    accounts_root = runs_root / sid / "cases" / "accounts"
+
+    account_a_dir = accounts_root / "21"
+    account_b_dir = accounts_root / "22"
+
+    _write_raw_lines(account_a_dir / "raw_lines.json", ["Creditor A", "Account # 1111"])
+    _write_raw_lines(account_b_dir / "raw_lines.json", ["Creditor B", "Account # 2222"])
+
+    _write_json(account_a_dir / "tags.json", [_merge_pair_tag(22)])
+    _write_json(account_b_dir / "tags.json", [])
+
+    packs_only_best = build_merge_ai_packs(sid, runs_root, max_lines_per_side=3)
+    assert packs_only_best == []
+
+    packs_all = build_merge_ai_packs(
+        sid,
+        runs_root,
+        only_merge_best=False,
+        max_lines_per_side=3,
+    )
+
+    assert len(packs_all) == 1
+    pack = packs_all[0]
+    assert pack["pair"] == {"a": 21, "b": 22}
+    assert len(pack["context"]["a"]) <= 3
+    assert len(pack["context"]["b"]) <= 3


### PR DESCRIPTION
## Summary
- add a merge AI pack builder that curates fresh context, numeric highlights, and prompt/contract payloads
- provide a CLI helper to materialize packs, mirror them under runs/<sid>, and update the run manifest
- add tests covering context extraction and merge_best filtering behavior

## Testing
- pytest tests/report_analysis/test_ai_packs_builder.py
- pytest tests/report_analysis/test_ai_pack.py

------
https://chatgpt.com/codex/tasks/task_b_68d0471eb9b483259774b754b7bf3131