### PR TITLE
Set AI packs dir in manifest when building packs

### DIFF
--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -91,6 +91,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     packs_dir.mkdir(parents=True, exist_ok=True)
     log.info("PACKS_DIR_USED sid=%s dir=%s", sid, packs_dir)
 
+    manifest = RunManifest.for_sid(sid)
+    manifest.upsert_ai_packs_dir(packs_dir)
+    persist_manifest(manifest)
+    log.info("MANIFEST_AI_PACKS_DIR_SET sid=%s dir=%s", sid, packs_dir)
+
     packs = build_merge_ai_packs(
         sid,
         runs_root,


### PR DESCRIPTION
## Summary
- upsert the AI packs directory in the run manifest as soon as pack generation begins
- retain the existing manifest update after writing the pack index

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d1bde0d2ec8325931ccb78d2431ba8