### PR TITLE
Implement atomic tag upserts and dedupe

### DIFF
--- a/backend/core/io/tags.py
+++ b/backend/core/io/tags.py
@@ -4,17 +4,37 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
+from collections.abc import Mapping as MappingABC
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Mapping, Sequence, Tuple
 
 
-def read_tags(path: os.PathLike | str) -> List[dict]:
-    """Read tags from ``path``.
+_TAG_FILENAME = "tags.json"
+
+
+def _resolve_tags_path(account_dir: os.PathLike | str) -> Path:
+    """Return the canonical path to ``tags.json`` for ``account_dir``."""
+
+    path = Path(account_dir)
+    if path.suffix:  # already a file path such as ``.../tags.json``
+        return path
+    return path / _TAG_FILENAME
+
+
+def _ensure_mapping(tag: object, *, location: Path) -> dict[str, object]:
+    if not isinstance(tag, MappingABC):
+        raise ValueError(f"Expected mapping tag entry in {location}")
+    return dict(tag)
+
+
+def read_tags(account_dir: os.PathLike | str) -> List[dict[str, object]]:
+    """Read tags for an account directory.
 
     Returns an empty list when the file does not exist.
     """
 
-    tag_path = Path(path)
+    tag_path = _resolve_tags_path(account_dir)
     if not tag_path.exists():
         return []
 
@@ -27,49 +47,87 @@ def read_tags(path: os.PathLike | str) -> List[dict]:
     if not isinstance(data, list):
         raise ValueError(f"Expected list in tags file: {tag_path}")
 
-    return data
+    return [
+        _ensure_mapping(entry, location=tag_path) for entry in data
+    ]
 
 
-def upsert_tag(path: os.PathLike | str, tag: dict, key_fields: Sequence[str]) -> None:
-    """Insert or update ``tag`` at ``path`` keyed by ``key_fields``.
+def write_tags_atomic(account_dir: os.PathLike | str, tags: Iterable[Mapping[str, object]]) -> None:
+    """Write ``tags`` for ``account_dir`` using an atomic replace."""
 
