### PR TITLE
Queue AI pipeline after case build

### DIFF
--- a/backend/core/io/tags_compactor.py
+++ b/backend/core/io/tags_compactor.py
@@ -1,26 +1,79 @@
-"""Helpers to compact tags for entire runs."""
-
-from __future__ import annotations
-
-import os
+import json
 from pathlib import Path
 
-from .tags_minimize import compact_account_tags
 
-_DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
-
-
-def compact_tags_for_sid(sid: str, runs_root: Path | str | None = None) -> None:
-    """Compact ``tags.json`` files and summaries for all accounts of ``sid``."""
-
-    root = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
-    accounts_root = root / str(sid) / "cases" / "accounts"
-    if not accounts_root.exists():
+def compact_tags_for_sid(sid: str, runs_root: Path | None = None):
+    base = Path(runs_root or "runs") / sid / "cases" / "accounts"
+    if not base.exists():
         return
+    for acc in base.iterdir():
+        if not acc.is_dir():
+            continue
+        tags_p = acc / "tags.json"
+        if not tags_p.exists():
+            continue
+        try:
+            tags = json.loads(tags_p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
 
-    for entry in sorted(accounts_root.iterdir()):
-        if entry.is_dir():
-            compact_account_tags(entry)
+        minimal = []
+        merge_expl = []
+        ai_expl = []
 
+        for t in tags or []:
+            k = t.get("kind")
+            if k == "issue":
+                minimal.append({"kind": "issue", "type": t.get("type")})
+            elif k == "merge_best":
+                minimal.append(
+                    {
+                        "kind": "merge_best",
+                        "with": t.get("with"),
+                        "decision": t.get("decision"),
+                    }
+                )
+                merge_expl.append(t)
+            elif k == "ai_decision":
+                minimal.append(
+                    {
+                        "kind": "ai_decision",
+                        "with": t.get("with"),
+                        "decision": t.get("decision"),
+                        "at": t.get("at"),
+                    }
+                )
+                ai_expl.append(t)
+            elif k == "same_debt_pair":
+                minimal.append(
+                    {
+                        "kind": "same_debt_pair",
+                        "with": t.get("with"),
+                        "at": t.get("at"),
+                    }
+                )
+                ai_expl.append(t)
+            else:
+                # Keep unknown tags in a minimal way
+                m = {"kind": k}
+                for f in ("with", "decision", "type", "at", "tag"):
+                    if f in t:
+                        m[f] = t[f]
+                minimal.append(m)
 
-__all__ = ["compact_tags_for_sid"]
+        # write minimal tags
+        tags_p.write_text(
+            json.dumps(minimal, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        # move explanations to summary.json
+        summ_p = acc / "summary.json"
+        try:
+            summary = json.loads(summ_p.read_text(encoding="utf-8")) if summ_p.exists() else {}
+        except Exception:
+            summary = {}
+        summary["merge_explanations"] = merge_expl
+        summary["ai_explanations"] = ai_expl
+        summ_p.write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+        )

--- a/tests/test_extract_problematic_accounts_task.py
+++ b/tests/test_extract_problematic_accounts_task.py
@@ -24,13 +24,16 @@ def test_extract_problematic_accounts_task_builder(tmp_path, monkeypatch, caplog
     monkeypatch.setattr(task_module, "PROJECT_ROOT", tmp_path, raising=False)
     monkeypatch.setenv("ENABLE_AUTO_AI_PIPELINE", "1")
 
+    task_module._AUTO_AI_PIPELINE_ENQUEUED.clear()
+
     ai_calls: list[str] = []
 
-    def _fake_queue(sid_value: str, *, runs_root=None, flag_env=None):
-        ai_calls.append(sid_value)
-        return {"queued": True, "reason": "queued"}
+    class _DummyTask:
+        def delay(self, sid_value: str):
+            ai_calls.append(sid_value)
+            return {"sid": sid_value}
 
-    monkeypatch.setattr(task_module, "maybe_queue_auto_ai_pipeline", _fake_queue)
+    monkeypatch.setattr(task_module, "maybe_run_ai_pipeline", _DummyTask())
     monkeypatch.setattr(
         task_module, "has_ai_merge_best_tags", lambda runs_root, sid: True
     )
@@ -79,13 +82,16 @@ def test_extract_problematic_accounts_task_no_candidates(tmp_path, monkeypatch, 
     monkeypatch.setattr(task_module, "PROJECT_ROOT", tmp_path, raising=False)
     monkeypatch.setenv("ENABLE_AUTO_AI_PIPELINE", "1")
 
+    task_module._AUTO_AI_PIPELINE_ENQUEUED.clear()
+
     ai_calls: list[str] = []
 
-    def _fake_queue(sid_value: str, *, runs_root=None, flag_env=None):
-        ai_calls.append(sid_value)
-        return {"queued": False, "reason": "no_candidates"}
+    class _DummyTask:
+        def delay(self, sid_value: str):
+            ai_calls.append(sid_value)
+            return {"sid": sid_value}
 
-    monkeypatch.setattr(task_module, "maybe_queue_auto_ai_pipeline", _fake_queue)
+    monkeypatch.setattr(task_module, "maybe_run_ai_pipeline", _DummyTask())
     monkeypatch.setattr(
         task_module, "has_ai_merge_best_tags", lambda runs_root, sid: False
     )


### PR DESCRIPTION
## Summary
- trigger the automatic AI Celery task after building cases when AI merge tags are present, ensuring each SID is queued only once per worker
- replace the tag compactor with the minimal-tag implementation that writes explanations to summary.json
- update the problematic-accounts task tests to exercise the new Celery queueing hook

## Testing
- pytest tests/test_extract_problematic_accounts_task.py
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d1628c6db08325bd3e415fdf6fcb2a