### PR TITLE
Add adjudicator and acctnum normalization tests

### DIFF
--- a/tests/ai/test_adjudicator_contract.py
+++ b/tests/ai/test_adjudicator_contract.py
@@ -1,0 +1,40 @@
+"""Contract tests for AI adjudicator normalization."""
+from __future__ import annotations
+
+from backend.core.ai.adjudicator import _normalize_and_validate_decision
+
+
+def test_normalizes_decision_to_match_flags() -> None:
+    """Flags win over the raw decision when they disagree."""
+
+    payload = {
+        "decision": "MERGE",
+        "reason": "  inconsistent debt  ",
+        "flags": {"account_match": "true", "debt_match": "FALSE"},
+    }
+
+    normalized, was_normalized = _normalize_and_validate_decision(payload)
+
+    assert normalized["decision"] == "same_account_debt_diff"
+    assert normalized["reason"] == "inconsistent debt"
+    assert normalized["flags"] == {"account_match": True, "debt_match": False}
+    assert normalized["normalized"] is True
+    assert was_normalized is True
+
+
+def test_keeps_merge_when_flags_strong_match() -> None:
+    """The adjudicator keeps a merge decision when both flags are true."""
+
+    payload = {
+        "decision": " merge ",
+        "reason": "Shared account number and balance",
+        "flags": {"account_match": True, "debt_match": True},
+    }
+
+    normalized, was_normalized = _normalize_and_validate_decision(payload)
+
+    assert normalized["decision"] == "merge"
+    assert normalized["reason"] == "Shared account number and balance"
+    assert normalized["flags"] == {"account_match": True, "debt_match": True}
+    assert "normalized" not in normalized
+    assert was_normalized is False

