### PR TITLE
Stop writing AI manifest data into artifacts

### DIFF
--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -135,11 +135,11 @@ dump_json(index_path, out_index)
 
 # עדכון המניפסט
 manifest = load_json(manifest_path, default={})
-ai_packs = manifest.setdefault("artifacts",{}).setdefault("ai_packs",{})
-ai_packs["dir"] = str(PACKS_ROOT.resolve())
-ai_packs["index"] = str(index_path.resolve())
-ai_packs["logs"] = str((PACKS_ROOT/"logs.txt").resolve())
-manifest["artifacts"]["logs"] = manifest.get("artifacts",{}).get("logs",{})
+ai_section = manifest.setdefault("ai", {}).setdefault("packs", {})
+ai_section["dir"] = str(PACKS_ROOT.resolve())
+ai_section["index"] = str(index_path.resolve())
+ai_section["logs"] = str((PACKS_ROOT/"logs.txt").resolve())
+ai_section["pairs"] = len(out_index)
 dump_json(manifest_path, manifest)
 
 print(f"[BUILD] wrote {len(out_index)} packs to {PACKS_ROOT}")

--- a/scripts/run_ai_merge_flow.py
+++ b/scripts/run_ai_merge_flow.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - fallback to ensure repo modules are impo
 from backend.core.io.tags import read_tags
 from backend.core.logic.report_analysis import ai_sender
 from backend.core.logic.report_analysis.ai_packs import build_merge_ai_packs
-from backend.pipeline.runs import RunManifest, persist_manifest
+from backend.pipeline.runs import RunManifest
 
 from scripts.score_bureau_pairs import (
     AUTO_DECISIONS,
@@ -146,15 +146,11 @@ def build_packs_for_sid(
     logs_path = output_dir / "logs.txt"
 
     manifest = RunManifest.for_sid(sid_str)
-    persist_manifest(
-        manifest,
-        artifacts={
-            "ai_packs": {
-                "dir": output_dir,
-                "index": index_path,
-                "logs": logs_path,
-            }
-        },
+    manifest.update_ai_packs(
+        dir=output_dir,
+        index=index_path,
+        logs=logs_path,
+        pairs=len(items),
     )
 
     return PackBuildResult(

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -428,15 +428,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     index = _load_index(index_path)
     logs_path = packs_dir / "logs.txt"
 
-    persist_manifest(
-        manifest,
-        artifacts={
-            "ai_packs": {
-                "dir": packs_dir,
-                "index": index_path,
-                "logs": logs_path,
-            }
-        },
+    manifest.update_ai_packs(
+        dir=packs_dir,
+        index=index_path,
+        logs=logs_path,
+        pairs=len(index),
     )
 
     total = 0

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -653,9 +653,10 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch):
 
     manifest = RunManifest.for_sid(sid)
     manifest_data = json.loads((runs_root / sid / "manifest.json").read_text(encoding="utf-8"))
-    ai_artifacts = manifest_data["artifacts"]["ai_packs"]
-    assert Path(ai_artifacts["dir"]) == packs_dir.resolve()
-    assert Path(ai_artifacts["index"]) == (packs_dir / "index.json").resolve()
+    ai_packs = manifest_data["ai"]["packs"]
+    assert Path(ai_packs["dir"]) == packs_dir.resolve()
+    assert Path(ai_packs["index"]) == (packs_dir / "index.json").resolve()
+    assert Path(ai_packs["logs"]) == logs_path.resolve()
 
     status_info = manifest.data.get("ai", {}).get("status", {})
     assert status_info.get("sent") is True

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -297,10 +297,10 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
 
     manifest = RunManifest.for_sid(sid)
     manifest_data = json.loads((runs_root / sid / "manifest.json").read_text(encoding="utf-8"))
-    ai_artifacts = manifest_data["artifacts"]["ai_packs"]
-    assert Path(ai_artifacts["dir"]) == packs_dir.resolve()
-    assert Path(ai_artifacts["index"]) == (packs_dir / "index.json").resolve()
-    assert Path(ai_artifacts["logs"]) == logs_path.resolve()
+    ai_packs = manifest_data["ai"]["packs"]
+    assert Path(ai_packs["dir"]) == packs_dir.resolve()
+    assert Path(ai_packs["index"]) == (packs_dir / "index.json").resolve()
+    assert Path(ai_packs["logs"]) == logs_path.resolve()
 
     status_info = manifest.data.get("ai", {}).get("status", {})
     assert status_info.get("sent") is True


### PR DESCRIPTION
## Summary
- persist AI pack metadata exclusively via the canonical `ai.packs` manifest section and mirror logs from there for legacy consumers
- update AI pack build/send flows (including quick and run scripts) to call the new `RunManifest.update_ai_packs` helper instead of mutating `artifacts.ai_packs`
- refresh tests to assert against canonical AI manifest fields and cover the new logging path

## Testing
- pytest tests/pipeline/test_auto_ai.py tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d1bff28668832581d6e732b2adf139