-    When an existing tag shares the same key values, it is replaced with the new
-    ``tag`` payload. Otherwise the tag is appended. The write is performed
-    atomically.
-    """
-
-    tags = read_tags(path)
-
-    def matches(candidate: dict) -> bool:
-        return all(candidate.get(field) == tag.get(field) for field in key_fields)
-
-    updated = False
-    for index, existing in enumerate(tags):
-        if matches(existing):
-            tags[index] = tag
-            updated = True
-            break
-
-    if not updated:
-        tags.append(tag)
-
-    write_tags(path, tags)
-
-
-def write_tags(path: os.PathLike | str, tags: Iterable[dict]) -> None:
-    """Write ``tags`` to ``path`` atomically."""
-
-    tag_path = Path(path)
+    tag_path = _resolve_tags_path(account_dir)
     tag_path.parent.mkdir(parents=True, exist_ok=True)
 
-    temp_path = tag_path.with_suffix(tag_path.suffix + ".tmp")
+    serializable = [dict(tag) for tag in tags]
 
-    # Ensure deterministic output for re-runs.
-    data = list(tags)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=str(tag_path.parent), delete=False
+        ) as temp_file:
+            json.dump(
+                serializable,
+                temp_file,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            temp_path = Path(temp_file.name)
 
-    with temp_path.open("w", encoding="utf-8") as file:
-        json.dump(data, file, ensure_ascii=False, indent=2, sort_keys=True)
-        file.flush()
-        os.fsync(file.fileno())
+        if temp_path is None:  # pragma: no cover - defensive
+            raise RuntimeError("Temporary tags path was not created")
 
-    os.replace(temp_path, tag_path)
+        os.replace(temp_path, tag_path)
+    except Exception:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def _build_key(tag: Mapping[str, object], key_fields: Sequence[str]) -> Tuple[object, ...]:
+    return tuple(tag.get(field) for field in key_fields)
+
+
+def upsert_tag(
+    account_dir: os.PathLike | str,
+    new_tag: Mapping[str, object],
+    key_fields: Sequence[str] = ("kind", "with", "source"),
+) -> None:
+    """Upsert ``new_tag`` keyed by ``key_fields`` without introducing duplicates."""
+
+    if not isinstance(new_tag, MappingABC):
+        raise TypeError("new_tag must be a mapping")
+
+    tags = read_tags(account_dir)
+    tag_path = _resolve_tags_path(account_dir)
+
+    unique: list[dict[str, object]] = []
+    index_by_key: dict[Tuple[object, ...], int] = {}
+
+    for entry in tags:
+        mapping = _ensure_mapping(entry, location=tag_path)
+        key = _build_key(mapping, key_fields)
+        if key in index_by_key:
+            existing = unique[index_by_key[key]].copy()
+            existing.update(mapping)
+            unique[index_by_key[key]] = existing
+        else:
+            index_by_key[key] = len(unique)
+            unique.append(dict(mapping))
+
+    new_key = _build_key(new_tag, key_fields)
+    if new_key in index_by_key:
+        idx = index_by_key[new_key]
+        merged = unique[idx].copy()
+        merged.update(new_tag)
+        unique[idx] = merged
+    else:
+        index_by_key[new_key] = len(unique)
+        unique.append(dict(new_tag))
+
+    write_tags_atomic(account_dir, unique)

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -12,7 +12,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
-from backend.core.io.tags import read_tags, upsert_tag, write_tags
+from backend.core.io.tags import read_tags, upsert_tag, write_tags_atomic
 from backend.core.logic.report_analysis.ai_pack import build_ai_pack_for_pair
 from backend.core.logic.report_analysis import config as merge_config
 
@@ -1400,7 +1400,7 @@ def persist_merge_tags(
         existing_tags = read_tags(path)
         filtered = [tag for tag in existing_tags if tag.get("kind") not in merge_kinds]
         if filtered != existing_tags:
-            write_tags(path, filtered)
+            write_tags_atomic(path, filtered)
 
     valid_decisions = {"ai", "auto"}
     processed_pairs: Set[Tuple[int, int]] = set()

--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
 from backend.pipeline.runs import RunManifest, write_breadcrumb
-from backend.core.io.tags import read_tags, upsert_tag, write_tags
+from backend.core.io.tags import read_tags, upsert_tag, write_tags_atomic
 from backend.core.logic.report_analysis.problem_extractor import (
     build_rule_fields_from_triad,
     load_stagea_accounts_from_manifest,
@@ -572,7 +572,7 @@ def _build_problem_cases_lean(
             tag for tag in existing_tags if tag.get("kind") not in merge_kinds
         ]
         if filtered_tags != existing_tags:
-            write_tags(path, filtered_tags)
+            write_tags_atomic(path, filtered_tags)
 
     valid_decisions = {"ai", "auto"}
     for left, right in gen_unordered_pairs(written_indices):

--- a/tests/backend/core/io/test_tags.py
+++ b/tests/backend/core/io/test_tags.py
@@ -1,24 +1,86 @@
-from backend.core.io.tags import read_tags, upsert_tag
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from backend.core.io.tags import read_tags, upsert_tag, write_tags_atomic
 
 
-def test_upsert_tag_is_idempotent(tmp_path):
-    path = tmp_path / "tags.json"
-    tag = {"kind": "merge_pair", "with": "acct-123", "score": 87}
-
-    upsert_tag(path, tag, ["kind", "with"])
-    upsert_tag(path, tag, ["kind", "with"])
-
-    tags = read_tags(path)
-    assert tags == [tag]
+def _account_dir(tmp_path: Path) -> Path:
+    account_dir = tmp_path / "accounts" / "123"
+    account_dir.mkdir(parents=True, exist_ok=True)
+    return account_dir
 
 
-def test_upsert_tag_updates_existing_entry(tmp_path):
-    path = tmp_path / "tags.json"
-    original = {"kind": "merge_pair", "with": "acct-456", "score": 50}
-    updated = {"kind": "merge_pair", "with": "acct-456", "score": 92}
+def test_upsert_tag_updates_without_duplicates(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    initial = {
+        "kind": "merge_pair",
+        "with": 42,
+        "source": "merge_scorer",
+        "score": 87,
+    }
 
-    upsert_tag(path, original, ["kind", "with"])
-    upsert_tag(path, updated, ["kind", "with"])
+    upsert_tag(account_dir, initial, ("kind", "with"))
 
-    tags = read_tags(path)
-    assert tags == [updated]
+    update_payload = {
+        "kind": "merge_pair",
+        "with": 42,
+        "source": "merge_scorer",
+        "decision": "ai",
+        "reason": "new_context",
+    }
+
+    upsert_tag(account_dir, update_payload, ("kind", "with"))
+
+    tags = read_tags(account_dir)
+    assert len(tags) == 1
+    result = tags[0]
+    assert result["decision"] == "ai"
+    assert result["reason"] == "new_context"
+    # ``score`` should persist even though it was not in the update payload.
+    assert result["score"] == 87
+
+
+def test_upsert_tag_collapses_existing_duplicates(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    duplicate_key = {"kind": "ai_decision", "with": 7, "source": "ai"}
+    write_tags_atomic(
+        account_dir,
+        [
+            {**duplicate_key, "decision": "merge", "reason": "first"},
+            {**duplicate_key, "reason": "second"},
+        ],
+    )
+
+    upsert_tag(
+        account_dir,
+        {**duplicate_key, "decision": "different", "at": "2024-06-01T00:00:00Z"},
+    )
+
+    tags = read_tags(account_dir)
+    assert len(tags) == 1
+    entry = tags[0]
+    assert entry["decision"] == "different"
+    assert entry["reason"] == "second"
+    assert entry["at"] == "2024-06-01T00:00:00Z"
+
+
+def test_write_tags_atomic_replaces_file(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    tags_path = account_dir / "tags.json"
+    tags_path.write_text(json.dumps([{"kind": "initial"}]), encoding="utf-8")
+    original_stat = tags_path.stat()
+
+    write_tags_atomic(account_dir, [{"kind": "updated"}])
+
+    new_stat = tags_path.stat()
+    assert original_stat.st_ino != new_stat.st_ino
+    assert read_tags(account_dir) == [{"kind": "updated"}]
+
+    # Ensure the temporary file was removed.
+    leftovers = [
+        name for name in os.listdir(account_dir) if name.startswith("tmp") or name.endswith(".tmp")
+    ]
+    assert leftovers == []


### PR DESCRIPTION
## Summary
- add helpers in the tags IO module to resolve tag file paths, atomically rewrite tag files, and merge duplicate entries during upsert
- switch merge-related pipelines to the new atomic writer when pruning stale merge tags
- expand unit tests to cover deduplication behaviour and atomic replacement of tags.json

## Testing
- pytest tests/backend/core/io/test_tags.py tests/io/test_tags_idempotent.py

------
https://chatgpt.com/codex/tasks/task_b_68d05070798c8325a567d2481eafe3c9