### PR TITLE
Add AI merge pack sender with retries and tagging

### DIFF
--- a/backend/core/logic/report_analysis/ai_sender.py
+++ b/backend/core/logic/report_analysis/ai_sender.py
@@ -1,0 +1,390 @@
+"""Send merge adjudication packs to the AI adjudicator service."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import httpx
+
+from backend.core.io.tags import upsert_tag
+
+
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_TIMEOUT = 30.0
+
+# Retry configuration – one initial attempt plus three retries using this schedule.
+RETRY_BACKOFF_SECONDS: Sequence[float] = (1.0, 3.0, 7.0)
+MAX_RETRIES = len(RETRY_BACKOFF_SECONDS)
+
+ALLOWED_DECISIONS = {"merge", "same_debt", "different"}
+
+
+@dataclass(frozen=True)
+class AISenderConfig:
+    """Configuration required to contact the chat completion API."""
+
+    base_url: str
+    api_key: str
+    model: str
+    timeout: float
+
+
+@dataclass
+class SendOutcome:
+    """Result of attempting to adjudicate a single pack."""
+
+    success: bool
+    attempts: int
+    decision: str | None = None
+    reason: str | None = None
+    error_kind: str | None = None
+    error_message: str | None = None
+
+
+def _bool_from_env(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def is_enabled() -> bool:
+    """Return whether AI adjudication is enabled via configuration."""
+
+    env_value = os.getenv("ENABLE_AI_ADJUDICATOR")
+    enabled = _bool_from_env(env_value, default=False)
+    if env_value is not None:
+        return enabled
+
+    try:  # pragma: no cover - defensive fallback when module is absent
+        import backend.config as backend_config  # type: ignore
+
+        return bool(getattr(backend_config, "ENABLE_AI_ADJUDICATOR", False))
+    except Exception:  # pragma: no cover - optional dependency
+        return False
+
+
+def _coerce_positive_float(raw: str | None, default: float) -> float:
+    if raw is None:
+        return default
+    try:
+        value = float(str(raw).strip())
+    except Exception:
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+def load_config_from_env() -> AISenderConfig:
+    """Build :class:`AISenderConfig` from environment variables."""
+
+    base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is required when sending AI merge packs")
+
+    model = os.getenv("AI_MODEL", DEFAULT_MODEL).strip() or DEFAULT_MODEL
+    timeout = _coerce_positive_float(os.getenv("AI_REQUEST_TIMEOUT"), DEFAULT_TIMEOUT)
+
+    return AISenderConfig(base_url=base_url, api_key=api_key, model=model, timeout=timeout)
+
+
+def _format_url(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/chat/completions"
+
+
+def _default_http_request(
+    url: str,
+    payload: Mapping[str, Any],
+    headers: Mapping[str, str],
+    timeout: float,
+) -> httpx.Response:
+    return httpx.post(url, json=dict(payload), headers=dict(headers), timeout=timeout)
+
+
+def _strip_code_fences(text: str) -> str:
+    trimmed = text.strip()
+    if not trimmed.startswith("```"):
+        return trimmed
+
+    lines = [line for line in trimmed.splitlines()]
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _parse_model_payload(content: str) -> MutableMapping[str, Any]:
+    try:
+        data = json.loads(_strip_code_fences(content))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Model response must be valid JSON") from exc
+    if not isinstance(data, MutableMapping):
+        raise ValueError("Model response JSON must be an object")
+    return data
+
+
+def _sanitize_decision(payload: Mapping[str, Any]) -> tuple[str, str]:
+    raw_decision = payload.get("decision")
+    decision = str(raw_decision).strip().lower()
+    if decision not in ALLOWED_DECISIONS:
+        raise ValueError(f"Unsupported decision: {raw_decision!r}")
+
+    reason_raw = payload.get("reason")
+    if reason_raw is None:
+        raise ValueError("Model response missing reason")
+    reason = str(reason_raw).strip()
+    if not reason:
+        raise ValueError("Model response reason must be non-empty")
+
+    return decision, reason
+
+
+def send_single_attempt(
+    pack: Mapping[str, Any],
+    config: AISenderConfig,
+    *,
+    request: Callable[[str, Mapping[str, Any], Mapping[str, str], float], httpx.Response] | None = None,
+) -> tuple[str, str]:
+    """Send ``pack`` once and return the decision and reason."""
+
+    messages = pack.get("messages")
+    if not isinstance(messages, Sequence):
+        raise ValueError("Pack is missing messages payload")
+
+    url = _format_url(config.base_url)
+    payload = {
+        "model": config.model,
+        "messages": list(messages),
+        "temperature": 0.0,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {
+        "Authorization": f"Bearer {config.api_key}",
+        "Content-Type": "application/json",
+    }
+
+    sender = request or _default_http_request
+    response = sender(url, payload, headers, config.timeout)
+    response.raise_for_status()
+    data = response.json()
+    choices = data.get("choices") if isinstance(data, Mapping) else None
+    if not choices:
+        raise ValueError("Model response missing choices")
+    message = choices[0].get("message") if isinstance(choices[0], Mapping) else None
+    if not isinstance(message, Mapping):
+        raise ValueError("Model response missing message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("Model response missing textual content")
+
+    parsed = _parse_model_payload(content)
+    return _sanitize_decision(parsed)
+
+
+LogCallback = Callable[[str, Mapping[str, Any]], None]
+
+
+def process_pack(
+    pack: Mapping[str, Any],
+    config: AISenderConfig,
+    *,
+    request: Callable[[str, Mapping[str, Any], Mapping[str, str], float], httpx.Response] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    log: LogCallback | None = None,
+) -> SendOutcome:
+    """Attempt to adjudicate ``pack`` using retry logic."""
+
+    attempts = 0
+    last_error: Exception | None = None
+    max_attempts = 1 + MAX_RETRIES
+
+    while attempts < max_attempts:
+        attempts += 1
+        if log is not None:
+            log(
+                "ATTEMPT",
+                {
+                    "attempt": attempts,
+                    "max_attempts": max_attempts,
+                },
+            )
+
+        try:
+            decision, reason = send_single_attempt(pack, config, request=request)
+            if log is not None:
+                log(
+                    "SUCCESS",
+                    {
+                        "attempt": attempts,
+                        "decision": decision,
+                    },
+                )
+            return SendOutcome(success=True, attempts=attempts, decision=decision, reason=reason)
+        except Exception as exc:  # pragma: no cover - diverse error sources
+            last_error = exc
+            if log is not None:
+                log(
+                    "ERROR",
+                    {
+                        "attempt": attempts,
+                        "error": exc.__class__.__name__,
+                    },
+                )
+
+            if attempts > MAX_RETRIES:
+                break
+
+            delay = RETRY_BACKOFF_SECONDS[min(attempts - 1, len(RETRY_BACKOFF_SECONDS) - 1)]
+            if log is not None:
+                log(
+                    "RETRY",
+                    {
+                        "attempt": attempts,
+                        "delay_seconds": delay,
+                    },
+                )
+            sleep(delay)
+
+    error_kind = last_error.__class__.__name__ if last_error is not None else "UnknownError"
+    error_message = str(last_error) if last_error is not None else "unknown"
+    if log is not None:
+        log(
+            "FAILURE",
+            {
+                "attempt": attempts,
+                "error": error_kind,
+            },
+        )
+    return SendOutcome(
+        success=False,
+        attempts=attempts,
+        decision=None,
+        reason=None,
+        error_kind=error_kind,
+        error_message=error_message,
+    )
+
+
+def isoformat_timestamp(dt: datetime | None = None) -> str:
+    """Return a UTC ISO-8601 timestamp without fractional seconds."""
+
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _account_tags_dir(runs_root: os.PathLike[str] | str, sid: str) -> str:
+    base = os.fspath(runs_root)
+    return os.path.join(base, sid, "cases", "accounts")
+
+
+def _ensure_int(value: Any, label: str) -> int:
+    try:
+        return int(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(f"{label} must be an integer") from exc
+
+
+def write_decision_tags(
+    runs_root: os.PathLike[str] | str,
+    sid: str,
+    a_idx: Any,
+    b_idx: Any,
+    decision: str,
+    reason: str,
+    at: str,
+) -> None:
+    """Write symmetric ai_decision (and optional same_debt) tags for the pair."""
+
+    account_a = _ensure_int(a_idx, "a_idx")
+    account_b = _ensure_int(b_idx, "b_idx")
+
+    base = _account_tags_dir(runs_root, sid)
+
+    def _tag_payload(source: int, other: int) -> dict[str, Any]:
+        return {
+            "kind": "ai_decision",
+            "tag": "ai_decision",
+            "source": "ai_adjudicator",
+            "with": other,
+            "decision": decision,
+            "reason": reason,
+            "at": at,
+        }
+
+    for source_idx, other_idx in ((account_a, account_b), (account_b, account_a)):
+        tag_path = os.path.join(base, str(source_idx), "tags.json")
+        upsert_tag(tag_path, _tag_payload(source_idx, other_idx), ("kind", "with", "source"))
+        if decision == "same_debt":
+            same_debt_tag = {
+                "kind": "same_debt_pair",
+                "with": other_idx,
+                "source": "ai_adjudicator",
+                "at": at,
+            }
+            upsert_tag(tag_path, same_debt_tag, ("kind", "with", "source"))
+
+
+def write_error_tags(
+    runs_root: os.PathLike[str] | str,
+    sid: str,
+    a_idx: Any,
+    b_idx: Any,
+    error_kind: str,
+    message: str,
+    at: str,
+) -> None:
+    """Write symmetric ai_error tags for the pair."""
+
+    account_a = _ensure_int(a_idx, "a_idx")
+    account_b = _ensure_int(b_idx, "b_idx")
+
+    base = _account_tags_dir(runs_root, sid)
+
+    def _payload(other: int) -> dict[str, Any]:
+        return {
+            "kind": "ai_error",
+            "with": other,
+            "source": "ai_adjudicator",
+            "error_kind": error_kind,
+            "message": message,
+            "at": at,
+        }
+
+    for source_idx, other_idx in ((account_a, account_b), (account_b, account_a)):
+        tag_path = os.path.join(base, str(source_idx), "tags.json")
+        upsert_tag(tag_path, _payload(other_idx), ("kind", "with", "source"))
+
+
+__all__ = [
+    "AISenderConfig",
+    "SendOutcome",
+    "ALLOWED_DECISIONS",
+    "RETRY_BACKOFF_SECONDS",
+    "MAX_RETRIES",
+    "is_enabled",
+    "load_config_from_env",
+    "send_single_attempt",
+    "process_pack",
+    "isoformat_timestamp",
+    "write_decision_tags",
+    "write_error_tags",
+]
+

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -1,0 +1,172 @@
+"""Send merge V2 AI packs to the adjudicator service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:  # pragma: no cover - convenience bootstrap for direct execution
+    import scripts._bootstrap  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - fallback when bootstrap is unavailable
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from backend.core.logic.report_analysis import ai_sender
+from backend.pipeline.runs import RunManifest, persist_manifest
+
+
+def _load_index(path: Path) -> list[Mapping[str, object]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"Pack index must be a list: {path}")
+    return [dict(entry) for entry in data]
+
+
+def _load_pack(path: Path) -> Mapping[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError(f"AI pack must be a JSON object: {path}")
+    return data
+
+
+def _resolve_packs_dir(runs_root: Path, sid: str, override: str | None) -> Path:
+    if override:
+        return Path(override)
+    return runs_root / sid / "ai_packs"
+
+
+def _append_log(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+
+
+def _log_factory(path: Path, sid: str, pair: Mapping[str, int], file_name: str):
+    def _log(event: str, payload: Mapping[str, object] | None = None) -> None:
+        extras: dict[str, object] = {
+            "sid": sid,
+            "pair": {"a": pair["a"], "b": pair["b"]},
+            "file": file_name,
+        }
+        if payload:
+            extras.update(payload)
+        serialized = json.dumps(extras, ensure_ascii=False, sort_keys=True)
+        line = f"{ai_sender.isoformat_timestamp()} AI_ADJUDICATOR_{event} {serialized}\n"
+        _append_log(path, line)
+
+    return _log
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sid", required=True, help="Session identifier")
+    parser.add_argument(
+        "--runs-root",
+        default="runs",
+        help="Root directory containing runs/<SID> outputs",
+    )
+    parser.add_argument(
+        "--packs-dir",
+        default=None,
+        help="Optional override for the directory containing ai packs",
+    )
+    args = parser.parse_args(argv)
+
+    if not ai_sender.is_enabled():
+        print("[AI] adjudicator disabled; skipping")
+        return
+
+    config = ai_sender.load_config_from_env()
+
+    sid = str(args.sid)
+    runs_root = Path(args.runs_root)
+    packs_dir = _resolve_packs_dir(runs_root, sid, args.packs_dir)
+    index_path = packs_dir / "index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Pack index not found: {index_path}")
+
+    index = _load_index(index_path)
+    logs_path = packs_dir / "logs.txt"
+
+    manifest = RunManifest.for_sid(sid)
+    persist_manifest(
+        manifest,
+        artifacts={
+            "ai": {
+                "packs_dir": packs_dir,
+                "packs_index": index_path,
+                "logs": logs_path,
+            }
+        },
+    )
+
+    total = 0
+    successes = 0
+    failures = 0
+
+    for entry in index:
+        if "a" not in entry or "b" not in entry or "file" not in entry:
+            raise ValueError(f"Invalid pack index entry: {entry}")
+        a_idx = int(entry["a"])
+        b_idx = int(entry["b"])
+        pack_path = packs_dir / str(entry["file"])
+        if not pack_path.exists():
+            raise FileNotFoundError(f"Pack file missing: {pack_path}")
+
+        pack = _load_pack(pack_path)
+        total += 1
+
+        log = _log_factory(logs_path, sid, {"a": a_idx, "b": b_idx}, pack_path.name)
+        log("PACK_START", {})
+
+        outcome = ai_sender.process_pack(pack, config, log=log)
+        timestamp = ai_sender.isoformat_timestamp()
+
+        if outcome.success and outcome.decision and outcome.reason:
+            ai_sender.write_decision_tags(
+                runs_root,
+                sid,
+                a_idx,
+                b_idx,
+                outcome.decision,
+                outcome.reason,
+                timestamp,
+            )
+            log(
+                "PACK_SUCCESS",
+                {"decision": outcome.decision, "reason": outcome.reason},
+            )
+            successes += 1
+        else:
+            ai_sender.write_error_tags(
+                runs_root,
+                sid,
+                a_idx,
+                b_idx,
+                outcome.error_kind or "Error",
+                outcome.error_message or "",
+                timestamp,
+            )
+            log(
+                "PACK_FAILURE",
+                {
+                    "error_kind": outcome.error_kind or "Error",
+                },
+            )
+            failures += 1
+
+    print(
+        "[AI] adjudicated {total} packs ({successes} success, {failures} errors)".format(
+            total=total, successes=successes, failures=failures
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/tests/report_analysis/test_ai_sender.py
+++ b/tests/report_analysis/test_ai_sender.py
@@ -1,0 +1,218 @@
+import json
+from pathlib import Path
+
+import httpx
+
+from backend.core.logic.report_analysis import ai_sender
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _sample_pack() -> dict:
+    return {
+        "messages": [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user"},
+        ]
+    }
+
+
+def _config() -> ai_sender.AISenderConfig:
+    return ai_sender.AISenderConfig(
+        base_url="https://example.test/v1",
+        api_key="key-123",
+        model="gpt-test",
+        timeout=12.0,
+    )
+
+
+def test_send_single_attempt_success() -> None:
+    captured: dict[str, object] = {}
+
+    def _request(url, payload, headers, timeout):
+        captured["url"] = url
+        captured["payload"] = payload
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {"decision": "merge", "reason": "strong match"}
+                            )
+                        }
+                    }
+                ]
+            }
+        )
+
+    decision, reason = ai_sender.send_single_attempt(
+        _sample_pack(),
+        _config(),
+        request=_request,
+    )
+
+    assert decision == "merge"
+    assert reason == "strong match"
+    assert captured["url"] == "https://example.test/v1/chat/completions"
+    assert captured["headers"] == {
+        "Authorization": "Bearer key-123",
+        "Content-Type": "application/json",
+    }
+    assert captured["payload"]["model"] == "gpt-test"
+    assert captured["payload"]["response_format"] == {"type": "json_object"}
+    assert captured["timeout"] == 12.0
+
+
+def test_process_pack_retries_then_success(monkeypatch) -> None:
+    attempts = {"count": 0}
+    delays: list[float] = []
+    events: list[tuple[str, dict]] = []
+
+    def _request(url, payload, headers, timeout):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise httpx.HTTPError("temporary failure")
+        return _FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {"decision": "same_debt", "reason": "oc vs ca"}
+                            )
+                        }
+                    }
+                ]
+            }
+        )
+
+    outcome = ai_sender.process_pack(
+        _sample_pack(),
+        _config(),
+        request=_request,
+        sleep=delays.append,
+        log=lambda event, payload: events.append((event, dict(payload))),
+    )
+
+    assert outcome.success is True
+    assert outcome.decision == "same_debt"
+    assert outcome.reason == "oc vs ca"
+    assert outcome.attempts == 3
+    assert delays == [1.0, 3.0]
+    assert any(event == "SUCCESS" for event, _ in events)
+
+
+def test_process_pack_failure_records_error() -> None:
+    delays: list[float] = []
+
+    def _request(url, payload, headers, timeout):
+        raise httpx.ReadTimeout("timed out")
+
+    outcome = ai_sender.process_pack(
+        _sample_pack(),
+        _config(),
+        request=_request,
+        sleep=delays.append,
+        log=lambda event, payload: None,
+    )
+
+    assert outcome.success is False
+    assert outcome.error_kind == "ReadTimeout"
+    assert outcome.attempts == 4
+    assert delays == [1.0, 3.0, 7.0]
+
+
+def test_write_decision_tags_same_debt(tmp_path: Path) -> None:
+    ai_sender.write_decision_tags(
+        tmp_path,
+        "case-001",
+        11,
+        16,
+        "same_debt",
+        "matching oc and ca",
+        "2024-06-01T00:00:00Z",
+    )
+
+    base = tmp_path / "case-001" / "cases" / "accounts"
+    tags_a = json.loads((base / "11" / "tags.json").read_text(encoding="utf-8"))
+    tags_b = json.loads((base / "16" / "tags.json").read_text(encoding="utf-8"))
+
+    assert tags_a == [
+        {
+            "at": "2024-06-01T00:00:00Z",
+            "decision": "same_debt",
+            "kind": "ai_decision",
+            "reason": "matching oc and ca",
+            "source": "ai_adjudicator",
+            "tag": "ai_decision",
+            "with": 16,
+        },
+        {
+            "at": "2024-06-01T00:00:00Z",
+            "kind": "same_debt_pair",
+            "source": "ai_adjudicator",
+            "with": 16,
+        },
+    ]
+    assert tags_b == [
+        {
+            "at": "2024-06-01T00:00:00Z",
+            "decision": "same_debt",
+            "kind": "ai_decision",
+            "reason": "matching oc and ca",
+            "source": "ai_adjudicator",
+            "tag": "ai_decision",
+            "with": 11,
+        },
+        {
+            "at": "2024-06-01T00:00:00Z",
+            "kind": "same_debt_pair",
+            "source": "ai_adjudicator",
+            "with": 11,
+        },
+    ]
+
+
+def test_write_error_tags(tmp_path: Path) -> None:
+    ai_sender.write_error_tags(
+        tmp_path,
+        "case-002",
+        21,
+        22,
+        "Timeout",
+        "deadline exceeded",
+        "2024-06-01T01:00:00Z",
+    )
+
+    base = tmp_path / "case-002" / "cases" / "accounts"
+    tags_a = json.loads((base / "21" / "tags.json").read_text(encoding="utf-8"))
+    tags_b = json.loads((base / "22" / "tags.json").read_text(encoding="utf-8"))
+
+    expected = {
+        "at": "2024-06-01T01:00:00Z",
+        "error_kind": "Timeout",
+        "kind": "ai_error",
+        "message": "deadline exceeded",
+        "source": "ai_adjudicator",
+    }
+
+    expected_a = dict(expected)
+    expected_a["with"] = 22
+    expected_b = dict(expected)
+    expected_b["with"] = 21
+
+    assert tags_a == [expected_a]
+    assert tags_b == [expected_b]
+


### PR DESCRIPTION
## Summary
- add an ai_sender helper that performs chat completions with retries, strict response validation, and tag writers
- add a CLI to iterate merge V2 packs, log adjudicator attempts, and write ai_decision/ai_error tags symmetrically
- cover the new logic with targeted tests for retries, parsing, and tag persistence

## Testing
- pytest tests/report_analysis/test_ai_sender.py
- pytest tests/report_analysis/test_ai_adjudicator.py

------
https://chatgpt.com/codex/tasks/task_b_68d04ba313888325888787c042ad74d9