### PR TITLE
Add Celery task for automatic AI pipeline

### DIFF
--- a/backend/core/io/tags_compactor.py
+++ b/backend/core/io/tags_compactor.py
@@ -1,0 +1,26 @@
+"""Helpers to compact tags for entire runs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .tags_minimize import compact_account_tags
+
+_DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
+
+
+def compact_tags_for_sid(sid: str, runs_root: Path | str | None = None) -> None:
+    """Compact ``tags.json`` files and summaries for all accounts of ``sid``."""
+
+    root = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
+    accounts_root = root / str(sid) / "cases" / "accounts"
+    if not accounts_root.exists():
+        return
+
+    for entry in sorted(accounts_root.iterdir()):
+        if entry.is_dir():
+            compact_account_tags(entry)
+
+
+__all__ = ["compact_tags_for_sid"]

--- a/backend/core/logic/ai/__init__.py
+++ b/backend/core/logic/ai/__init__.py
@@ -1,0 +1,5 @@
+"""Helper wrappers exposing AI pipeline helpers."""
+
+__all__ = [
+    "send_ai_merge_packs",
+]

--- a/backend/core/logic/ai/send_ai_merge_packs.py
+++ b/backend/core/logic/ai/send_ai_merge_packs.py
@@ -1,0 +1,28 @@
+"""Programmatic helpers for sending merge AI packs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scripts.send_ai_merge_packs import main as _send_main
+
+_DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
+
+
+def run_send_for_sid(
+    sid: str, *, runs_root: Path | str | None = None, packs_dir: Path | str | None = None
+) -> None:
+    """Send adjudication packs for ``sid`` using the CLI implementation."""
+
+    argv: list[str] = ["--sid", str(sid)]
+    if packs_dir is not None:
+        argv.extend(["--packs-dir", str(packs_dir)])
+
+    root = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
+    argv.extend(["--runs-root", str(root)])
+
+    _send_main(argv)
+
+
+__all__ = ["run_send_for_sid"]

--- a/backend/core/logic/merge/__init__.py
+++ b/backend/core/logic/merge/__init__.py
@@ -1,0 +1,5 @@
+"""Helper utilities for merge logic wrappers."""
+
+__all__ = [
+    "scorer",
+]

--- a/backend/core/logic/merge/scorer.py
+++ b/backend/core/logic/merge/scorer.py
@@ -1,0 +1,33 @@
+"""Wrappers around merge scoring helpers for programmatic use."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scripts.score_bureau_pairs import ScoreComputationResult, score_accounts
+
+_DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
+
+
+def score_bureau_pairs_cli(
+    *, sid: str, write_tags: bool = False, runs_root: Path | str | None = None
+) -> ScoreComputationResult:
+    """Execute the score-bureau-pairs workflow similar to the CLI.
+
+    Parameters
+    ----------
+    sid:
+        The run/session identifier.
+    write_tags:
+        When ``True`` persists merge tags back to account ``tags.json`` files.
+    runs_root:
+        Optional override for the runs directory root.
+    """
+
+    sid_str = str(sid)
+    runs_root_path = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
+    return score_accounts(sid_str, runs_root=runs_root_path, write_tags=write_tags)
+
+
+__all__ = ["score_bureau_pairs_cli"]


### PR DESCRIPTION
## Summary
- add a Celery task that automatically runs scoring, pack build, sending, and compaction when merge-best AI candidates are present
- expose wrappers around the existing CLI scripts so the pipeline can call them programmatically

## Testing
- pytest tests/scripts/test_score_bureau_pairs.py

------
https://chatgpt.com/codex/tasks/task_b_68d15d70ba7c8325a6d1483950dabfa1