### PR TITLE
Add helper to compact tags and persist explanations

### DIFF
--- a/backend/core/logic/report_analysis/tags_compact.py
+++ b/backend/core/logic/report_analysis/tags_compact.py
@@ -1,0 +1,323 @@
+"""Helpers for compacting account tags and persisting verbose context."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Sequence
+
+from backend.core.io.tags import read_tags, write_tags_atomic
+
+
+def _ensure_path(path: os.PathLike[str] | str) -> Path:
+    return Path(path)
+
+
+def _coerce_int(value: Any) -> Any:
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except Exception:
+        return value
+
+
+def _coerce_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value != ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _load_summary(summary_path: Path) -> dict[str, Any]:
+    if not summary_path.exists():
+        return {}
+    try:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if isinstance(data, dict):
+        return dict(data)
+    return {}
+
+
+def _coerce_mapping_list(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, (list, tuple)):
+        items = value
+    else:
+        items = []
+    result: list[dict[str, Any]] = []
+    for entry in items:
+        if isinstance(entry, Mapping):
+            result.append(dict(entry))
+    return result
+
+
+def _merge_entries(
+    existing: Iterable[Mapping[str, Any]],
+    updates: Iterable[Mapping[str, Any]],
+    key_fields: Sequence[str],
+) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    index: dict[tuple[Any, ...], int] = {}
+
+    for entry in existing:
+        data = dict(entry)
+        key = tuple(data.get(field) for field in key_fields)
+        if key in index:
+            merged[index[key]] = data
+        else:
+            index[key] = len(merged)
+            merged.append(data)
+
+    for entry in updates:
+        data = dict(entry)
+        key = tuple(data.get(field) for field in key_fields)
+        if key in index:
+            merged[index[key]] = data
+        else:
+            index[key] = len(merged)
+            merged.append(data)
+
+    return merged
+
+
+def _minimal_issue(tag: Mapping[str, Any]) -> dict[str, Any]:
+    minimal: dict[str, Any] = {"kind": "issue"}
+    type_value = tag.get("type")
+    if type_value is not None:
+        minimal["type"] = str(type_value)
+    return minimal
+
+
+def _minimal_merge_best(tag: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": "merge_best"}
+    partner = _coerce_int(tag.get("with"))
+    if partner is not None:
+        payload["with"] = partner
+    decision = _coerce_str(tag.get("decision"))
+    if decision is not None:
+        payload["decision"] = decision
+    return payload
+
+
+def _minimal_ai_decision(tag: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": "ai_decision"}
+    partner = _coerce_int(tag.get("with"))
+    if partner is not None:
+        payload["with"] = partner
+    decision = _coerce_str(tag.get("decision"))
+    if decision is not None:
+        payload["decision"] = decision
+    at_value = _coerce_str(tag.get("at"))
+    if at_value is not None:
+        payload["at"] = at_value
+    return payload
+
+
+def _minimal_same_debt(tag: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": "same_debt_pair"}
+    partner = _coerce_int(tag.get("with"))
+    if partner is not None:
+        payload["with"] = partner
+    at_value = _coerce_str(tag.get("at"))
+    if at_value is not None:
+        payload["at"] = at_value
+    return payload
+
+
+def _minimal_other(tag: Mapping[str, Any]) -> dict[str, Any] | None:
+    minimal: dict[str, Any] = {}
+    for key, value in tag.items():
+        if key in {"tag", "source", "parts", "aux", "reasons", "conflicts", "raw_response", "reason", "details", "score_total", "strong_rank", "tiebreaker", "total", "mid", "dates_all", "strong"}:
+            continue
+        if key == "kind":
+            minimal["kind"] = str(value)
+        elif key == "with":
+            partner = _coerce_int(value)
+            if partner is not None:
+                minimal["with"] = partner
+        elif isinstance(value, (str, int, float, bool)) and value != "":
+            minimal[key] = value
+    if not minimal:
+        return None
+    minimal.setdefault("kind", str(tag.get("kind", "")))
+    return {key: val for key, val in minimal.items() if val is not None}
+
+
+def _merge_explanation_from_tag(tag: Mapping[str, Any]) -> dict[str, Any] | None:
+    kind = str(tag.get("kind", ""))
+    if kind not in {"merge_best", "merge_pair"}:
+        return None
+
+    payload: dict[str, Any] = {"kind": kind}
+    partner = _coerce_int(tag.get("with"))
+    if partner is not None:
+        payload["with"] = partner
+    decision = _coerce_str(tag.get("decision"))
+    if decision is not None:
+        payload["decision"] = decision
+
+    verbose_fields = {
+        "total": tag.get("total"),
+        "mid": tag.get("mid"),
+        "dates_all": tag.get("dates_all"),
+        "parts": tag.get("parts"),
+        "aux": tag.get("aux"),
+        "reasons": tag.get("reasons"),
+        "conflicts": tag.get("conflicts"),
+        "strong": tag.get("strong"),
+        "strong_rank": tag.get("strong_rank"),
+        "score_total": tag.get("score_total"),
+        "tiebreaker": tag.get("tiebreaker"),
+    }
+
+    if not any(_has_value(value) for value in verbose_fields.values()):
+        return None
+
+    for key, value in verbose_fields.items():
+        if _has_value(value):
+            payload[key] = value
+
+    aux = tag.get("aux")
+    if isinstance(aux, Mapping):
+        acct_level = aux.get("acctnum_level")
+        if _has_value(acct_level):
+            payload.setdefault("acctnum_level", acct_level)
+        matched_fields = aux.get("matched_fields")
+        if isinstance(matched_fields, Mapping) and matched_fields:
+            payload.setdefault("matched_fields", dict(matched_fields))
+
+    return payload
+
+
+def _ai_explanation_from_tag(
+    tag: Mapping[str, Any],
+    *,
+    decision_reason_map: dict[Any, str],
+) -> list[dict[str, Any]]:
+    kind = str(tag.get("kind", ""))
+    partner = _coerce_int(tag.get("with"))
+    decision = _coerce_str(tag.get("decision"))
+    reason = tag.get("reason")
+    raw_response = tag.get("raw_response")
+    explanations: list[dict[str, Any]] = []
+
+    if kind == "ai_decision":
+        if isinstance(partner, int) and isinstance(reason, str) and reason:
+            decision_reason_map[partner] = reason
+        if not _has_value(reason) and not _has_value(raw_response):
+            return []
+        payload: dict[str, Any] = {"kind": kind}
+        if partner is not None:
+            payload["with"] = partner
+        if decision is not None:
+            payload["decision"] = decision
+        if _has_value(reason):
+            payload["reason"] = reason
+        if _has_value(raw_response):
+            payload["raw_response"] = raw_response
+        explanations.append(payload)
+        return explanations
+
+    if kind == "same_debt_pair":
+        if not _has_value(reason) and isinstance(partner, int):
+            reason = decision_reason_map.get(partner)
+        if not _has_value(reason):
+            return []
+        payload = {"kind": kind}
+        if partner is not None:
+            payload["with"] = partner
+        payload["reason"] = reason
+        explanations.append(payload)
+
+    return explanations
+
+
+def compact_tags_for_account(account_dir: os.PathLike[str] | str) -> None:
+    """Reduce ``tags.json`` to final tags and persist verbose context in summary."""
+
+    account_path = _ensure_path(account_dir)
+    tags = read_tags(account_path)
+    if not tags:
+        return
+
+    minimal_tags: list[dict[str, Any]] = []
+    merge_explanations: list[dict[str, Any]] = []
+    ai_explanations: list[dict[str, Any]] = []
+    reason_by_partner: dict[Any, str] = {}
+
+    for tag in tags:
+        if not isinstance(tag, Mapping):
+            continue
+
+        kind = str(tag.get("kind", ""))
+        if kind == "issue":
+            minimal_tags.append(_minimal_issue(tag))
+        elif kind == "merge_best":
+            minimal_tags.append(_minimal_merge_best(tag))
+        elif kind == "ai_decision":
+            minimal_tags.append(_minimal_ai_decision(tag))
+        elif kind == "same_debt_pair":
+            minimal_tags.append(_minimal_same_debt(tag))
+        else:
+            other = _minimal_other(tag)
+            if other is not None and other.get("kind"):
+                minimal_tags.append(other)
+
+        merge_payload = _merge_explanation_from_tag(tag)
+        if merge_payload is not None:
+            merge_explanations.append(merge_payload)
+
+        ai_payloads = _ai_explanation_from_tag(tag, decision_reason_map=reason_by_partner)
+        if ai_payloads:
+            ai_explanations.extend(ai_payloads)
+
+    write_tags_atomic(account_path, minimal_tags)
+
+    summary_path = account_path / "summary.json"
+    summary_data = _load_summary(summary_path)
+
+    existing_merge = _coerce_mapping_list(summary_data.get("merge_explanations"))
+    existing_ai = _coerce_mapping_list(summary_data.get("ai_explanations"))
+
+    if merge_explanations:
+        summary_data["merge_explanations"] = _merge_entries(
+            existing_merge, merge_explanations, ("kind", "with")
+        )
+    elif "merge_explanations" in summary_data:
+        summary_data["merge_explanations"] = _merge_entries(
+            existing_merge, (), ("kind", "with")
+        )
+
+    if ai_explanations:
+        summary_data["ai_explanations"] = _merge_entries(
+            existing_ai, ai_explanations, ("kind", "with", "decision")
+        )
+    elif "ai_explanations" in summary_data:
+        summary_data["ai_explanations"] = _merge_entries(
+            existing_ai, (), ("kind", "with", "decision")
+        )
+
+    if merge_explanations or ai_explanations or summary_path.exists():
+        summary_path.write_text(
+            json.dumps(summary_data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+
+__all__ = ["compact_tags_for_account"]
+

--- a/tests/report_analysis/test_tags_compact.py
+++ b/tests/report_analysis/test_tags_compact.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.core.io.tags import read_tags
+from backend.core.logic.report_analysis.tags_compact import compact_tags_for_account
+
+
+def _account_dir(tmp_path: Path) -> Path:
+    account_dir = tmp_path / "cases" / "accounts" / "7"
+    account_dir.mkdir(parents=True, exist_ok=True)
+    return account_dir
+
+
+def _write_tags(account_dir: Path, payload: list[dict[str, object]]) -> None:
+    tag_path = account_dir / "tags.json"
+    tag_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _read_summary(account_dir: Path) -> dict[str, object]:
+    summary_path = account_dir / "summary.json"
+    if not summary_path.exists():
+        return {}
+    return json.loads(summary_path.read_text(encoding="utf-8"))
+
+
+def test_compact_tags_moves_verbose_data_to_summary(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    summary_path = account_dir / "summary.json"
+    summary_path.write_text(
+        json.dumps({"existing": True, "merge_explanations": [{"kind": "merge_best", "with": 99}]}, indent=2),
+        encoding="utf-8",
+    )
+
+    _write_tags(
+        account_dir,
+        [
+            {
+                "kind": "issue",
+                "type": "collection",
+                "details": {"problem_reasons": ["reason-a"]},
+            },
+            {
+                "kind": "merge_best",
+                "with": "16",
+                "decision": "ai",
+                "total": 59,
+                "parts": {"balance_owed": 31},
+                "aux": {
+                    "acctnum_level": "none",
+                    "matched_fields": {"balance_owed": True},
+                    "by_field_pairs": {},
+                },
+                "reasons": ["strong:balance_owed", "mid", "total"],
+                "conflicts": ["amount_conflict:high_balance"],
+                "source": "merge_scorer",
+            },
+            {
+                "kind": "ai_decision",
+                "with": 16,
+                "decision": "different",
+                "reason": "Different account numbers and conflicting last payment dates; same debt indicated.",
+                "raw_response": {
+                    "decision": "different",
+                    "reason": "Different account numbers and conflicting last payment dates; same debt indicated.",
+                },
+                "at": "2025-09-21T22:47:26Z",
+            },
+            {
+                "kind": "same_debt_pair",
+                "with": 16,
+                "at": "2025-09-21T22:47:26Z",
+            },
+        ],
+    )
+
+    compact_tags_for_account(account_dir)
+
+    tags_after = read_tags(account_dir)
+    assert tags_after == [
+        {"kind": "issue", "type": "collection"},
+        {"kind": "merge_best", "with": 16, "decision": "ai"},
+        {
+            "kind": "ai_decision",
+            "with": 16,
+            "decision": "different",
+            "at": "2025-09-21T22:47:26Z",
+        },
+        {"kind": "same_debt_pair", "with": 16, "at": "2025-09-21T22:47:26Z"},
+    ]
+
+    summary_after = _read_summary(account_dir)
+    assert summary_after["existing"] is True
+
+    merge_entries = summary_after["merge_explanations"]
+    assert isinstance(merge_entries, list)
+    assert {entry.get("with") for entry in merge_entries} == {16, 99}
+    merge_entry = next(entry for entry in merge_entries if entry.get("with") == 16)
+    assert merge_entry["kind"] == "merge_best"
+    assert merge_entry["total"] == 59
+    assert merge_entry["parts"] == {"balance_owed": 31}
+    assert merge_entry["conflicts"] == ["amount_conflict:high_balance"]
+    assert merge_entry["matched_fields"] == {"balance_owed": True}
+    assert merge_entry["acctnum_level"] == "none"
+
+    ai_entries = summary_after["ai_explanations"]
+    assert isinstance(ai_entries, list)
+    assert {entry.get("kind") for entry in ai_entries} == {"ai_decision", "same_debt_pair"}
+    ai_decision_entry = next(entry for entry in ai_entries if entry.get("kind") == "ai_decision")
+    assert ai_decision_entry["with"] == 16
+    assert "raw_response" in ai_decision_entry
+    same_debt_entry = next(entry for entry in ai_entries if entry.get("kind") == "same_debt_pair")
+    assert same_debt_entry["reason"].startswith("Different account numbers")
+
+    summary_snapshot = json.loads(summary_path.read_text(encoding="utf-8"))
+    tags_snapshot = read_tags(account_dir)
+
+    compact_tags_for_account(account_dir)
+
+    assert read_tags(account_dir) == tags_snapshot
+    assert json.loads(summary_path.read_text(encoding="utf-8")) == summary_snapshot
+


### PR DESCRIPTION
## Summary
- add `compact_tags_for_account` helper that rewrites tags.json with minimal fields and migrates verbose merge/AI data into summary.json
- capture merge and AI explanations in summary.json without duplicating entries across runs
- add regression test covering tag compaction and summary aggregation

## Testing
- `pytest tests/report_analysis/test_tags_compact.py tests/backend/core/io/test_tags.py`


------
https://chatgpt.com/codex/tasks/task_b_68d08be27e4c8325b0a492c9d6772865