### PR TITLE
Add account number merge logging and expose levels

### DIFF
--- a/backend/core/logic/tags/compact.py
+++ b/backend/core/logic/tags/compact.py
@@ -311,16 +311,24 @@ def _merge_explanation_from_tag(tag: Mapping[str, object]) -> dict[str, object] 
             payload[key] = value
             meaningful = True
 
+    acct_level_value: str | None = None
     aux = tag.get("aux")
     if isinstance(aux, Mapping):
         acct_level = aux.get("acctnum_level")
-        if _has_value(acct_level):
-            payload.setdefault("acctnum_level", acct_level)
-            meaningful = True
+        if isinstance(acct_level, str) and acct_level:
+            acct_level_value = acct_level
         matched_fields = aux.get("matched_fields")
         if isinstance(matched_fields, Mapping) and matched_fields:
             payload.setdefault("matched_fields", dict(matched_fields))
             meaningful = True
+
+    if acct_level_value is None:
+        direct_level = tag.get("acctnum_level")
+        if isinstance(direct_level, str) and direct_level:
+            acct_level_value = direct_level
+    if acct_level_value is not None:
+        payload["acctnum_level"] = acct_level_value
+        meaningful = True
 
     return payload if meaningful else None
 


### PR DESCRIPTION
## Summary
- emit structured MERGE_V2_ACCTNUM_MATCH logs with the detected account-number match level and last-four digits
- carry the account-number match level and boolean into merge scoring aux data and best-partner summaries
- surface the account-number level in merge explanations for merge_pair and merge_best entries

## Testing
- pytest tests/report_analysis/test_account_merge_score_pair.py tests/report_analysis/test_account_merge_best_partner.py

------
https://chatgpt.com/codex/tasks/task_b_68d5b1a6834c8325a1e16f0c49a3655f