### PR TITLE
Track best bureau pair per field in merge scoring

### DIFF
--- a/tests/report_analysis/test_account_merge_helpers_det.py
+++ b/tests/report_analysis/test_account_merge_helpers_det.py
@@ -139,6 +139,26 @@ def test_match_field_best_of_9_cross_bureau_balance():
     assert aux["normalized_values"] == (100.0, 100.0)
 
 
+def test_match_field_best_of_9_unmatched_has_best_pair():
+    cfg = get_merge_cfg()
+    account_a = {
+        "transunion": {"balance_owed": "100"},
+        "experian": {},
+        "equifax": {},
+    }
+    account_b = {
+        "transunion": {},
+        "experian": {"balance_owed": "175"},
+        "equifax": {},
+    }
+
+    matched, aux = match_field_best_of_9("balance_owed", account_a, account_b, cfg)
+
+    assert matched is False
+    assert aux["best_pair"] == ("transunion", "experian")
+    assert aux["normalized_values"] == (100.0, 175.0)
+
+
 def test_match_field_best_of_9_account_number_aux():
     cfg = get_merge_cfg()
     account_a = {


### PR DESCRIPTION
## Summary
- evaluate every cross-bureau combination per merge field and keep the winning pair metadata even when no tolerance match occurs
- retain the strongest account-number pairing while recording the first viable combination for other fields so matched_pairs surfaces the source bureaus
- document the behavior with a new deterministic helper test that covers the unmatched scenario

## Testing
- `pytest tests/report_analysis/test_account_merge_helpers_det.py`


------
https://chatgpt.com/codex/tasks/task_b_68d5ed979764832584c7bd70dd6a8e14