### PR TITLE
Stop persisting AI decisions under cases accounts

### DIFF
--- a/tests/report_analysis/test_ai_adjudicator.py
+++ b/tests/report_analysis/test_ai_adjudicator.py
@@ -56,20 +56,6 @@ def test_adjudicate_pair_disabled(monkeypatch, tmp_path):
 
     ai_adjudicator.persist_ai_decision("case-123", tmp_path, 11, 16, resp)
 
-    path_a = base / "11" / "ai" / "decision_pair_11_16.json"
-    path_b = base / "16" / "ai" / "decision_pair_16_11.json"
-
-    assert path_a.exists()
-    assert path_b.exists()
-
-    saved_a = jsonlib.loads(path_a.read_text(encoding="utf-8"))
-    saved_b = jsonlib.loads(path_b.read_text(encoding="utf-8"))
-
-    assert saved_a["decision"] == "ai_disabled"
-    assert saved_a["pair"] == {"a": 11, "b": 16}
-    assert saved_b["pair"] == {"a": 16, "b": 11}
-    assert saved_b["decision"] == "ai_disabled"
-
     tags_a_path = base / "11" / "tags.json"
     tags_b_path = base / "16" / "tags.json"
 
@@ -91,8 +77,8 @@ def test_adjudicate_pair_disabled(monkeypatch, tmp_path):
     assert tags_b == [expected_tag_b]
     assert not legacy_a.exists()
     assert not legacy_b.exists()
-    assert not list((path_a.parent).glob("pack_pair_*"))
-    assert not list((path_b.parent).glob("pack_pair_*"))
+    assert not (base / "11" / "ai").exists()
+    assert not (base / "16" / "ai").exists()
 
 
 def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
@@ -156,18 +142,6 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
 
     ai_adjudicator.persist_ai_decision("case-123", tmp_path, 11, 16, resp)
 
-    path_a = base / "11" / "ai" / "decision_pair_11_16.json"
-    path_b = base / "16" / "ai" / "decision_pair_16_11.json"
-
-    saved_a = jsonlib.loads(path_a.read_text(encoding="utf-8"))
-    saved_b = jsonlib.loads(path_b.read_text(encoding="utf-8"))
-
-    assert saved_a["decision"] == "merge"
-    assert saved_a["confidence"] == 0.83
-    assert saved_a["pair"] == {"a": 11, "b": 16}
-    assert saved_b["pair"] == {"a": 16, "b": 11}
-    assert saved_b["reasons"] == ["matched creditor names"]
-
     tags_a_path = base / "11" / "tags.json"
     tags_b_path = base / "16" / "tags.json"
 
@@ -195,8 +169,8 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     assert tags_b == [expected_b]
     assert not legacy_a.exists()
     assert not legacy_b.exists()
-    assert not list((path_a.parent).glob("pack_pair_*"))
-    assert not list((path_b.parent).glob("pack_pair_*"))
+    assert not (base / "11" / "ai").exists()
+    assert not (base / "16" / "ai").exists()
 
 
 def test_adjudicate_pair_enabled_no_merge(monkeypatch, tmp_path):
@@ -240,17 +214,6 @@ def test_adjudicate_pair_enabled_no_merge(monkeypatch, tmp_path):
     ai_adjudicator.persist_ai_decision("case-123", tmp_path, 11, 16, resp)
 
     base = tmp_path / "case-123" / "cases" / "accounts"
-    path_a = base / "11" / "ai" / "decision_pair_11_16.json"
-    path_b = base / "16" / "ai" / "decision_pair_16_11.json"
-
-    saved_a = jsonlib.loads(path_a.read_text(encoding="utf-8"))
-    saved_b = jsonlib.loads(path_b.read_text(encoding="utf-8"))
-
-    assert saved_a["decision"] == "no_merge"
-    assert saved_a["confidence"] == 0.41
-    assert saved_b["decision"] == "no_merge"
-    assert saved_b["reasons"] == ["conflicting payment history"]
-
     tags_a_path = base / "11" / "tags.json"
     tags_b_path = base / "16" / "tags.json"
 
@@ -276,3 +239,5 @@ def test_adjudicate_pair_enabled_no_merge(monkeypatch, tmp_path):
 
     assert tags_a == [expected_a]
     assert tags_b == [expected_b]
+    assert not (base / "11" / "ai").exists()
+    assert not (base / "16" / "ai").exists()

--- a/tests/report_analysis/test_tags_update_after_ai.py
+++ b/tests/report_analysis/test_tags_update_after_ai.py
@@ -74,15 +74,6 @@ def test_persist_ai_decision_overwrites_with_new_result(tmp_path):
     persist_ai_decision(sid, runs_root, 303, 101, second_response)
 
     base = runs_root / sid / "cases" / "accounts"
-    path_a = base / "101" / "ai" / "decision_pair_101_303.json"
-    path_b = base / "303" / "ai" / "decision_pair_303_101.json"
-
-    saved_a = json.loads(path_a.read_text(encoding="utf-8"))
-    saved_b = json.loads(path_b.read_text(encoding="utf-8"))
-
-    assert saved_a["decision"] == "no_merge"
-    assert saved_b["decision"] == "no_merge"
-
     expected_tag_a = {
         "kind": "merge_result",
         "with": 303,
@@ -102,4 +93,6 @@ def test_persist_ai_decision_overwrites_with_new_result(tmp_path):
 
     assert tags_a == [expected_tag_a]
     assert tags_b == [expected_tag_b]
+    assert not (base / "101" / "ai").exists()
+    assert not (base / "303" / "ai").exists()
 


### PR DESCRIPTION
## Summary
- remove legacy AI adjudicator writes under runs/<sid>/cases/accounts/ai by pruning old artifacts and updating persistence to only refresh tags
- update adjudicator unit tests to expect tag-only storage and removal of legacy ai directories
- adjust persist_ai_decision tests to confirm ai directories are no longer created

## Testing
- pytest tests/report_analysis/test_ai_adjudicator.py tests/report_analysis/test_tags_update_after_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d0906984cc832593e1e50a610a60bb