### PR TITLE
Centralize AI pack storage

### DIFF
--- a/backend/core/logic/report_analysis/ai_pack.py
+++ b/backend/core/logic/report_analysis/ai_pack.py
@@ -180,22 +180,12 @@ def _build_pack_payload(
     }
 
 
-def _write_pack(path: Path, payload: dict, overwrite: bool) -> None:
-    if path.exists() and not overwrite:
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2)
-    path.write_text(serialized + "\n", encoding="utf-8")
-
-
 def build_ai_pack_for_pair(
     sid: str,
     runs_root: str | os.PathLike[str],
     a_idx: int,
     b_idx: int,
     highlights: Mapping[str, object] | None,
-    *,
-    overwrite: bool = False,
 ) -> dict:
     sid_str = str(sid)
     runs_root_path = Path(runs_root)
@@ -235,23 +225,6 @@ def build_ai_pack_for_pair(
         highlights,
         max_lines,
     )
-    pack_for_b = _build_pack_payload(
-        sid_str,
-        account_b,
-        account_a,
-        context_b,
-        context_a,
-        account_number_b,
-        account_number_a,
-        highlights,
-        max_lines,
-    )
-
-    pack_a_path = accounts_root / str(account_a) / "ai" / f"pack_pair_{account_a}_{account_b}.json"
-    pack_b_path = accounts_root / str(account_b) / "ai" / f"pack_pair_{account_b}_{account_a}.json"
-
-    _write_pack(pack_a_path, pack_for_a, overwrite)
-    _write_pack(pack_b_path, pack_for_b, overwrite)
 
     return pack_for_a
 

--- a/backend/pipeline/runs.py
+++ b/backend/pipeline/runs.py
@@ -89,6 +89,7 @@ class RunManifest:
                 "exports": {},
                 "logs": {},
                 "ai": {},
+                "ai_packs": {},
             },
             "env_snapshot": {}
         }

--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -124,17 +124,21 @@ for pr in pairs:
         )
     }
 
-    out_dir = PACKS_ROOT/f"{a_idx}-{b_idx}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_file = out_dir/"pack.json"
+    filename = f"{a_idx:03d}-{b_idx:03d}.json"
+    out_file = PACKS_ROOT/filename
     dump_json(out_file, pack)
-    out_index.append({"a":a_idx,"b":b_idx,"file":str(out_file)})
+    out_index.append({"a":a_idx,"b":b_idx,"file":filename})
+
+# כתיבת אינדקס מרכזי
+index_path = PACKS_ROOT/"index.json"
+dump_json(index_path, out_index)
 
 # עדכון המניפסט
 manifest = load_json(manifest_path, default={})
-manifest.setdefault("artifacts",{}).setdefault("ai",{})
-manifest["artifacts"]["ai"]["packs_dir"] = str(PACKS_ROOT)
-manifest["artifacts"]["ai"]["pairs"] = out_index
+ai_packs = manifest.setdefault("artifacts",{}).setdefault("ai_packs",{})
+ai_packs["dir"] = str(PACKS_ROOT.resolve())
+ai_packs["index"] = str(index_path.resolve())
+ai_packs["logs"] = str((PACKS_ROOT/"logs.txt").resolve())
 manifest["artifacts"]["logs"] = manifest.get("artifacts",{}).get("logs",{})
 dump_json(manifest_path, manifest)
 

--- a/scripts/adjudicate_pairs.py
+++ b/scripts/adjudicate_pairs.py
@@ -181,7 +181,6 @@ def adjudicate_pairs_for_sid(
             a_idx,
             b_idx,
             highlights,
-            overwrite=True,
         )
 
         decision = adjudicate_pair(pack)

--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -26,12 +26,6 @@ def _write_json_file(path: Path, payload: object) -> None:
     path.write_text(serialized + "\n", encoding="utf-8")
 
 
-def _resolve_out_dir(base: Path, sid: str, out_dir_arg: str | None) -> Path:
-    if out_dir_arg:
-        return Path(out_dir_arg)
-    return base / sid / "ai_packs"
-
-
 def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--sid", required=True, help="Session identifier")
