### PR TITLE
Only mark AI merge packs sent on success

### DIFF
--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -597,9 +597,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         )
         successes += 1
 
-    manifest.set_ai_sent()
-    persist_manifest(manifest)
-    log.info("MANIFEST_AI_SENT sid=%s", sid)
+    if failures == 0:
+        manifest.set_ai_sent()
+        persist_manifest(manifest)
+        log.info("MANIFEST_AI_SENT sid=%s", sid)
 
     print(
         "[AI] adjudicated {total} packs ({successes} success, {failures} errors)".format(


### PR DESCRIPTION
## Summary
- avoid marking the run manifest as ai_sent when failures occur during sending

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d1a57391f0832590cbe2f1a4505dd3