### PR TITLE
Add configurable account number weights

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -57,6 +57,10 @@ def env_int(name: str, default: int) -> int:
     val = os.getenv(name)
     if val is None:
         return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
 
 
 def env_list(name: str, default: list[str]) -> list[str]:
@@ -66,10 +70,6 @@ def env_list(name: str, default: list[str]) -> list[str]:
         return default
     parts = [p.strip() for p in val.split(",") if p.strip()]
     return parts or default
-    try:
-        return int(val)
-    except ValueError:
-        return default
 
 
 # Backwards compatibility for older imports
@@ -198,6 +198,11 @@ UTILIZATION_PROBLEM_THRESHOLD = float(
     os.getenv("UTILIZATION_PROBLEM_THRESHOLD", "0.90")
 )
 SERIOUS_DELINQUENCY_MIN_DPD = int(os.getenv("SERIOUS_DELINQUENCY_MIN_DPD", "60"))
+
+ACCTNUM_EXACT_WEIGHT = env_int("ACCTNUM_EXACT_WEIGHT", 50)
+ACCTNUM_LAST5_WEIGHT = env_int("ACCTNUM_LAST5_WEIGHT", 35)
+ACCTNUM_LAST4_WEIGHT = env_int("ACCTNUM_LAST4_WEIGHT", 25)
+ACCTNUM_MASKED_WEIGHT = env_int("ACCTNUM_MASKED_WEIGHT", 15)
 
 ENABLE_TIER1_KEYWORDS = _env_bool("ENABLE_TIER1_KEYWORDS", False)
 ENABLE_TIER2_KEYWORDS = _env_bool("ENABLE_TIER2_KEYWORDS", False)

--- a/backend/core/logic/merge/scorer.py
+++ b/backend/core/logic/merge/scorer.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
+from backend import config as app_config
 from scripts.score_bureau_pairs import ScoreComputationResult, score_accounts
 
 _DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
+
+logger = logging.getLogger(__name__)
+
+SCORER_WEIGHTS = {
+    "acctnum_exact": app_config.ACCTNUM_EXACT_WEIGHT,
+    "last5": app_config.ACCTNUM_LAST5_WEIGHT,
+    "last4": app_config.ACCTNUM_LAST4_WEIGHT,
+    "masked": app_config.ACCTNUM_MASKED_WEIGHT,
+}
 
 
 def score_bureau_pairs_cli(
@@ -26,6 +37,13 @@ def score_bureau_pairs_cli(
     """
 
     sid_str = str(sid)
+    logger.info(
+        "SCORER_WEIGHTS acctnum_exact=%s last5=%s last4=%s masked=%s",
+        SCORER_WEIGHTS["acctnum_exact"],
+        SCORER_WEIGHTS["last5"],
+        SCORER_WEIGHTS["last4"],
+        SCORER_WEIGHTS["masked"],
+    )
     runs_root_path = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
     return score_accounts(sid_str, runs_root=runs_root_path, write_tags=write_tags)
 

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -12,6 +12,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
+from backend import config as app_config
 from backend.core.io.tags import read_tags, upsert_tag, write_tags_atomic
 from backend.core.logic.normalize.accounts import (
     last4 as normalize_last4,
@@ -271,10 +272,10 @@ _ACCOUNT_LEVEL_ORDER = {
     "exact": 4,
 }
 _ACCOUNT_NUMBER_WEIGHTS = {
-    "masked_match": 15,
-    "last4": 25,
-    "last5": 35,
-    "exact": 50,
+    "masked_match": app_config.ACCTNUM_MASKED_WEIGHT,
+    "last4": app_config.ACCTNUM_LAST4_WEIGHT,
+    "last5": app_config.ACCTNUM_LAST5_WEIGHT,
+    "exact": app_config.ACCTNUM_EXACT_WEIGHT,
 }
 _MASK_CHARS = {"*", "x", "X", "•", "●"}
 


### PR DESCRIPTION
## Summary
- allow account number scoring weights to be overridden via environment variables
- log the active account-number weights when running the scorer utility
- ensure integer environment overrides are parsed correctly in the config helper

## Testing
- pytest tests/report_analysis/test_merge_cfg.py

------
https://chatgpt.com/codex/tasks/task_b_68d58b45b780832595a4531f09265075