### PR TITLE
Improve account number matching levels

### DIFF
--- a/tests/merge/test_acctnum_normalization.py
+++ b/tests/merge/test_acctnum_normalization.py
@@ -23,7 +23,7 @@ def test_normalize_acctnum_handles_mask_only() -> None:
 
 
 def test_account_number_level_exact() -> None:
-    assert account_merge.account_number_level("001234567890", "1234567890") == "exact"
+    assert account_merge.account_number_level("1234567890", "1234567890") == "exact"
 
 
 def test_account_number_level_last6() -> None:
@@ -32,3 +32,15 @@ def test_account_number_level_last6() -> None:
 
 def test_account_number_level_last4() -> None:
     assert account_merge.account_number_level("12345678", "005678") == "last4"
+
+
+def test_acctnum_match_level_masked_exact() -> None:
+    level, debug = account_merge.acctnum_match_level("**12**34", "**12**34")
+    assert level == "exact"
+    assert debug["left"]["canon_mask"] == "*12*34"
+    assert debug["right"]["canon_mask"] == "*12*34"
+
+
+def test_acctnum_match_level_prefers_last6() -> None:
+    level, _ = account_merge.acctnum_match_level("99123456", "123456")
+    assert level == "last6"

--- a/tests/report_analysis/test_account_merge_helpers_det.py
+++ b/tests/report_analysis/test_account_merge_helpers_det.py
@@ -75,7 +75,7 @@ def test_payment_amount_zero_rule_respected():
     "a,b,expected",
     [
         ("123456", "123456", "exact"),
-        ("000123456", "123456", "exact"),
+        ("000123456", "123456", "last6"),
         ("1111123456", "222223456", "last4"),
         ("abcd", "****", "none"),
     ],

--- a/tests/report_analysis/test_account_merge_score_pair.py
+++ b/tests/report_analysis/test_account_merge_score_pair.py
@@ -47,7 +47,7 @@ ACCOUNT_POINTS = {
 @pytest.mark.parametrize(
     "left,right,expected_level",
     [
-        ("1234", "001234", "exact"),
+        ("1234", "001234", "last4"),
         ("XXXX1234", "99991234", "last4"),
         ("99-123456", "123456", "last6"),
         ("**** ****3000", "***3000", "exact"),


### PR DESCRIPTION
## Summary
- add an acctnum_match_level helper that normalizes digits and detects exact/last6/last4 matches
- wire the helper into the scorer so account number matches log MERGE_V2_ACCTNUM_MATCH and flow into matched_fields
- refresh merge scoring tests to exercise the new levels and debug payloads

## Testing
- pytest tests/merge/test_acctnum_normalization.py tests/report_analysis/test_account_merge_helpers_det.py
- pytest tests/scripts/test_score_bureau_pairs.py
- pytest tests/report_analysis/test_account_merge_score_pair.py

------
https://chatgpt.com/codex/tasks/task_b_68d5abd3b5d88325b1a3031fe92fa229