### PR TITLE
Add auto AI pipeline lock guard and async cleanup

### DIFF
--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -1,4 +1,6 @@
 import json
+import os
+import time
 from pathlib import Path
 
 from backend.pipeline import auto_ai, auto_ai_tasks
@@ -37,8 +39,9 @@ def test_maybe_queue_auto_ai_pipeline_queues_when_candidates(monkeypatch, tmp_pa
 
     recorded: dict[str, object] = {}
 
-    def fake_enqueue(sid: str) -> str:
+    def fake_enqueue(sid: str, runs_root=None) -> str:
         recorded["sid"] = sid
+        recorded["runs_root"] = runs_root
         return "async-result"
 
     monkeypatch.setattr(auto_ai_tasks, "enqueue_auto_ai_chain", fake_enqueue)
@@ -49,12 +52,22 @@ def test_maybe_queue_auto_ai_pipeline_queues_when_candidates(monkeypatch, tmp_pa
         flag_env=flag_env,
     )
 
-    marker_path = runs_root / sid / "ai_packs" / auto_ai.PIPELINE_MARKER_FILENAME
+    lock_path = (
+        runs_root
+        / sid
+        / auto_ai.AUTO_AI_PIPELINE_DIRNAME
+        / auto_ai.INFLIGHT_LOCK_FILENAME
+    )
 
     assert result["queued"] is True
     assert result["reason"] == "queued"
-    assert recorded == {"sid": sid}
-    assert marker_path.exists()
+    assert recorded == {"sid": sid, "runs_root": runs_root}
+    assert lock_path.exists()
+    assert result["lock_path"] == str(lock_path)
+    assert result["pipeline_dir"] == str(lock_path.parent)
+    assert result["last_ok_path"] == str(
+        lock_path.parent / auto_ai.LAST_OK_FILENAME
+    )
 
 
 def test_maybe_queue_auto_ai_pipeline_skips_without_candidates(monkeypatch, tmp_path: Path) -> None:
@@ -91,7 +104,7 @@ def test_maybe_queue_auto_ai_pipeline_skips_when_disabled(monkeypatch, tmp_path:
     assert calls == []
 
 
-def test_maybe_queue_auto_ai_pipeline_skips_when_marker_present(monkeypatch, tmp_path: Path) -> None:
+def test_maybe_queue_auto_ai_pipeline_skips_when_lock_present(monkeypatch, tmp_path: Path) -> None:
     sid = "in-progress"
     runs_root = tmp_path / "runs"
     flag_env = {"ENABLE_AUTO_AI_PIPELINE": "1"}
@@ -99,14 +112,99 @@ def test_maybe_queue_auto_ai_pipeline_skips_when_marker_present(monkeypatch, tmp
     tags_path = runs_root / sid / "cases" / "accounts" / "11" / "tags.json"
     _write_json(tags_path, [{"kind": "merge_best", "decision": "ai", "with": 99}])
 
-    marker_path = runs_root / sid / "ai_packs" / auto_ai.PIPELINE_MARKER_FILENAME
-    marker_path.parent.mkdir(parents=True, exist_ok=True)
-    marker_path.write_text("{}", encoding="utf-8")
+    lock_path = (
+        runs_root
+        / sid
+        / auto_ai.AUTO_AI_PIPELINE_DIRNAME
+        / auto_ai.INFLIGHT_LOCK_FILENAME
+    )
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("{}", encoding="utf-8")
 
     calls: list[object] = []
-    monkeypatch.setattr(auto_ai_tasks, "enqueue_auto_ai_chain", lambda sid: calls.append(sid))
+    monkeypatch.setattr(
+        auto_ai_tasks,
+        "enqueue_auto_ai_chain",
+        lambda sid, runs_root=None: calls.append((sid, runs_root)),
+    )
 
     result = auto_ai.maybe_queue_auto_ai_pipeline(sid, runs_root=runs_root, flag_env=flag_env)
 
-    assert result == {"queued": False, "reason": "in_progress"}
+    assert result == {"queued": False, "reason": "inflight"}
     assert calls == []
+
+
+def test_maybe_queue_auto_ai_pipeline_clears_stale_lock(monkeypatch, tmp_path: Path) -> None:
+    sid = "stale"
+    runs_root = tmp_path / "runs"
+    flag_env = {"ENABLE_AUTO_AI_PIPELINE": "1"}
+
+    tags_path = runs_root / sid / "cases" / "accounts" / "11" / "tags.json"
+    _write_json(tags_path, [{"kind": "merge_best", "decision": "ai", "with": 42}])
+
+    lock_path = (
+        runs_root
+        / sid
+        / auto_ai.AUTO_AI_PIPELINE_DIRNAME
+        / auto_ai.INFLIGHT_LOCK_FILENAME
+    )
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("{}", encoding="utf-8")
+    old_age = auto_ai.DEFAULT_INFLIGHT_TTL_SECONDS + 5
+    past = time.time() - old_age
+    os.utime(lock_path, (past, past))
+
+    recorded: dict[str, object] = {}
+
+    def fake_enqueue(sid: str, runs_root=None) -> str:
+        recorded["sid"] = sid
+        recorded["runs_root"] = runs_root
+        return "queued"
+
+    monkeypatch.setattr(auto_ai_tasks, "enqueue_auto_ai_chain", fake_enqueue)
+
+    result = auto_ai.maybe_queue_auto_ai_pipeline(
+        sid,
+        runs_root=runs_root,
+        flag_env=flag_env,
+    )
+
+    assert result["queued"] is True
+    assert recorded == {"sid": sid, "runs_root": runs_root}
+
+
+def test_maybe_queue_auto_ai_pipeline_force_overrides_lock(monkeypatch, tmp_path: Path) -> None:
+    sid = "force"
+    runs_root = tmp_path / "runs"
+    flag_env = {"ENABLE_AUTO_AI_PIPELINE": "1"}
+
+    tags_path = runs_root / sid / "cases" / "accounts" / "11" / "tags.json"
+    _write_json(tags_path, [{"kind": "merge_best", "decision": "ai", "with": 11}])
+
+    lock_path = (
+        runs_root
+        / sid
+        / auto_ai.AUTO_AI_PIPELINE_DIRNAME
+        / auto_ai.INFLIGHT_LOCK_FILENAME
+    )
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("{}", encoding="utf-8")
+
+    recorded: dict[str, object] = {}
+
+    def fake_enqueue(sid: str, runs_root=None) -> str:
+        recorded["sid"] = sid
+        recorded["runs_root"] = runs_root
+        return "queued"
+
+    monkeypatch.setattr(auto_ai_tasks, "enqueue_auto_ai_chain", fake_enqueue)
+
+    result = auto_ai.maybe_queue_auto_ai_pipeline(
+        sid,
+        runs_root=runs_root,
+        flag_env=flag_env,
+        force=True,
+    )
+
+    assert result["queued"] is True
+    assert recorded == {"sid": sid, "runs_root": runs_root}


### PR DESCRIPTION
## Summary
- add an .ai_pipeline guard with inflight lock + TTL/force handling around auto AI queueing
- update the Celery auto AI chain to pass the runs root, clean locks on failure, and persist last_ok summaries
- expand pipeline unit tests to cover new locking paths and force/TTL behaviours

## Testing
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d0a1cafe1083258e9de14e99ccab1a