### PR TITLE
Handle OpenAI project headers for AI adjudicator

### DIFF
--- a/backend/core/ai/adjudicator.py
+++ b/backend/core/ai/adjudicator.py
@@ -72,8 +72,12 @@ def decide_merge_or_different(pack: dict, *, timeout: int) -> dict:
     headers = {
         "Authorization": f"Bearer {api_key}",
     }
-    project_id = os.getenv("OPENAI_PROJECT_ID")
-    if api_key.startswith("sk-proj-") and project_id:
+    project_id = (os.getenv("OPENAI_PROJECT_ID") or "").strip()
+    if api_key.startswith("sk-proj-"):
+        if not project_id:
+            raise RuntimeError(
+                "OPENAI_PROJECT_ID must be set when using project-scoped OpenAI API keys"
+            )
         headers["OpenAI-Project"] = project_id
 
     org_id = os.getenv("OPENAI_ORG_ID")

--- a/tests/test_ai_adjudicator.py
+++ b/tests/test_ai_adjudicator.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any
+
+import pytest
+
+from backend.core.ai import adjudicator
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        if payload is None:
+            payload = {"decision": "merge", "reason": "test"}
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(self._payload, ensure_ascii=False)
+                    }
+                }
+            ]
+        }
+
+
+def _clear_ai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("OPENAI_API_KEY", "AI_MODEL", "OPENAI_PROJECT_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_decide_merge_requires_project_id_for_project_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-missing")
+    monkeypatch.setenv("AI_MODEL", "unit-test-model")
+
+    called: dict[str, Any] = {}
+
+    def fake_post(*args: Any, **kwargs: Any) -> _FakeResponse:
+        called["args"] = args
+        return _FakeResponse()
+
+    monkeypatch.setattr(adjudicator.httpx, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="OPENAI_PROJECT_ID must be set"):
+        adjudicator.decide_merge_or_different({}, timeout=5)
+
+    assert called == {}
+
+
+def test_decide_merge_attaches_project_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-abc123")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "proj-789")
+    monkeypatch.setenv("AI_MODEL", "merge-model")
+
+    recorded: dict[str, Any] = {}
+
+    def fake_post(url: str, *, headers: dict[str, str], json: dict[str, Any], timeout: int) -> _FakeResponse:
+        recorded["url"] = url
+        recorded["headers"] = dict(headers)
+        recorded["json"] = json
+        recorded["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(adjudicator.httpx, "post", fake_post)
+
+    result = adjudicator.decide_merge_or_different({}, timeout=7)
+
+    assert result == {"decision": "merge", "reason": "test"}
+    assert recorded["headers"]["Authorization"].startswith("Bearer sk-proj-abc123")
+    assert recorded["headers"]["OpenAI-Project"] == "proj-789"


### PR DESCRIPTION
## Summary
- require an OpenAI project id when project-scoped API keys are used by the adjudicator client
- attach the OpenAI-Project header for project keys and cover the behavior with focused unit tests

## Testing
- pytest tests/test_ai_adjudicator.py
- pytest tests/scripts/test_send_ai_merge_packs.py
- pytest tests/pipeline/test_auto_ai.py
- pytest tests/test_ai_env_config.py

------
https://chatgpt.com/codex/tasks/task_b_68d0a5f678d8832590a92fa5a4948b5b