### PR TITLE
Ensure AI merge summaries include normalized metadata

### DIFF
--- a/backend/core/logic/report_analysis/problem_case_builder.py
+++ b/backend/core/logic/report_analysis/problem_case_builder.py
@@ -427,6 +427,9 @@ def _build_problem_cases_lean(
             for key in ("problem_reasons", "problem_tags", "primary_issue"):
                 if key in existing_summary:
                     summary_obj[key] = existing_summary[key]
+            for key in ("merge_explanations", "ai_explanations", "merge_scoring"):
+                if key in existing_summary:
+                    summary_obj[key] = existing_summary[key]
         else:
             primary_issue, problem_reasons, problem_tags = _extract_candidate_reason(cand)
             reasons_list = _coerce_list(problem_reasons) or []

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -509,7 +509,9 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
     assert tags_a_first == _expected_minimal_tags(16, timestamp=timestamp)
     assert tags_b_first == _expected_minimal_tags(11, timestamp=timestamp)
     assert summary_a_first["merge_explanations"][0]["with"] == 16
+    assert any(entry.get("origin") == "ai" for entry in summary_a_first["merge_explanations"])
     assert summary_b_first["ai_explanations"][0]["decision"] == "merge"
+    assert summary_b_first["ai_explanations"][0]["normalized"] is False
 
     payload = auto_ai_tasks.ai_score_step.run(sid, str(runs_root))
     payload = auto_ai_tasks.ai_build_packs_step.run(payload)

--- a/tests/report_analysis/test_tags_compact.py
+++ b/tests/report_analysis/test_tags_compact.py
@@ -109,6 +109,9 @@ def test_compact_tags_moves_verbose_data_to_summary(tmp_path: Path) -> None:
     assert {entry.get("kind") for entry in ai_entries} == {"ai_decision", "same_debt_pair"}
     ai_decision_entry = next(entry for entry in ai_entries if entry.get("kind") == "ai_decision")
     assert ai_decision_entry["with"] == 16
+    assert ai_decision_entry["normalized"] is False
+    assert ai_decision_entry["decision"] == "different"
+    assert ai_decision_entry["reason"].startswith("Different account numbers")
     assert "raw_response" in ai_decision_entry
     same_debt_entry = next(entry for entry in ai_entries if entry.get("kind") == "same_debt_pair")
     assert same_debt_entry["reason"].startswith("Different account numbers")


### PR DESCRIPTION
## Summary
- preserve existing summary metadata when compacting account tags so AI decisions retain reasons and merge scoring values
- write normalized-aware AI explanation entries, including AI merge markers, while avoiding overwriting summary fields when tags are minimal
- keep lean problem case builder from dropping merge and AI explanation data, and extend tests to cover the new expectations

## Testing
- pytest tests/report_analysis/test_tags_compact.py
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d5836c6f9083259a36d48fa3df4d48