### PR TITLE
Fix merge scorer account-number matching

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -533,6 +533,7 @@ _ACCOUNT_LAST4_KEYS = (
     "account_last4",
     "last4",
     "account_number",
+    "account_number_display",
 )
 _TYPE_FIELDS = {"creditor_type", "account_type"}
 
@@ -678,6 +679,8 @@ def match_field_best_of_9(
         if not isinstance(left_branch, Mapping):
             continue
         raw_left = left_branch.get(field_key)
+        if field_key == "account_number" and is_missing(raw_left):
+            raw_left = left_branch.get("account_number_display")
         if is_missing(raw_left):
             continue
         norm_left = _normalize_field_value(field_key, raw_left)
@@ -689,6 +692,8 @@ def match_field_best_of_9(
             if not isinstance(right_branch, Mapping):
                 continue
             raw_right = right_branch.get(field_key)
+            if field_key == "account_number" and is_missing(raw_right):
+                raw_right = right_branch.get("account_number_display")
             if is_missing(raw_right):
                 continue
             norm_right = _normalize_field_value(field_key, raw_right)

--- a/tests/core/test_acctnum_matching.py
+++ b/tests/core/test_acctnum_matching.py
@@ -32,6 +32,27 @@ def cfg() -> account_merge.MergeCfg:
     return account_merge.get_merge_cfg({})
 
 
+def test_account_number_display_is_used_for_matching(cfg: account_merge.MergeCfg) -> None:
+    bureaus_a = {
+        "transunion": {"account_number_display": "****1234"},
+        "experian": {},
+        "equifax": {},
+    }
+    bureaus_b = {
+        "transunion": {},
+        "experian": {"account_number_display": "XX1234"},
+        "equifax": {},
+    }
+
+    result = account_merge.score_pair_0_100(bureaus_a, bureaus_b, cfg)
+
+    assert result["aux"]["account_number"]["acctnum_level"] == "last4"
+    assert (
+        result["parts"]["account_number"]
+        == account_merge.POINTS_ACCTNUM_LAST4
+    )
+
+
 @pytest.mark.parametrize("left,right,expected_level,expected_points", MATCH_CASES)
 def test_acctnum_match_scoring(
     cfg: account_merge.MergeCfg,


### PR DESCRIPTION
## Summary
- include account_number_display values when matching account numbers during merge scoring so the field can award points
- capture account_number_display entries when collecting account-number last4 values for conflict detection and logging
- add a regression test covering account_number_display fallback matching

## Testing
- pytest tests/core/test_acctnum_matching.py
- pytest tests/report_analysis/test_account_merge_score_pair.py

------
https://chatgpt.com/codex/tasks/task_b_68d5ba083ae8832599acad9539b09b11