### PR TITLE
Use environment-configured retries for AI adjudicator calls

### DIFF
--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 from collections.abc import Mapping as MappingABC
 from datetime import datetime, timezone
@@ -24,6 +25,9 @@ from backend.core.ai.adjudicator import decide_merge_or_different
 from backend.core.io.tags import upsert_tag
 from backend.pipeline.runs import RunManifest, persist_manifest
 
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_SCHEDULE = "1,3,7"
+
 
 def _load_index(path: Path) -> list[Mapping[str, object]]:
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -37,6 +41,49 @@ def _load_pack(path: Path) -> Mapping[str, object]:
     if not isinstance(data, MappingABC):
         raise ValueError(f"AI pack must be a JSON object: {path}")
     return data
+
+
+def _env_max_retries() -> int:
+    raw = os.getenv("AI_MAX_RETRIES")
+    if raw is None or raw.strip() == "":
+        return DEFAULT_MAX_RETRIES
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError("AI_MAX_RETRIES must be an integer") from exc
+    return max(0, value)
+
+
+def _parse_backoff_schedule(raw: str | None) -> list[float]:
+    if raw is None:
+        return []
+    parts = [part.strip() for part in raw.split(",")]
+    schedule: list[float] = []
+    for part in parts:
+        if not part:
+            continue
+        try:
+            value = float(part)
+        except ValueError as exc:
+            raise ValueError("AI_BACKOFF_SCHEDULE values must be numbers") from exc
+        if value < 0:
+            raise ValueError("AI_BACKOFF_SCHEDULE values must be non-negative")
+        schedule.append(value)
+    return schedule
+
+
+def _env_backoff_schedule() -> list[float]:
+    raw = os.getenv("AI_BACKOFF_SCHEDULE")
+    if raw is None:
+        raw = DEFAULT_BACKOFF_SCHEDULE
+    return _parse_backoff_schedule(raw)
+
+
+def _backoff_delay(schedule: Sequence[float], attempt_number: int) -> float:
+    if not schedule:
+        return 0.0
+    index = min(max(attempt_number - 1, 0), len(schedule) - 1)
+    return schedule[index]
 
 
 def _resolve_packs_dir(runs_root: Path, sid: str, override: str | None) -> Path:
@@ -151,18 +198,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         default=None,
         help="Optional override for the directory containing ai packs",
     )
-    parser.add_argument(
-        "--max-retries",
-        type=int,
-        default=3,
-        help="Maximum number of retries after the initial request",
-    )
-    parser.add_argument(
-        "--backoff",
-        type=float,
-        default=2.0,
-        help="Base backoff (seconds) multiplied by the attempt number",
-    )
     args = parser.parse_args(argv)
 
     sid = str(args.sid)
@@ -190,6 +225,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     total = 0
     successes = 0
     failures = 0
+    max_retries = _env_max_retries()
+    backoff_schedule = _env_backoff_schedule()
+    max_attempts = max(0, max_retries) + 1
 
     for entry in index:
         if "a" not in entry or "b" not in entry or "file" not in entry:
@@ -205,8 +243,6 @@ def main(argv: Sequence[str] | None = None) -> None:
 
         log = _log_factory(logs_path, sid, {"a": a_idx, "b": b_idx}, pack_path.name)
         attempts = 0
-        max_attempts = max(0, int(args.max_retries)) + 1
-        backoff = max(float(args.backoff), 0.0)
         decision_payload: Mapping[str, object] | None = None
 
         while attempts < max_attempts:
@@ -233,8 +269,18 @@ def main(argv: Sequence[str] | None = None) -> None:
                 if attempts >= max_attempts:
                     decision_payload = None
                     break
-                if backoff > 0:
-                    time.sleep(backoff * attempts)
+                next_attempt = attempts + 1
+                delay = _backoff_delay(backoff_schedule, attempts)
+                log(
+                    "RETRY",
+                    {
+                        "attempt": next_attempt,
+                        "max_attempts": max_attempts,
+                        "delay": delay,
+                    },
+                )
+                if delay > 0:
+                    time.sleep(delay)
             else:
                 log(
                     "RESPONSE",


### PR DESCRIPTION
## Summary
- load retry count and backoff schedule from AI_MAX_RETRIES and AI_BACKOFF_SCHEDULE env vars
- implement schedule-based sleep handling with retry logging markers

## Testing
- python -m compileall scripts/send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d074a5648c832580b6d2bf1b86e480