### PR TITLE
Ensure auto AI manifest persistence and pack logging

### DIFF
--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -18,7 +18,7 @@ from backend.core.logic.tags.compact import (
     compact_account_tags,
     compact_tags_for_sid,
 )
-from backend.pipeline.runs import RUNS_ROOT, RunManifest
+from backend.pipeline.runs import RUNS_ROOT, RunManifest, persist_manifest
 from scripts.build_ai_merge_packs import main as build_ai_merge_packs_main
 from scripts.send_ai_merge_packs import main as send_ai_merge_packs_main
 
@@ -474,12 +474,14 @@ def _run_auto_ai_pipeline(sid: str):
 
     run_send_for_sid(sid, runs_root=RUNS_ROOT)
     manifest.set_ai_sent()
+    persist_manifest(manifest)
     logger.info("MANIFEST_AI_SENT sid=%s", sid)
 
     # === 4) compact tags (keep only tags; push explanations to summary.json)
     try:
         compact_tags_for_sid(sid)
         manifest.set_ai_compacted()
+        persist_manifest(manifest)
         logger.info("MANIFEST_AI_COMPACTED sid=%s", sid)
         logger.info("TAGS_COMPACTED sid=%s", sid)
     except Exception as exc:  # pragma: no cover - defensive logging


### PR DESCRIPTION
## Summary
- persist the run manifest after marking AI packs as sent and compacted in the pipeline
- allow the AI pack sender to read either `pairs` or `packs` index formats and avoid shadowing the module logger when writing pack logs

## Testing
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d1a12139a883259cffeb03b80746d7