### PR TITLE
Standardize merge v2 and AI adjudicator logging markers

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -756,7 +756,7 @@ def score_all_pairs_0_100(
         try:
             idx_val = int(raw_idx)
         except (TypeError, ValueError):
-            logger.warning("MERGE_SCORE sid=<%s> invalid_index=%r", sid, raw_idx)
+            logger.warning("MERGE_V2_SCORE sid=<%s> invalid_index=%r", sid, raw_idx)
             continue
         requested_indices.append(idx_val)
 
@@ -772,13 +772,13 @@ def score_all_pairs_0_100(
                 idx_val = int(entry.name)
             except (TypeError, ValueError):
                 logger.debug(
-                    "MERGE_SCORE sid=<%s> skip_account_dir=%r", sid, entry.name
+                    "MERGE_V2_SCORE sid=<%s> skip_account_dir=%r", sid, entry.name
                 )
                 continue
             discovered_indices.append(idx_val)
     else:
         logger.warning(
-            "MERGE_SCORE sid=<%s> accounts_dir_missing path=%s",
+            "MERGE_V2_SCORE sid=<%s> accounts_dir_missing path=%s",
             sid,
             accounts_root,
         )
@@ -789,7 +789,7 @@ def score_all_pairs_0_100(
             missing = requested_set - set(indices)
             if missing:
                 logger.debug(
-                    "MERGE_SCORE sid=<%s> missing_requested_indices=%s",
+                    "MERGE_V2_SCORE sid=<%s> missing_requested_indices=%s",
                     sid,
                     sorted(missing),
                 )
@@ -815,12 +815,12 @@ def score_all_pairs_0_100(
             bureaus = load_bureaus(sid, idx, runs_root=runs_root)
         except FileNotFoundError:
             logger.warning(
-                "MERGE_SCORE sid=<%s> idx=<%s> bureaus_missing", sid, idx
+                "MERGE_V2_SCORE sid=<%s> idx=<%s> bureaus_missing", sid, idx
             )
             bureaus = {}
         except Exception:
             logger.exception(
-                "MERGE_SCORE sid=<%s> idx=<%s> bureaus_load_failed", sid, idx
+                "MERGE_V2_SCORE sid=<%s> idx=<%s> bureaus_load_failed", sid, idx
             )
             bureaus = {}
         bureaus_by_idx[idx] = bureaus
@@ -862,15 +862,8 @@ def score_all_pairs_0_100(
                 "matched_pairs": aux_payload.get("by_field_pairs", {}),
                 "matched_fields": aux_payload.get("matched_fields", {}),
             }
-            logger.info("MERGE_SCORE %s", json.dumps(score_log, sort_keys=True))
-            compact_score = {
-                "sid": sid,
-                "i": left,
-                "j": right,
-                "total": total_score,
-                "decision": str(result.get("decision", "different")),
-            }
-            logger.info("MERGE_V2_SCORE %s", json.dumps(compact_score, sort_keys=True))
+            score_log["decision"] = str(result.get("decision", "different"))
+            logger.info("MERGE_V2_SCORE %s", json.dumps(score_log, sort_keys=True))
 
             for event in result.get("trigger_events", []) or []:
                 if not isinstance(event, Mapping):
@@ -883,12 +876,10 @@ def score_all_pairs_0_100(
                     "kind": kind,
                     "details": event.get("details", {}),
                 }
-                logger.info("MERGE_TRIGGER %s", json.dumps(trigger_log, sort_keys=True))
-                if kind in {"strong", "mid", "dates", "total"}:
-                    logger.info(
-                        "MERGE_V2_TRIGGER %s",
-                        json.dumps(trigger_log, sort_keys=True),
-                    )
+                logger.info(
+                    "MERGE_V2_TRIGGER %s",
+                    json.dumps(trigger_log, sort_keys=True),
+                )
 
             decision_log = {
                 "sid": sid,
@@ -899,7 +890,6 @@ def score_all_pairs_0_100(
                 "triggers": list(result.get("triggers", [])),
                 "conflicts": list(result.get("conflicts", [])),
             }
-            logger.info("MERGE_DECISION %s", json.dumps(decision_log, sort_keys=True))
             logger.info(
                 "MERGE_V2_DECISION %s", json.dumps(decision_log, sort_keys=True)
             )

--- a/backend/core/logic/report_analysis/ai_adjudicator.py
+++ b/backend/core/logic/report_analysis/ai_adjudicator.py
@@ -251,7 +251,7 @@ def adjudicate_pair(pack: dict) -> dict[str, Any]:
             "pair": {"a": a_idx, "b": b_idx},
             "reason": "disabled",
         }
-        logger.info("MERGE_V2_SKIPPED %s", json.dumps(log_payload, sort_keys=True))
+        logger.info("AI_ADJUDICATOR_SKIPPED %s", json.dumps(log_payload, sort_keys=True))
         return {"decision": "ai_disabled", "confidence": 0.0, "reasons": []}
 
     url, payload, headers, metadata = _build_request_payload(pack)
@@ -265,7 +265,7 @@ def adjudicate_pair(pack: dict) -> dict[str, Any]:
         "max_tokens": metadata.get("max_tokens"),
         "prompt_tokens_est": prompt_tokens_est,
     }
-    logger.info("MERGE_V2_CALL %s", json.dumps(request_log, sort_keys=True))
+    logger.info("AI_ADJUDICATOR_REQUEST %s", json.dumps(request_log, sort_keys=True))
 
     timeout_s = float(merge_config.get_ai_request_timeout())
 
@@ -294,7 +294,7 @@ def adjudicate_pair(pack: dict) -> dict[str, Any]:
             "reasons_count": len(sanitized.get("reasons", [])),
             "latency_ms": round(duration_ms, 3),
         }
-        logger.info("MERGE_V2_DECISION %s", json.dumps(response_log, sort_keys=True))
+        logger.info("AI_ADJUDICATOR_RESPONSE %s", json.dumps(response_log, sort_keys=True))
         return sanitized
     except Exception as exc:
         duration_ms = (time.perf_counter() - started) * 1000
@@ -304,7 +304,7 @@ def adjudicate_pair(pack: dict) -> dict[str, Any]:
             "error": exc.__class__.__name__,
             "latency_ms": round(duration_ms, 3),
         }
-        logger.error("MERGE_V2_CALL_ERROR %s", json.dumps(error_log, sort_keys=True))
+        logger.error("AI_ADJUDICATOR_ERROR %s", json.dumps(error_log, sort_keys=True))
         raise
 
 

--- a/docs/analyzer_inputs.md
+++ b/docs/analyzer_inputs.md
@@ -145,14 +145,12 @@ consumers.【F:backend/core/logic/report_analysis/account_merge.py†L272-L352�
 
 ### Observability and logs
 
-- Pairwise scoring emits the detailed `MERGE_SCORE ...` / `MERGE_DECISION ...`
+- Pairwise scoring emits `MERGE_V2_SCORE ...` / `MERGE_V2_DECISION ...`
   logs for every comparison. Use ripgrep to inspect them, e.g. `rg
-  "MERGE_DECISION" runs/<sid>/ -g"*.log"`.
-- Compact counterparts (`MERGE_V2_SCORE`, `MERGE_V2_TRIGGER`,
-  `MERGE_V2_DECISION`) mirror the same activity with just the essential
-  identifiers so dashboards can efficiently trace merge traffic. The
-  scorer continues to expose the richer `MERGE_TRIGGER` entries whenever a
-  strong, mid, dates, or total trigger fires.【F:backend/core/logic/report_analysis/account_merge.py†L821-L878】
+  "MERGE_V2_DECISION" runs/<sid>/ -g"*.log"`.【F:backend/core/logic/report_analysis/account_merge.py†L855-L895】
+- `MERGE_V2_TRIGGER` entries capture every trigger the scorer evaluates so
+  dashboards can efficiently trace merge traffic alongside the per-pair
+  scores.【F:backend/core/logic/report_analysis/account_merge.py†L855-L895】
 
 ### Where merge conclusions are stored
 

--- a/tests/report_analysis/test_account_merge_best_partner.py
+++ b/tests/report_analysis/test_account_merge_best_partner.py
@@ -162,13 +162,13 @@ def test_score_all_pairs_emits_structured_logs(tmp_path, caplog) -> None:
     ):
         score_all_pairs_0_100(sid, [0, 1], runs_root=tmp_path)
 
-    score_messages = [
+    v2_score_messages = [
         record.getMessage()
         for record in caplog.records
-        if record.getMessage().startswith("MERGE_SCORE ")
+        if record.getMessage().startswith("MERGE_V2_SCORE ")
     ]
-    assert score_messages
-    score_payload = json.loads(score_messages[0].split(" ", 1)[1])
+    assert v2_score_messages
+    score_payload = json.loads(v2_score_messages[0].split(" ", 1)[1])
     assert score_payload["sid"] == sid
     assert score_payload["i"] == 0
     assert score_payload["j"] == 1
@@ -177,13 +177,13 @@ def test_score_all_pairs_emits_structured_logs(tmp_path, caplog) -> None:
     assert "matched_pairs" in score_payload
     assert "account_number" in score_payload["matched_pairs"]
 
-    trigger_messages = [
+    v2_trigger_messages = [
         record.getMessage()
         for record in caplog.records
-        if record.getMessage().startswith("MERGE_TRIGGER ")
+        if record.getMessage().startswith("MERGE_V2_TRIGGER ")
     ]
-    assert trigger_messages
-    trigger_payload = json.loads(trigger_messages[0].split(" ", 1)[1])
+    assert v2_trigger_messages
+    trigger_payload = json.loads(v2_trigger_messages[0].split(" ", 1)[1])
     assert {
         "sid",
         "i",
@@ -192,36 +192,15 @@ def test_score_all_pairs_emits_structured_logs(tmp_path, caplog) -> None:
         "details",
     }.issubset(trigger_payload)
 
-    decision_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.getMessage().startswith("MERGE_DECISION ")
-    ]
-    assert decision_messages
-    decision_payload = json.loads(decision_messages[0].split(" ", 1)[1])
-    for key in ("sid", "i", "j", "decision", "total"):
-        assert key in decision_payload
-
-    v2_score_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.getMessage().startswith("MERGE_V2_SCORE ")
-    ]
-    assert v2_score_messages
-
-    v2_trigger_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.getMessage().startswith("MERGE_V2_TRIGGER ")
-    ]
-    assert v2_trigger_messages
-
     v2_decision_messages = [
         record.getMessage()
         for record in caplog.records
         if record.getMessage().startswith("MERGE_V2_DECISION ")
     ]
     assert v2_decision_messages
+    decision_payload = json.loads(v2_decision_messages[0].split(" ", 1)[1])
+    for key in ("sid", "i", "j", "decision", "total"):
+        assert key in decision_payload
 
 
 def test_score_all_pairs_debug_pair_logs(tmp_path, caplog) -> None:


### PR DESCRIPTION
## Summary
- update merge pair scoring logs to only emit the MERGE_V2_* markers while retaining detailed payloads for observability
- rename AI adjudicator logging markers to the AI_ADJUDICATOR_* namespace and align retry logging in the sender
- refresh documentation and tests to reflect the new telemetry conventions

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py tests/report_analysis/test_ai_sender.py tests/report_analysis/test_ai_adjudicator.py

------
https://chatgpt.com/codex/tasks/task_b_68d0541d6ce88325aad581f1118c0528