### PR TITLE
Add structured logging and run summaries for the auto AI pipeline

### DIFF
--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -396,6 +396,16 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
     assert first_result["packs"] == 1
     assert first_result["pairs"] == 2
 
+    logs_path = runs_root / sid / "ai_packs" / "logs.txt"
+    first_logs = [
+        json.loads(line)
+        for line in logs_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(first_logs) == 1
+    assert first_logs[0]["packs"] == 1
+    assert first_logs[0]["pairs"] == 2
+
     tags_a_first = json.loads((account_a / "tags.json").read_text(encoding="utf-8"))
     tags_b_first = json.loads((account_b / "tags.json").read_text(encoding="utf-8"))
     summary_a_first = json.loads((account_a / "summary.json").read_text(encoding="utf-8"))
@@ -413,6 +423,14 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
 
     assert second_result["packs"] == 1
     assert second_result["pairs"] == 2
+
+    second_logs = [
+        json.loads(line)
+        for line in logs_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [entry["packs"] for entry in second_logs] == [1, 1]
+    assert [entry["pairs"] for entry in second_logs] == [2, 2]
 
     tags_a_second = json.loads((account_a / "tags.json").read_text(encoding="utf-8"))
     tags_b_second = json.loads((account_b / "tags.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add structured log events for each auto-AI task phase and append JSONL run summaries
- log AI pack index metadata while reusing the existing Celery chain
- extend the auto AI pipeline test to assert the new logs file content

## Testing
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d0aaf71de88325b4462ecc115989a2