### PR TITLE
Refine AI adjudication outputs with enriched scoring and flags

### DIFF
--- a/scripts/adjudicate_pairs.py
+++ b/scripts/adjudicate_pairs.py
@@ -192,13 +192,16 @@ def adjudicate_pairs_for_sid(
             "pair": {"a": a_idx, "b": b_idx},
             "decision": decision.get("decision"),
             "confidence": decision.get("confidence"),
+            "reason": decision.get("reason"),
             "reasons": list(decision.get("reasons", [])),
+            "flags": dict(decision.get("flags", {})),
         }
         logger.info("MERGE_V2_MANUAL_DONE %s", json.dumps(summary, sort_keys=True))
 
+        reason = decision.get("reason") or ""
         print(
             f"{sid} pair {a_idx}-{b_idx}: {decision.get('decision')} "
-            f"(confidence={decision.get('confidence')})"
+            f"flags={decision.get('flags', {})} reason={reason}"
         )
         reasons = decision.get("reasons") or []
         for reason in reasons:

--- a/scripts/run_ai_merge_flow.py
+++ b/scripts/run_ai_merge_flow.py
@@ -190,10 +190,11 @@ def send_packs(
                 outcome.decision,
                 outcome.reason,
                 timestamp,
+                outcome.flags,
             )
             log(
                 "PACK_SUCCESS",
-                {"decision": outcome.decision, "reason": outcome.reason},
+                {"decision": outcome.decision, "reason": outcome.reason, "flags": outcome.flags},
             )
             successes += 1
         else:

--- a/tests/report_analysis/test_ai_adjudicator_prompt.py
+++ b/tests/report_analysis/test_ai_adjudicator_prompt.py
@@ -14,9 +14,15 @@ def test_build_prompt_from_pack_limits_context(monkeypatch):
         "ids": {
             "account_number_a": "1234",
             "account_number_b": "5678",
+            "account_number_a_normalized": "1234",
+            "account_number_b_normalized": "5678",
+            "account_number_a_last4": "1234",
+            "account_number_b_last4": "5678",
         },
         "highlights": {
             "total": 81,
+            "identity_score": 38,
+            "debt_score": 22,
             "triggers": ["strong:balance_owed", "mid:dates"],
             "parts": {"balance_owed": 42, "account_number": 10},
             "matched_fields": {"balance_owed": True},
@@ -46,7 +52,11 @@ def test_build_prompt_from_pack_limits_context(monkeypatch):
     assert user_payload["sid"] == "sample-sid"
     assert user_payload["pair"] == {"a": 11, "b": 16}
     assert user_payload["account_numbers"] == {"a": "1234", "b": "5678"}
+    assert user_payload["account_numbers_normalized"] == {"a": "1234", "b": "5678"}
+    assert user_payload["account_numbers_last4"] == {"a": "1234", "b": "5678"}
     assert user_payload["highlights"]["total"] == 81
+    assert user_payload["highlights"]["identity_score"] == 38
+    assert user_payload["highlights"]["debt_score"] == 22
     assert "ignored" not in user_payload["highlights"]
     assert len(user_payload["context"]["a"]) == 3
     assert user_payload["context"]["a"][-1] == "Balance: 500"

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -105,10 +105,10 @@ def test_build_merge_ai_packs_curates_context_and_prompt(tmp_path: Path) -> None
     assert "Two-Year Payment History" not in " ".join(context_a)
     assert pack["ids"]["account_number_a"] == "409451******"
     assert pack["ids"]["account_number_b"] == "409451******"
-    assert pack["ids"]["account_number_a_norm"] == "409451"
-    assert pack["ids"]["account_number_b_norm"] == "409451"
-    assert pack["ids"]["account_last4_a"] == "9451"
-    assert pack["ids"]["account_last4_b"] == "9451"
+    assert pack["ids"]["account_number_a_normalized"] == "409451"
+    assert pack["ids"]["account_number_b_normalized"] == "409451"
+    assert pack["ids"]["account_number_a_last4"] == "9451"
+    assert pack["ids"]["account_number_b_last4"] == "9451"
     assert pack["highlights"]["total"] == 59
     assert pack["highlights"]["identity_score"] == 28
     assert pack["highlights"]["debt_score"] == 31
@@ -130,18 +130,22 @@ def test_build_merge_ai_packs_curates_context_and_prompt(tmp_path: Path) -> None
     assert user_payload["numeric_match_summary"]["total"] == 59
     assert user_payload["numeric_match_summary"]["identity_score"] == 28
     assert user_payload["numeric_match_summary"]["debt_score"] == 31
-    assert user_payload["ids"]["account_number_a_norm"] == "409451"
-    assert user_payload["ids"]["account_number_b_norm"] == "409451"
-    assert user_payload["ids"]["account_last4_a"] == "9451"
-    assert user_payload["ids"]["account_last4_b"] == "9451"
+    assert user_payload["ids"]["account_number_a_normalized"] == "409451"
+    assert user_payload["ids"]["account_number_b_normalized"] == "409451"
+    assert user_payload["ids"]["account_number_a_last4"] == "9451"
+    assert user_payload["ids"]["account_number_b_last4"] == "9451"
     assert user_payload["output_contract"]["decision"] == [
         "merge",
-        "same_account",
-        "same_account_debt_different",
         "same_debt",
         "same_debt_account_different",
+        "same_account",
+        "same_account_debt_different",
         "different",
     ]
+    assert user_payload["output_contract"]["flags"] == {
+        "account_match": ["true", "false", "unknown"],
+        "debt_match": ["true", "false", "unknown"],
+    }
 
 
 def test_build_merge_ai_packs_only_merge_best_filter(tmp_path: Path) -> None:

--- a/tests/scripts/test_run_ai_merge_flow.py
+++ b/tests/scripts/test_run_ai_merge_flow.py
@@ -45,6 +45,7 @@ def test_prepare_summary_rows_with_ai_decision(tmp_path: Path) -> None:
         "same_debt",
         "matching balances",
         "2024-01-01T00:00:00Z",
+        {"account_match": "unknown", "debt_match": True},
     )
 
     outcomes = _load_ai_outcomes(sid, runs_root)


### PR DESCRIPTION
## Summary
- extend merge AI prompts to capture normalized account numbers, identity/debt scores, and six decision outcomes with match flags
- enrich AI pack exports with normalized IDs, split identity vs debt scores, and contract expectations for decision flags
- propagate account/debt match flags through senders, tag writers, and manual adjudication scripts while slimming pair tags

## Testing
- pytest tests/report_analysis/test_ai_adjudicator.py tests/report_analysis/test_ai_adjudicator_prompt.py tests/report_analysis/test_ai_sender.py tests/report_analysis/test_ai_packs_builder.py tests/report_analysis/test_tags_update_after_ai.py tests/scripts/test_run_ai_merge_flow.py

------
https://chatgpt.com/codex/tasks/task_b_68d56c1affac8325b03d06e9661cb56a