--- a/tests/merge/test_acctnum_normalization.py
+++ b/tests/merge/test_acctnum_normalization.py
@@ -1,0 +1,31 @@
+"""Tests for account-number tokenization and match levels."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.logic.report_analysis import account_merge
+from backend.core.logic.report_analysis.account_merge import AcctnumToken
+
+
+def test_account_number_level_exact() -> None:
+    assert account_merge.account_number_level("001234567890", "1234567890") == "exact"
+
+
+def test_account_number_level_last4() -> None:
+    assert account_merge.account_number_level("12345678", "005678") == "last4"
+
+
+def test_account_number_level_masked_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    token_a = AcctnumToken(value="012", masked_value="**012", signature="MMDDD")
+    token_b = AcctnumToken(value="012", masked_value="xx012", signature="MMDDD")
+
+    def _fake_normalize(raw: str) -> dict[str, set[str | AcctnumToken]]:
+        if raw == "first":
+            return {"last4": set(), "last5": set(), "tokens": {token_a}}
+        if raw == "second":
+            return {"last4": set(), "last5": set(), "tokens": {token_b}}
+        raise AssertionError(f"Unexpected raw value: {raw}")
+
+    monkeypatch.setattr(account_merge, "normalize_acctnum", _fake_normalize)
+
+    assert account_merge.account_number_level("first", "second") == "masked_match"

--- a/tests/pipeline/test_ai_resolution_flow.py
+++ b/tests/pipeline/test_ai_resolution_flow.py
@@ -1,0 +1,142 @@
+"""Minimal end-to-end tests for the AI resolution pipeline."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import send_ai_merge_packs
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "flags,expected_decision,expected_pair",
+    [
+        ({"account_match": True, "debt_match": True}, "merge", "same_account_pair"),
+        (
+            {"account_match": "true", "debt_match": "FALSE"},
+            "same_account_debt_diff",
+            "same_account_pair",
+        ),
+        (
+            {"account_match": "false", "debt_match": "true"},
+            "same_debt_account_diff",
+            "same_debt_pair",
+        ),
+        (
+            {"account_match": False, "debt_match": False},
+            "different",
+            None,
+        ),
+    ],
+)
+def test_send_packs_normalizes_decisions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    flags: dict[str, bool | str],
+    expected_decision: str,
+    expected_pair: str | None,
+) -> None:
+    runs_root = tmp_path / "runs"
+    sid = f"flow-{expected_decision}"
+    packs_dir = runs_root / sid / "ai_packs"
+    packs_dir.mkdir(parents=True, exist_ok=True)
+
+    pack_filename = "pair_001_002.jsonl"
+    pack_payload = {
+        "messages": [
+            {"role": "system", "content": "instructions"},
+            {"role": "user", "content": "Account pair"},
+        ]
+    }
+    (packs_dir / pack_filename).write_text(
+        json.dumps(pack_payload, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    index_payload = {
+        "sid": sid,
+        "pairs": [
+            {
+                "a": 1,
+                "b": 2,
+                "pack_file": pack_filename,
+                "lines_a": 0,
+                "lines_b": 0,
+                "score_total": 0,
+            }
+        ],
+    }
+    _write_json(packs_dir / "index.json", index_payload)
+
+    accounts_root = runs_root / sid / "cases" / "accounts"
+    _write_json(accounts_root / "1" / "tags.json", [])
+    _write_json(accounts_root / "2" / "tags.json", [])
+
+    monkeypatch.setenv("ENABLE_AI_ADJUDICATOR", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("RUNS_ROOT", str(runs_root))
+
+    reason = f"Stub decision for {expected_decision}"
+    timestamp = "2024-07-01T00:00:00Z"
+
+    def _fake_decide(pack: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+        assert pack == pack_payload
+        return {"decision": "merge", "reason": reason, "flags": dict(flags)}
+
+    monkeypatch.setattr(send_ai_merge_packs, "decide_merge_or_different", _fake_decide)
+    monkeypatch.setattr(
+        send_ai_merge_packs,
+        "_isoformat_timestamp",
+        lambda dt=None: timestamp,
+    )
+
+    send_ai_merge_packs.main(["--sid", sid, "--runs-root", str(runs_root)])
+
+    tags_a = json.loads((accounts_root / "1" / "tags.json").read_text(encoding="utf-8"))
+    tags_b = json.loads((accounts_root / "2" / "tags.json").read_text(encoding="utf-8"))
+
+    def _expected_flags(raw_flags: dict[str, bool | str]) -> dict[str, bool | str]:
+        normalized: dict[str, bool | str] = {}
+        for key, value in raw_flags.items():
+            if isinstance(value, str):
+                lowered = value.strip().lower()
+                if lowered == "unknown":
+                    normalized[key] = "unknown"
+                else:
+                    normalized[key] = lowered == "true"
+            else:
+                normalized[key] = bool(value)
+        return normalized
+
+    expected_flags = _expected_flags(flags)
+
+    ai_tag_a = next(tag for tag in tags_a if tag["kind"] == "ai_decision")
+    assert ai_tag_a["decision"] == expected_decision
+    assert ai_tag_a["with"] == 2
+    assert ai_tag_a["reason"] == reason
+    assert ai_tag_a["flags"] == expected_flags
+
+    ai_tag_b = next(tag for tag in tags_b if tag["kind"] == "ai_decision")
+    assert ai_tag_b["decision"] == expected_decision
+    assert ai_tag_b["with"] == 1
+    assert ai_tag_b["reason"] == reason
+    assert ai_tag_b["flags"] == expected_flags
+
+    def _pair_kinds(tags: list[dict[str, Any]]) -> set[str]:
+        return {tag["kind"] for tag in tags if tag["kind"] in {"same_account_pair", "same_debt_pair"}}
+
+    pair_kinds_a = _pair_kinds(tags_a)
+    pair_kinds_b = _pair_kinds(tags_b)
+
+    if expected_pair is None:
+        assert pair_kinds_a == set()
+        assert pair_kinds_b == set()
+    else:
+        assert pair_kinds_a == {expected_pair}
+        assert pair_kinds_b == {expected_pair}


### PR DESCRIPTION
## Summary
- add unit coverage for the adjudicator decision normalization contract
- cover account-number tokenizer outputs for exact, last4, and masked-match scenarios
- exercise the send_ai_merge_packs flow to ensure decisions are normalized before tagging

## Testing
- pytest tests/ai/test_adjudicator_contract.py tests/merge/test_acctnum_normalization.py tests/pipeline/test_ai_resolution_flow.py

------
https://chatgpt.com/codex/tasks/task_b_68d58c40e9ac8325a191a9ab77ed77b5