### PR TITLE
Improve AI pack logging

### DIFF
--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -116,7 +116,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         score_total = _safe_int(highlights.get("total"))
 
         _write_pack(pack_path, pack)
-        log.info("PACK_WRITTEN sid=%s file=%s", sid, pack_filename)
+        log.info("PACK_WRITTEN sid=%s file=%s a=%s b=%s", sid, pack_filename, a_idx, b_idx)
 
         index_entries.append(
             {
@@ -138,21 +138,18 @@ def main(argv: Sequence[str] | None = None) -> None:
             "pairs_count": pairs_count,
         }
         _write_index(index_path, index_payload)
-        log.info(
-            "INDEX_WRITTEN sid=%s index=%s pairs=%s",
-            sid,
-            index_path,
-            len(index_payload.get("packs", [])),
-        )
+        packs_in_index = len(index_payload.get("packs", []))
+        log.info("INDEX_WRITTEN sid=%s index=%s pairs=%d", sid, index_path, packs_in_index)
 
         manifest = RunManifest.for_sid(sid)
-        manifest.set_ai_built(packs_dir, len(index_payload.get("packs", [])))
+        manifest.set_ai_built(packs_dir, packs_in_index)
         persist_manifest(manifest)
         log.info(
-            "MANIFEST_AI_PACKS_UPDATED sid=%s dir=%s pairs=%s",
+            "MANIFEST_AI_PACKS_UPDATED sid=%s dir=%s index=%s pairs=%d",
             sid,
             packs_dir,
-            len(index_payload.get("packs", [])),
+            index_path,
+            packs_in_index,
         )
     else:
         log.info("INDEX_SKIPPED_NO_PAIRS sid=%s dir=%s", sid, packs_dir)

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -411,8 +411,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         preferred_dir = manifest.get_ai_packs_dir()
         preferred_dir_path = Path(preferred_dir) if preferred_dir else None
         if preferred_dir_path and preferred_dir_path.exists():
+            log.info("SENDER_PACKS_DIR_FROM_MANIFEST sid=%s dir=%s", sid, preferred_dir_path)
             packs_dir = preferred_dir_path
-            log.info("SENDER_PACKS_DIR_FROM_MANIFEST sid=%s dir=%s", sid, packs_dir)
         else:
             packs_dir = _packs_dir_for(sid, runs_root_path)
             log.info("SENDER_PACKS_DIR_FALLBACK sid=%s dir=%s", sid, packs_dir)


### PR DESCRIPTION
## Summary
- expand build script logging to include per-pack identifiers, index counts, and manifest update details
- log the source of the packs directory selection when sending packs

## Testing
- python -m compileall scripts/build_ai_merge_packs.py scripts/send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d1ad6e6fcc8325834479090dc67b10