### PR TITLE
Ensure AI pipeline detects decision-only merge tags

### DIFF
--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -73,6 +73,16 @@ def test_has_ai_merge_best_pairs_guard_handles_structured_tags(tmp_path: Path) -
     assert auto_ai.has_ai_merge_best_pairs(sid, runs_root) is False
 
 
+def test_has_ai_merge_best_pairs_detects_missing_partner(tmp_path: Path) -> None:
+    runs_root = tmp_path / "runs"
+    sid = "no-partner"
+    account_tags = runs_root / sid / "cases" / "accounts"
+
+    _write_json(account_tags / "11" / "tags.json", [{"kind": "merge_best", "decision": "ai"}])
+
+    assert auto_ai.has_ai_merge_best_pairs(sid, runs_root) is True
+
+
 def test_maybe_queue_auto_ai_pipeline_queues_when_candidates(monkeypatch, tmp_path: Path) -> None:
     sid = "queue-me"
     runs_root = tmp_path / "runs"


### PR DESCRIPTION
## Summary
- treat merge_best tags with decision=="ai" as AI candidates even when no partner is prefilled
- add an inflight lock context manager helper for the AI pipeline
- document the new behavior with a regression test covering tags that omit the partner field

## Testing
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d15a4561dc83259bac1d6c1a2634af