### PR TITLE
Improve account-number match detection with formatted digits

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -377,6 +377,12 @@ def acctnum_match_level(a: str | None, b: str | None) -> Tuple[str, Dict[str, Di
     digits_a = str(norm_a.get("digits") or "")
     digits_b = str(norm_b.get("digits") or "")
 
+    has_digits_a = bool(norm_a.get("has_digits"))
+    has_digits_b = bool(norm_b.get("has_digits"))
+
+    if not has_digits_a and not has_digits_b:
+        return "none", debug
+
     has_mask_a = bool(norm_a.get("has_mask"))
     has_mask_b = bool(norm_b.get("has_mask"))
 
@@ -395,8 +401,21 @@ def acctnum_match_level(a: str | None, b: str | None) -> Tuple[str, Dict[str, Di
             return "last4"
         return "masked_match"
 
-    if digits_a and digits_b and len(digits_a) == len(digits_b) and digits_a == digits_b:
-        level = _level_for_visible_digits(len(digits_a), has_mask_a, has_mask_b)
+    def _normalize_for_exact(digits: str) -> str:
+        if not digits:
+            return ""
+        trimmed = digits.lstrip("0")
+        return trimmed if trimmed else "0"
+
+    normalized_a = _normalize_for_exact(digits_a)
+    normalized_b = _normalize_for_exact(digits_b)
+
+    if normalized_a and normalized_b and normalized_a == normalized_b:
+        visible_digits = max(
+            int(norm_a.get("visible_digits") or 0),
+            int(norm_b.get("visible_digits") or 0),
+        )
+        level = _level_for_visible_digits(visible_digits, has_mask_a, has_mask_b)
         return level, debug
 
     canon_a = str(norm_a.get("canon_mask") or "")

--- a/tests/core/test_acctnum_matching.py
+++ b/tests/core/test_acctnum_matching.py
@@ -18,6 +18,12 @@ MATCH_CASES = [
     ("****-**789012", "789012", "last6", account_merge.POINTS_ACCTNUM_LAST6),
     ("****-****-****-0423", "X X X X 0423", "last4", account_merge.POINTS_ACCTNUM_LAST4),
     ("****-****-****-1111", "....2222", "none", 0),
+    (
+        "0000 1234 5678 9000",
+        "123456789000",
+        "exact",
+        account_merge.POINTS_ACCTNUM_EXACT,
+    ),
 ]
 
 

--- a/tests/merge/test_acctnum_normalization.py
+++ b/tests/merge/test_acctnum_normalization.py
@@ -44,3 +44,13 @@ def test_acctnum_match_level_masked_last4() -> None:
 def test_acctnum_match_level_prefers_last6() -> None:
     level, _ = account_merge.acctnum_match_level("99123456", "123456")
     assert level == "last6"
+
+
+def test_acctnum_match_level_trims_leading_zero_for_exact() -> None:
+    level, _ = account_merge.acctnum_match_level("000012345678", "12345678")
+    assert level == "exact"
+
+
+def test_acctnum_match_level_fully_masked_returns_none() -> None:
+    level, _ = account_merge.acctnum_match_level("********", "XXXX")
+    assert level == "none"


### PR DESCRIPTION
## Summary
- treat account numbers with only formatting differences as exact matches by normalizing leading zeros and ignoring fully masked pairs
- keep acctnum scoring metadata consistent downstream and cover the edge cases with dedicated tests

## Testing
- pytest tests/merge/test_acctnum_normalization.py tests/core/test_acctnum_matching.py tests/report_analysis/test_account_merge_score_pair.py

------
https://chatgpt.com/codex/tasks/task_b_68d5b5db07e88325b658215c1093552e