### PR TITLE
Ensure atomic writes for tags and summary artifacts

### DIFF
--- a/backend/core/io/json_io.py
+++ b/backend/core/io/json_io.py
@@ -1,0 +1,23 @@
+"""Lightweight JSON IO helpers with atomic writes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    """Atomically write ``payload`` as JSON to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+__all__ = ["_atomic_write_json"]
+


### PR DESCRIPTION
## Summary
- add a reusable atomic JSON write helper for shared use
- ensure tag compaction writes tags and summary files atomically and emits log markers

## Testing
- pytest tests/backend/core/io/test_tags.py

------
https://chatgpt.com/codex/tasks/task_b_68d58717f4c88325a11bb1d2c8279fdc