### PR TITLE
Surface account-number levels in merge summaries

### DIFF
--- a/backend/core/logic/merge/scorer.py
+++ b/backend/core/logic/merge/scorer.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
+from dataclasses import replace
 from pathlib import Path
+from typing import Any, Dict
 
 from backend import config as app_config
 from scripts.score_bureau_pairs import ScoreComputationResult, score_accounts
@@ -19,6 +22,34 @@ SCORER_WEIGHTS = {
     "last4": app_config.ACCTNUM_LAST4_WEIGHT,
     "masked": app_config.ACCTNUM_MASKED_WEIGHT,
 }
+
+
+def _ensure_tag_levels(
+    merge_tags: Mapping[int, Mapping[str, Any]] | None,
+) -> Dict[int, Dict[str, Any]]:
+    enriched: Dict[int, Dict[str, Any]] = {}
+    if not isinstance(merge_tags, Mapping):
+        return enriched
+
+    for idx, tag in merge_tags.items():
+        if not isinstance(tag, Mapping):
+            continue
+        tag_dict = dict(tag)
+        acct_level = tag_dict.get("acctnum_level")
+        if not isinstance(acct_level, str) or not acct_level:
+            aux_payload = tag_dict.get("aux")
+            if isinstance(aux_payload, Mapping):
+                acct_level = str(aux_payload.get("acctnum_level") or "none")
+            else:
+                acct_level = "none"
+        tag_dict["acctnum_level"] = acct_level
+        try:
+            key = int(idx)
+        except (TypeError, ValueError):
+            continue
+        enriched[key] = tag_dict
+
+    return enriched
 
 
 def score_bureau_pairs_cli(
@@ -45,7 +76,13 @@ def score_bureau_pairs_cli(
         SCORER_WEIGHTS["masked"],
     )
     runs_root_path = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
-    return score_accounts(sid_str, runs_root=runs_root_path, write_tags=write_tags)
+    computation = score_accounts(
+        sid_str, runs_root=runs_root_path, write_tags=write_tags
+    )
+    enriched_tags = _ensure_tag_levels(computation.merge_tags)
+    if enriched_tags:
+        computation = replace(computation, merge_tags=enriched_tags)
+    return computation
 
 
 __all__ = ["score_bureau_pairs_cli"]

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1645,6 +1645,12 @@ def _normalize_merge_payload_for_tag(
         for reason in payload["reasons"]
     )
 
+    aux_payload = payload.get("aux")
+    acct_level = "none"
+    if isinstance(aux_payload, Mapping):
+        acct_level = str(aux_payload.get("acctnum_level") or "none")
+    payload["acctnum_level"] = acct_level
+
     return payload
 
 
@@ -1734,6 +1740,7 @@ def _merge_tag_from_best(
             "reasons": [],
             "tiebreaker": "none",
         }
+        merge_tag["acctnum_level"] = "none"
         return merge_tag
 
     score_total = int(best_result.get("total", 0) or 0)
@@ -1742,6 +1749,7 @@ def _merge_tag_from_best(
     conflicts = list(best_result.get("conflicts", []))
     parts = _sanitize_parts(best_result.get("parts"))
     aux_payload = _build_aux_payload(best_result.get("aux", {}))
+    acct_level = str(aux_payload.get("acctnum_level", "none") or "none")
 
     score_entries = _build_score_entries(partner_scores, best_partner)
     best_entry = {
@@ -1767,6 +1775,7 @@ def _merge_tag_from_best(
         "reasons": reasons,
         "tiebreaker": tiebreaker,
     }
+    merge_tag["acctnum_level"] = acct_level
     return merge_tag
 
 

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -523,7 +523,7 @@ def _write_decision_tags_resolved(
             reasons = unique_reasons
             matched_fields: dict[str, bool] = {}
             aux_payload = merge_tag.get("aux")
-            acctnum_level: str | None = None
+            acctnum_level = "none"
             if isinstance(aux_payload, MappingABC):
                 raw_matched = aux_payload.get("matched_fields")
                 if isinstance(raw_matched, MappingABC):
@@ -542,8 +542,7 @@ def _write_decision_tags_resolved(
                 "identity_score": identity_score,
                 "debt_score": debt_score,
             }
-            if acctnum_level:
-                merge_summary["acctnum_level"] = acctnum_level
+            merge_summary["acctnum_level"] = acctnum_level
             summary_payload["merge_scoring"] = merge_summary
             _write_summary(summary_path, summary_payload)
 

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -779,17 +779,20 @@ def test_ai_pairing_flow_compaction(
         "last_payment": True,
         "account_number": True,
     }
+    assert "acctnum_level" in merge_entry
 
     merge_score_a = summary_a.get("merge_scoring")
     assert merge_score_a
     assert merge_score_a["best_with"] == 16
     assert merge_score_a["score_total"] >= 0
     assert merge_score_a["matched_fields"].get("balance_owed") is True
+    assert "acctnum_level" in merge_score_a
 
     merge_score_b = summary_b.get("merge_scoring")
     assert merge_score_b
     assert merge_score_b["best_with"] == 11
     assert merge_score_b["matched_fields"].get("balance_owed") is True
+    assert "acctnum_level" in merge_score_b
 
     # Tags should remain compact on repeated compaction.
     snapshot_a = json.loads((account_a_dir / "tags.json").read_text(encoding="utf-8"))

--- a/tests/test_manifest_cases_registration.py
+++ b/tests/test_manifest_cases_registration.py
@@ -128,6 +128,9 @@ def test_build_problem_cases_writes_tags(tmp_path):
     summary_path = run_dir / "cases" / "accounts" / "0" / "summary.json"
     summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
     assert "merge_tag" not in summary_data
+    merge_scoring_summary = summary_data.get("merge_scoring")
+    if isinstance(merge_scoring_summary, dict):
+        assert "acctnum_level" in merge_scoring_summary
 
     assert summary["merge_scoring"]["scores"][0][1]["decision"] == "ai"
     assert summary["merge_scoring"]["best"][0]["partner_index"] == 1


### PR DESCRIPTION
## Summary
- ensure merge tag payloads returned by the CLI wrapper always expose the derived account-number level
- propagate the account-number level onto merge tag structures so summaries and explanations can surface it
- record the account-number level in AI merge summaries and extend tests to assert the new field appears

## Testing
- pytest tests/scripts/test_send_ai_merge_packs.py
- pytest tests/scripts/test_score_bureau_pairs.py
- pytest tests/test_manifest_cases_registration.py

------
https://chatgpt.com/codex/tasks/task_b_68d5da56278c8325b7a80711e9c4361d