### PR TITLE
Ensure AI pack manifest updates before no-pack checks

### DIFF
--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -229,15 +229,14 @@ def main(argv: Sequence[str] | None = None) -> None:
         packs_in_index = len(index_payload.get("packs", []))
         log.info("INDEX_WRITTEN sid=%s index=%s pairs=%d", sid, index_path, packs_in_index)
 
-        manifest = RunManifest.for_sid(sid)
-        manifest.set_ai_built(packs_dir, packs_in_index)
+        manifest = RunManifest.for_sid(sid).set_ai_built(packs_dir, pairs_count)
         persist_manifest(manifest)
         log.info(
             "MANIFEST_AI_PACKS_UPDATED sid=%s dir=%s index=%s pairs=%d",
             sid,
             packs_dir,
             index_path,
-            packs_in_index,
+            pairs_count,
         )
     else:
         log.info("INDEX_SKIPPED_NO_PAIRS sid=%s dir=%s", sid, packs_dir)


### PR DESCRIPTION
## Summary
- update the AI merge pack builder to persist the manifest immediately after writing index.json
- guard the auto AI pipeline against setting `skipped_no_packs` when packs exist and add build logging

## Testing
- python -m compileall scripts/build_ai_merge_packs.py backend/pipeline/auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d5881da9648325bc90f34ed4192cae