### PR TITLE
Ensure uploaded artifacts persist in manifest

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -58,6 +58,7 @@ from backend.core.logic.letters.explanations_normalizer import (
 from backend.core.materialize.casestore_view import build_account_view
 
 logger = logging.getLogger(__name__)
+log = logger
 
 api_bp = Blueprint("api", __name__)
 
@@ -181,6 +182,13 @@ def start_process():
             copy2(pdf_path, dst)
         manifest.set_artifact("uploads", "smartcredit_report", dst)
         persist_manifest(manifest)
+        log.info(
+            "MANIFEST_ARTIFACT_ADDED sid=%s group=%s name=%s path=%s",
+            manifest.sid,
+            "uploads",
+            "smartcredit_report",
+            dst,
+        )
 
         set_session(
             session_id,

--- a/backend/pipeline/runs.py
+++ b/backend/pipeline/runs.py
@@ -182,7 +182,7 @@ class RunManifest:
                 )
             cursor = next_cursor
         cursor[str(name)] = resolved_path
-        return self
+        return self.save()
 
     def _ensure_ai_section(self) -> tuple[dict[str, object], dict[str, object]]:
         ai = self.data.setdefault("ai", {})


### PR DESCRIPTION
## Summary
- ensure `RunManifest.set_artifact` persists updates immediately
- log manifest artifact additions after persisting upload metadata for credit report uploads

## Testing
- pytest tests/test_run_manifest.py tests/test_manifest_cases_registration.py

------
https://chatgpt.com/codex/tasks/task_b_68d1b5016c0c8325b87385f03a86adcd