### PR TITLE
Automate AI pipeline invocation after case build

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from backend.core.logic.report_analysis.block_exporter import export_stage_a, run_stage_a
+from backend.pipeline.auto_ai import maybe_run_auto_ai_pipeline
 from backend.pipeline.runs import RunManifest
 from backend.core.logic.report_analysis.problem_case_builder import build_problem_cases
 from backend.core.logic.report_analysis.problem_extractor import detect_problem_accounts
@@ -222,6 +223,13 @@ def build_problem_cases_task(self, prev: dict | None = None, sid: str | None = N
         cases_info.get("count"),
         cases_info.get("dir"),
     )
+
+    try:
+        maybe_run_auto_ai_pipeline(sid, summary=summary)
+    except Exception:
+        log.error("AUTO_AI_PIPELINE_FAILED sid=%s", sid, exc_info=True)
+        raise
+
     return summary
 
 

--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -1,0 +1,163 @@
+"""Automatic AI adjudication hooks for the case-build pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from backend.core.logic.report_analysis.tags_compact import (
+    compact_tags_for_account,
+)
+from backend.pipeline.runs import RunManifest
+from scripts.build_ai_merge_packs import main as build_ai_merge_packs_main
+from scripts.score_bureau_pairs import score_accounts
+from scripts.send_ai_merge_packs import main as send_ai_merge_packs_main
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_run_auto_ai_pipeline(
+    sid: str, *, summary: Mapping[str, object] | None = None
+) -> None:
+    """Run the automatic AI pipeline when enabled via the environment flag."""
+
+    if os.getenv("ENABLE_AUTO_AI_PIPELINE", "0") != "1":
+        return
+
+    _run_auto_ai_pipeline(sid, summary=summary)
+
+
+def _run_auto_ai_pipeline(
+    sid: str, *, summary: Mapping[str, object] | None = None
+) -> None:
+    manifest = RunManifest.for_sid(sid)
+    run_dir = manifest.path.parent
+    runs_root = run_dir.parent
+
+    accounts_dir = _resolve_accounts_dir(run_dir, summary)
+    touched_accounts: set[int] = set()
+    index_entries: list[Mapping[str, object]] = []
+
+    logger.info("AUTO_AI_PIPELINE start sid=%s", sid)
+
+    try:
+        scoring = score_accounts(sid, runs_root=runs_root, write_tags=True)
+        touched_accounts.update(_normalize_indices(scoring.indices))
+
+        _build_ai_packs(sid, runs_root)
+
+        index_path = run_dir / "ai_packs" / "index.json"
+        index_entries = _load_ai_index(index_path)
+        touched_accounts.update(_indices_from_index(index_entries))
+
+        _send_ai_packs(sid)
+
+        _compact_accounts(accounts_dir, touched_accounts)
+    except Exception:
+        logger.error("AUTO_AI_PIPELINE failed sid=%s", sid, exc_info=True)
+        raise
+    else:
+        logger.info(
+            "AUTO_AI_PIPELINE done sid=%s accounts=%d packs=%d",
+            sid,
+            len(touched_accounts),
+            len(index_entries),
+        )
+
+
+def _build_ai_packs(sid: str, runs_root: Path) -> None:
+    argv = ["--sid", sid, "--runs-root", str(runs_root)]
+    try:
+        build_ai_merge_packs_main(argv)
+    except SystemExit as exc:  # pragma: no cover - defensive
+        if exc.code not in (None, 0):
+            raise RuntimeError(
+                f"build_ai_merge_packs failed for sid={sid} exit={exc.code}"
+            ) from exc
+
+
+def _send_ai_packs(sid: str) -> None:
+    argv = ["--sid", sid]
+    try:
+        send_ai_merge_packs_main(argv)
+    except SystemExit as exc:
+        if exc.code not in (None, 0):
+            raise RuntimeError(
+                f"send_ai_merge_packs failed for sid={sid} exit={exc.code}"
+            ) from exc
+
+
+def _normalize_indices(indices: Sequence[object]) -> set[int]:
+    normalized: set[int] = set()
+    for value in indices:
+        try:
+            normalized.add(int(value))
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def _resolve_accounts_dir(
+    run_dir: Path, summary: Mapping[str, object] | None
+) -> Path:
+    if isinstance(summary, Mapping):
+        cases = summary.get("cases")
+        if isinstance(cases, Mapping):
+            dir_value = cases.get("dir")
+            if isinstance(dir_value, (str, Path)) and str(dir_value):
+                candidate = Path(dir_value)
+                return candidate
+    return run_dir / "cases" / "accounts"
+
+
+def _load_ai_index(path: Path) -> list[Mapping[str, object]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid AI pack index JSON: {path}") from exc
+    if not isinstance(data, list):
+        raise ValueError(f"AI pack index must be a list: {path}")
+    entries: list[Mapping[str, object]] = []
+    for entry in data:
+        if isinstance(entry, Mapping):
+            entries.append(entry)
+    return entries
+
+
+def _indices_from_index(index_entries: Iterable[Mapping[str, object]]) -> set[int]:
+    values: set[int] = set()
+    for entry in index_entries:
+        for key in ("a", "b"):
+            if key not in entry:
+                continue
+            try:
+                values.add(int(entry[key]))
+            except (TypeError, ValueError):
+                continue
+    return values
+
+
+def _compact_accounts(accounts_dir: Path, indices: Iterable[int]) -> None:
+    unique_indices = sorted({int(idx) for idx in indices})
+    if not unique_indices:
+        return
+
+    for idx in unique_indices:
+        account_dir = accounts_dir / f"{idx}"
+        if not account_dir.exists():
+            continue
+        try:
+            compact_tags_for_account(account_dir)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.warning(
+                "AUTO_AI_PIPELINE compact failed account=%s dir=%s",
+                idx,
+                account_dir,
+                exc_info=True,
+            )
+

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+from backend.pipeline import auto_ai
+from backend.pipeline.runs import RunManifest
+
+
+def test_maybe_run_auto_ai_pipeline_runs_full_flow(monkeypatch, tmp_path):
+    sid = "SID123"
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv("RUNS_ROOT", str(runs_root))
+    monkeypatch.setenv("ENABLE_AUTO_AI_PIPELINE", "1")
+
+    manifest = RunManifest.for_sid(sid)
+    run_dir = manifest.path.parent
+    accounts_dir = run_dir / "cases" / "accounts"
+    (accounts_dir / "1").mkdir(parents=True, exist_ok=True)
+    (accounts_dir / "2").mkdir(parents=True, exist_ok=True)
+
+    recorded: dict[str, object] = {}
+
+    class DummyScore:
+        def __init__(self, indices):
+            self.indices = indices
+
+    def fake_score_accounts(
+        sid_arg: str,
+        *,
+        runs_root: Path,
+        write_tags: bool,
+        only_ai_rows: bool = False,
+    ):
+        recorded["score"] = {
+            "sid": sid_arg,
+            "runs_root": Path(runs_root),
+            "write_tags": write_tags,
+            "only_ai_rows": only_ai_rows,
+        }
+        return DummyScore(indices=[1])
+
+    def fake_build(argv):
+        recorded["build"] = list(argv)
+        packs_dir = run_dir / "ai_packs"
+        packs_dir.mkdir(parents=True, exist_ok=True)
+        index_payload = [{"a": 1, "b": 2, "file": "001-002.json"}]
+        (packs_dir / "index.json").write_text(
+            json.dumps(index_payload), encoding="utf-8"
+        )
+
+    def fake_send(argv):
+        recorded["send"] = list(argv)
+
+    compact_calls: list[Path] = []
+
+    def fake_compact(account_dir: Path):
+        compact_calls.append(Path(account_dir))
+
+    monkeypatch.setattr(auto_ai, "score_accounts", fake_score_accounts)
+    monkeypatch.setattr(auto_ai, "build_ai_merge_packs_main", fake_build)
+    monkeypatch.setattr(auto_ai, "send_ai_merge_packs_main", fake_send)
+    monkeypatch.setattr(auto_ai, "compact_tags_for_account", fake_compact)
+
+    auto_ai.maybe_run_auto_ai_pipeline(sid, summary={"cases": {"dir": str(accounts_dir)}})
+
+    assert recorded["score"] == {
+        "sid": sid,
+        "runs_root": run_dir.parent,
+        "write_tags": True,
+        "only_ai_rows": False,
+    }
+    assert recorded["build"] == ["--sid", sid, "--runs-root", str(run_dir.parent)]
+    assert recorded["send"] == ["--sid", sid]
+    assert sorted(path.name for path in compact_calls) == ["1", "2"]
+
+
+def test_maybe_run_auto_ai_pipeline_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv("ENABLE_AUTO_AI_PIPELINE", raising=False)
+
+    called: list[object] = []
+
+    def fake_runner(*args, **kwargs):
+        called.append((args, kwargs))
+
+    monkeypatch.setattr(auto_ai, "_run_auto_ai_pipeline", fake_runner)
+
+    auto_ai.maybe_run_auto_ai_pipeline("SID", summary=None)
+
+    assert not called


### PR DESCRIPTION
## Summary
- trigger the automatic AI adjudication flow after problem cases finish building when `ENABLE_AUTO_AI_PIPELINE` is enabled
- add a reusable helper that scores accounts, builds/sends AI packs, and compacts account tags with detailed logging
- extend the AI send CLI to accept `--runs-root` overrides and preserve `ai_decision` tag payloads for same-debt responses

## Testing
- pytest tests/pipeline/test_auto_ai.py tests/scripts/test_send_ai_merge_packs.py tests/report_analysis/test_ai_packs_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68d08df86ae4832597955b95b1ec805d