@@ -39,11 +33,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         "--runs-root",
         default="runs",
         help="Root directory containing runs/<SID> outputs",
-    )
-    parser.add_argument(
-        "--out-dir",
-        default=None,
-        help="Optional output directory for packs (defaults to runs/<SID>/ai_packs)",
     )
     parser.add_argument(
         "--max-lines-per-side",
@@ -69,7 +58,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     sid = str(args.sid)
     runs_root = Path(args.runs_root)
-    out_dir = _resolve_out_dir(runs_root, sid, args.out_dir)
+    out_dir = runs_root / sid / "ai_packs"
 
     packs = build_merge_ai_packs(
         sid,
@@ -101,9 +90,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     persist_manifest(
         manifest,
         artifacts={
-            "ai": {
-                "packs_dir": out_dir,
-                "packs_index": index_path,
+            "ai_packs": {
+                "dir": out_dir,
+                "index": index_path,
                 "logs": logs_path,
             }
         },

--- a/scripts/preview_ai_pack.py
+++ b/scripts/preview_ai_pack.py
@@ -125,7 +125,6 @@ def preview_pair_pack(
         a_idx,
         b_idx,
         highlights,
-        overwrite=True,
     )
 
     pair = pack.get("pair", {})
@@ -141,8 +140,8 @@ def preview_pair_pack(
         )
     )
 
-    pack_path = runs_root / sid / "cases" / "accounts" / str(a_idx) / "ai" / f"pack_pair_{a_idx}_{b_idx}.json"
-    print(f"Pack path (A side): {pack_path}")
+    pack_path = runs_root / sid / "ai_packs" / f"{a_idx:03d}-{b_idx:03d}.json"
+    print(f"Pack path: {pack_path}")
 
     print("Highlights:")
     print(json.dumps(highlights_payload, ensure_ascii=False, indent=2, sort_keys=True))

--- a/scripts/run_ai_merge_flow.py
+++ b/scripts/run_ai_merge_flow.py
@@ -149,9 +149,9 @@ def build_packs_for_sid(
     persist_manifest(
         manifest,
         artifacts={
-            "ai": {
-                "packs_dir": output_dir,
-                "packs_index": index_path,
+            "ai_packs": {
+                "dir": output_dir,
+                "index": index_path,
                 "logs": logs_path,
             }
         },

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -97,9 +97,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     persist_manifest(
         manifest,
         artifacts={
-            "ai": {
-                "packs_dir": packs_dir,
-                "packs_index": index_path,
+            "ai_packs": {
+                "dir": packs_dir,
+                "index": index_path,
                 "logs": logs_path,
             }
         },

--- a/tests/report_analysis/test_ai_pack.py
+++ b/tests/report_analysis/test_ai_pack.py
@@ -69,22 +69,11 @@ def test_build_ai_pack_for_pair_creates_packs(tmp_path, monkeypatch):
     assert pack["ids"]["account_number_b"] == "409451******"
     assert pack["limits"]["max_lines_per_side"] == 5
 
-    pack_a_path = account_a_dir / "ai" / "pack_pair_11_16.json"
-    pack_b_path = account_b_dir / "ai" / "pack_pair_16_11.json"
-
-    assert pack_a_path.exists()
-    assert pack_b_path.exists()
-
-    saved_a = json.loads(pack_a_path.read_text(encoding="utf-8"))
-    saved_b = json.loads(pack_b_path.read_text(encoding="utf-8"))
-
-    assert saved_a == pack
-    assert saved_b["pair"] == {"a": 16, "b": 11}
-    assert saved_b["context"]["a"][0] == "U S BANK"
-    assert saved_b["context"]["b"][0] == "US BK CACS"
+    assert not (account_a_dir / "ai").exists()
+    assert not (account_b_dir / "ai").exists()
 
 
-def test_build_ai_pack_for_pair_writes_symmetrically(tmp_path, monkeypatch):
+def test_build_ai_pack_for_pair_is_consistent(tmp_path, monkeypatch):
     monkeypatch.setenv("AI_PACK_MAX_LINES_PER_SIDE", "3")
 
     sid = "sample-symmetric"
@@ -107,19 +96,15 @@ def test_build_ai_pack_for_pair_writes_symmetrically(tmp_path, monkeypatch):
 
     first_pack = build_ai_pack_for_pair(sid, runs_root, 201, 305, highlights)
 
-    pack_a_path = account_a_dir / "ai" / "pack_pair_201_305.json"
-    pack_b_path = account_b_dir / "ai" / "pack_pair_305_201.json"
-
-    assert pack_a_path.exists()
-    assert pack_b_path.exists()
+    assert first_pack["pair"] == {"a": 201, "b": 305}
+    assert first_pack["context"]["a"][0] == "Creditor A"
+    assert first_pack["context"]["b"][0] == "Creditor B"
 
     second_pack = build_ai_pack_for_pair(sid, runs_root, 305, 201, highlights)
 
-    # Reversing the inputs should still leave the artifacts mirrored correctly.
-    saved_a = json.loads(pack_a_path.read_text(encoding="utf-8"))
-    saved_b = json.loads(pack_b_path.read_text(encoding="utf-8"))
-
-    assert saved_a == first_pack
-    assert saved_b["pair"] == {"a": 305, "b": 201}
     assert second_pack["pair"] == {"a": 305, "b": 201}
-    assert saved_b == second_pack
+    assert second_pack["context"]["a"][0] == "Creditor B"
+    assert second_pack["context"]["b"][0] == "Creditor A"
+
+    assert not (account_a_dir / "ai").exists()
+    assert not (account_b_dir / "ai").exists()

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -205,14 +205,14 @@ def test_build_ai_merge_packs_cli_updates_manifest(tmp_path: Path, monkeypatch) 
     assert index_payload == [{"a": 11, "b": 16, "file": "011-016.json"}]
 
     manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    ai_artifacts = manifest_data["artifacts"]["ai"]
+    ai_artifacts = manifest_data["artifacts"]["ai_packs"]
 
     expected_dir = str(out_dir.resolve())
     expected_index = str(index_path.resolve())
     expected_logs = str((out_dir / "logs.txt").resolve())
 
     assert ai_artifacts == {
-        "packs_dir": expected_dir,
-        "packs_index": expected_index,
+        "dir": expected_dir,
+        "index": expected_index,
         "logs": expected_logs,
     }

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -30,7 +30,7 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
             },
         ]
     }
-    pack_path = packs_dir / "pair-11-16.json"
+    pack_path = packs_dir / "011-016.json"
     pack_path.write_text(json.dumps(pack_payload), encoding="utf-8")
     index_payload = [{"a": 11, "b": 16, "file": pack_path.name}]
     (packs_dir / "index.json").write_text(json.dumps(index_payload), encoding="utf-8")
@@ -92,7 +92,7 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
 
     manifest_path = runs_root / sid / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    ai_artifacts = manifest["artifacts"]["ai"]
-    assert Path(ai_artifacts["packs_dir"]) == packs_dir.resolve()
-    assert Path(ai_artifacts["packs_index"]) == (packs_dir / "index.json").resolve()
+    ai_artifacts = manifest["artifacts"]["ai_packs"]
+    assert Path(ai_artifacts["dir"]) == packs_dir.resolve()
+    assert Path(ai_artifacts["index"]) == (packs_dir / "index.json").resolve()
     assert Path(ai_artifacts["logs"]) == logs_path.resolve()


### PR DESCRIPTION
## Summary
- stop build_ai_pack_for_pair from writing per-account pack files and update callers
- write merge pack artifacts only into runs/<sid>/ai_packs and register them under artifacts.ai_packs in the manifest
- adjust helper scripts and quick builder plus tests for the new pack layout

## Testing
- pytest tests/report_analysis/test_ai_pack.py tests/report_analysis/test_ai_packs_builder.py tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d070435b948325b97a2ecd5997cc93