### PR TITLE
Normalize AI adjudicator decisions

### DIFF
--- a/backend/core/ai/adjudicator.py
+++ b/backend/core/ai/adjudicator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from typing import Any, Dict, Iterable
 
 import httpx
@@ -11,32 +12,23 @@ import httpx
 _SYSTEM_PROMPT = """You are a meticulous adjudicator for credit-report account pairing.
 Decide if two account entries (A,B) refer to the SAME underlying account.
 
-Decisions allowed (exact strings):
-- merge                   : same account AND same debt (safe merge)
-- same_account            : same account; debt unknown/unclear
-- same_account_debt_different : same account; debt conflicts
-- same_debt               : same obligation/story; account unknown/unclear
-- same_debt_account_different : same obligation; KNOWN different tradelines
-- different               : different accounts/obligations
-
-Always output JSON:
+Always output strict JSON matching the contract below (no prose around it):
 {
-  "decision": "<one of above>",
-  "reason": "short natural language",
-  "flags": {"account_match": true|false|"unknown", "debt_match": true|false|"unknown"}
+  "decision": "one of: different | same_debt | same_debt_account_diff | same_account | same_account_debt_diff | merge",
+  "flags": {"account_match": true|false|"unknown", "debt_match": true|false|"unknown"},
+  "reason": "short natural language"
 }
 
-Rules:
-- If normalized account numbers match (exact or last4 corroborated by lender+dates), set flags.account_match=true.
-- If balances/high_balance/past_due + timing align within tolerance → flags.debt_match=true; if they conflict → false.
-- If account_match=true AND debt_match=true → decision MUST be "merge".
-- If account_match=true AND debt_match=false → "same_account_debt_different".
-- If account_match=false AND debt_match=true:
-    - If you have evidence accounts are different → "same_debt_account_different";
-    - else (unknown account identity) → "same_debt".
-- If account_match=true and debt_match is "unknown" → "same_account".
-- If debt_match=true and account_match is "unknown" → "same_debt".
-- Otherwise → "different".
+Decision guidance:
+- Flags.account_match=true when normalized account numbers (exact or last4 corroborated by lender+dates) align.
+- Flags.debt_match=true when balances/high_balance/past_due + timing align within tolerance; false when they conflict.
+- If account_match=true and debt_match=true, recommend "merge" only when there is strong corroboration (acct numbers, dates, balances). Otherwise use "same_account".
+- If account_match=true and debt_match=false → "same_account_debt_diff".
+- If account_match=false and debt_match=true → "same_debt_account_diff" when you know the tradelines differ; otherwise stay with "same_debt".
+- If account_match=true and debt_match="unknown" → "same_account".
+- If debt_match=true and account_match="unknown" → "same_debt".
+- If either flag is "unknown" be conservative and avoid the *_diff suffix unless evidence is explicit.
+- If both flags are false → "different".
 
 Consider:
 • High-precision cues: account-number (last4/exact), balance owed equality within tolerances, date alignments.
@@ -55,8 +47,112 @@ _ALLOWED_USER_PAYLOAD_KEYS: Iterable[str] = (
 )
 
 
+_ALLOWED_DECISIONS: tuple[str, ...] = (
+    "different",
+    "same_debt",
+    "same_debt_account_diff",
+    "same_account",
+    "same_account_debt_diff",
+    "merge",
+)
+
+
 class AdjudicatorError(ValueError):
     """Raised when the AI adjudicator response is malformed."""
+
+
+def _normalize_match_flag(value: object, *, field: str) -> bool | str:
+    """Return a normalized boolean/"unknown" flag from ``value``."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        if lowered == "unknown":
+            return "unknown"
+    raise AdjudicatorError(
+        f"AI adjudicator flags must set {field} to true, false, or \"unknown\""
+    )
+
+
+def _decision_for_flags(
+    account_flag: bool | str,
+    debt_flag: bool | str,
+    *,
+    requested: str,
+) -> str:
+    """Return the contract-compliant decision for the provided flags."""
+
+    if account_flag is True and debt_flag is True:
+        return "merge" if requested == "merge" else "same_account"
+    if account_flag is True and debt_flag is False:
+        return "same_account_debt_diff"
+    if account_flag is False and debt_flag is True:
+        return "same_debt_account_diff"
+    if account_flag is True and debt_flag == "unknown":
+        return "same_account"
+    if account_flag == "unknown" and debt_flag is True:
+        return "same_debt"
+    if account_flag is False and debt_flag == "unknown":
+        return "different"
+    if account_flag == "unknown" and debt_flag is False:
+        return "different"
+    if account_flag == "unknown" and debt_flag == "unknown":
+        return "different"
+    if account_flag is False and debt_flag is False:
+        return "different"
+    return "different"
+
+
+def _normalize_and_validate_decision(
+    resp: Mapping[str, Any]
+) -> tuple[Dict[str, Any], bool]:
+    """Return the normalized decision payload and whether normalization occurred."""
+
+    if not isinstance(resp, Mapping):
+        raise AdjudicatorError("AI adjudicator response payload must be an object")
+
+    decision_raw = resp.get("decision")
+    if not isinstance(decision_raw, str) or not decision_raw.strip():
+        raise AdjudicatorError("AI adjudicator decision must be a non-empty string")
+    decision_value = decision_raw.strip().lower()
+
+    reason_raw = resp.get("reason")
+    if not isinstance(reason_raw, str) or not reason_raw.strip():
+        raise AdjudicatorError("AI adjudicator response must include a reason string")
+    reason_value = reason_raw.strip()
+
+    flags_raw = resp.get("flags")
+    if not isinstance(flags_raw, Mapping):
+        raise AdjudicatorError(
+            "AI adjudicator response must include flags.account_match/debt_match"
+        )
+
+    account_flag = _normalize_match_flag(flags_raw.get("account_match"), field="account_match")
+    debt_flag = _normalize_match_flag(flags_raw.get("debt_match"), field="debt_match")
+
+    normalized_decision = _decision_for_flags(account_flag, debt_flag, requested=decision_value)
+    if normalized_decision not in _ALLOWED_DECISIONS:
+        raise AdjudicatorError("AI adjudicator decision was outside the allowed set")
+
+    normalized_flags = {"account_match": account_flag, "debt_match": debt_flag}
+
+    normalized = decision_value not in _ALLOWED_DECISIONS or decision_value != normalized_decision
+
+    normalized_payload: Dict[str, Any] = dict(resp)
+    normalized_payload["decision"] = normalized_decision
+    normalized_payload["reason"] = reason_value
+    normalized_payload["flags"] = normalized_flags
+    if normalized:
+        normalized_payload["normalized"] = True
+    else:
+        normalized_payload.pop("normalized", None)
+
+    return normalized_payload, normalized
 
 
 def _coerce_positive_int(value: str | None, *, default: int) -> int:


### PR DESCRIPTION
## Summary
- update the adjudicator system prompt and add response normalization to keep decisions aligned with the new contract
- normalize and log AI decisions in the merge pack sender instead of flagging invalid results, enforcing the contract end-to-end
- refresh merge-pack tests to cover the updated decision names, normalization behaviour, and downstream tagging

## Testing
- pytest tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d57dee315c8325be1e7c80cb001110