### PR TITLE
Add bureau-level account number matcher to merge scorer

### DIFF
--- a/backend/core/logic/merge/scorer.py
+++ b/backend/core/logic/merge/scorer.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping as TypingMapping
 
 from backend import config as app_config
-from scripts.score_bureau_pairs import ScoreComputationResult, score_accounts
+from backend.core.merge import acctnum
+from scripts.score_bureau_pairs import (
+    ScoreComputationResult,
+    build_merge_tags,
+    build_pair_rows,
+    choose_best_partner_cached,
+    compute_scores_for_sid,
+    persist_merge_tags_to_tags,
+)
 
 _DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
 
@@ -50,20 +59,134 @@ def _ensure_tag_levels(
     return enriched
 
 
+def _load_bureau_payload(path: Path) -> Dict[str, Dict[str, Any]]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        logger.exception("MERGE_V2_ACCT_LOAD_FAILED path=%s", path)
+        return {}
+
+    if not isinstance(data, Mapping):
+        return {}
+
+    result: Dict[str, Dict[str, Any]] = {}
+    for bureau in ("transunion", "experian", "equifax"):
+        branch = data.get(bureau)
+        if isinstance(branch, Mapping):
+            result[bureau] = dict(branch)
+        else:
+            result[bureau] = {}
+    return result
+
+
+def _normalize_account_numbers(
+    payload: Mapping[str, Mapping[str, Any]] | None,
+) -> Dict[str, acctnum.NormalizedAccountNumber]:
+    normalized: Dict[str, acctnum.NormalizedAccountNumber] = {}
+    if not isinstance(payload, Mapping):
+        payload = {}
+    for bureau in ("transunion", "experian", "equifax"):
+        display = ""
+        branch = payload.get(bureau)
+        if isinstance(branch, Mapping):
+            display = str(branch.get("account_number_display") or "")
+        normalized[bureau] = acctnum.normalize_display(display)
+    return normalized
+
+
+def _update_result_with_match(
+    result: Dict[str, Any],
+    match: acctnum.AccountNumberMatch,
+) -> None:
+    parts = dict(result.get("parts") or {})
+    old_points = int(parts.get("account_number", 0) or 0)
+    new_points = match.points
+    parts["account_number"] = new_points
+    result["parts"] = parts
+
+    diff = new_points - old_points
+    for key in ("identity_score", "identity_sum", "total"):
+        try:
+            current = int(result.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            current = 0
+        result[key] = current + diff
+
+    highlights = dict(result.get("highlights") or {})
+    highlights["acctnum_level"] = match.level
+    result["highlights"] = highlights
+
+    matched_fields = dict(result.get("matched_fields") or {})
+    matched = match.level != "none"
+    matched_fields["account_number"] = matched
+    result["matched_fields"] = matched_fields
+
+    matched_pairs = dict(result.get("matched_pairs") or {})
+    if matched:
+        matched_pairs["account_number"] = [match.a_bureau, match.b_bureau]
+    else:
+        matched_pairs.pop("account_number", None)
+    result["matched_pairs"] = matched_pairs
+
+    aux = dict(result.get("aux") or {})
+    acct_aux = dict(aux.get("account_number") or {})
+    acct_aux["acctnum_level"] = match.level
+    acct_aux["matched"] = matched
+    acct_aux["best_pair"] = [match.a_bureau, match.b_bureau] if matched else []
+    acct_aux["raw_values"] = {"a": match.a.raw, "b": match.b.raw}
+    acct_aux["acctnum_debug"] = {
+        "a": match.a.to_debug_dict(),
+        "b": match.b.to_debug_dict(),
+    }
+    aux["account_number"] = acct_aux
+    result["aux"] = aux
+
+
+def _apply_account_number_scoring(
+    sid: str,
+    indices: Iterable[int],
+    scores_by_idx: TypingMapping[int, TypingMapping[int, Dict[str, Any]]],
+    normalized_by_idx: Mapping[int, Dict[str, acctnum.NormalizedAccountNumber]],
+) -> None:
+    sorted_indices = list(sorted(indices))
+    for pos, i in enumerate(sorted_indices):
+        left_scores = scores_by_idx.get(i)
+        if not isinstance(left_scores, Mapping):
+            continue
+        a_norm = normalized_by_idx.get(i, {})
+        for j in sorted_indices[pos + 1 :]:
+            result = left_scores.get(j)
+            if not isinstance(result, dict):
+                continue
+            b_norm = normalized_by_idx.get(j, {})
+            match = acctnum.best_account_number_match(a_norm, b_norm)
+            _update_result_with_match(result, match)
+            right_scores = scores_by_idx.get(j)
+            if isinstance(right_scores, Mapping):
+                reverse = right_scores.get(i)
+                if isinstance(reverse, dict):
+                    _update_result_with_match(reverse, match.swapped())
+            logger.info(
+                "MERGE_V2_ACCT_BEST sid=%s i=%s j=%s level=%s a_bureau=%s b_bureau=%s a_digits=%s b_digits=%s",
+                sid,
+                i,
+                j,
+                match.level,
+                match.a_bureau,
+                match.b_bureau,
+                match.a.digits,
+                match.b.digits,
+            )
+
+
 def score_bureau_pairs_cli(
     *, sid: str, write_tags: bool = False, runs_root: Path | str | None = None
 ) -> ScoreComputationResult:
-    """Execute the score-bureau-pairs workflow similar to the CLI.
-
-    Parameters
-    ----------
-    sid:
-        The run/session identifier.
-    write_tags:
-        When ``True`` persists merge tags back to account ``tags.json`` files.
-    runs_root:
-        Optional override for the runs directory root.
-    """
+    """Execute the score-bureau-pairs workflow similar to the CLI."""
 
     sid_str = str(sid)
     logger.info(
@@ -72,9 +195,45 @@ def score_bureau_pairs_cli(
         SCORER_WEIGHTS["masked"],
     )
     runs_root_path = Path(runs_root) if runs_root is not None else _DEFAULT_RUNS_ROOT
-    computation = score_accounts(
-        sid_str, runs_root=runs_root_path, write_tags=write_tags
+
+    indices, scores_by_idx = compute_scores_for_sid(sid_str, runs_root=runs_root_path)
+
+    if indices:
+        normalized_by_idx: Dict[int, Dict[str, acctnum.NormalizedAccountNumber]] = {}
+        for idx in indices:
+            path = (
+                runs_root_path
+                / sid_str
+                / "cases"
+                / "accounts"
+                / str(idx)
+                / "bureaus.json"
+            )
+            payload = _load_bureau_payload(path)
+            normalized_by_idx[idx] = _normalize_account_numbers(payload)
+        _apply_account_number_scoring(sid_str, indices, scores_by_idx, normalized_by_idx)
+        best_by_idx = choose_best_partner_cached(scores_by_idx)
+        rows = build_pair_rows(scores_by_idx)
+        merge_tags = build_merge_tags(scores_by_idx, best_by_idx)
+        if write_tags:
+            merge_tags = persist_merge_tags_to_tags(
+                sid_str, scores_by_idx, best_by_idx, runs_root=runs_root_path
+            )
+    else:
+        best_by_idx = {}
+        rows = []
+        merge_tags = {}
+
+    computation = ScoreComputationResult(
+        sid=sid_str,
+        runs_root=runs_root_path,
+        indices=indices,
+        scores_by_idx=scores_by_idx,
+        best_by_idx=best_by_idx,
+        merge_tags=merge_tags,
+        rows=rows,
     )
+
     enriched_tags = _ensure_tag_levels(computation.merge_tags)
     if enriched_tags:
         computation = replace(computation, merge_tags=enriched_tags)

--- a/backend/core/merge/__init__.py
+++ b/backend/core/merge/__init__.py
@@ -1,0 +1,17 @@
+"""Core helpers for merge candidate generation."""
+
+from .acctnum import (
+    AccountNumberMatch,
+    NormalizedAccountNumber,
+    best_account_number_match,
+    match_level,
+    normalize_display,
+)
+
+__all__ = [
+    "AccountNumberMatch",
+    "NormalizedAccountNumber",
+    "best_account_number_match",
+    "match_level",
+    "normalize_display",
+]

--- a/backend/core/merge/acctnum.py
+++ b/backend/core/merge/acctnum.py
@@ -1,0 +1,129 @@
+"""Account-number normalization and bureau-pair matching helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+__all__ = [
+    "AccountNumberMatch",
+    "NormalizedAccountNumber",
+    "best_account_number_match",
+    "match_level",
+    "normalize_display",
+]
+
+_BUREAUS = ("transunion", "experian", "equifax")
+
+_LEVEL_POINTS: Dict[str, int] = {
+    "exact": 40,
+    "last6_bin": 32,
+    "last6": 28,
+}
+
+_LEVEL_RANK: Dict[str, int] = {
+    "none": 0,
+    "last6": 1,
+    "last6_bin": 2,
+    "exact": 3,
+}
+
+
+@dataclass(frozen=True)
+class NormalizedAccountNumber:
+    """Normalized representation of a bureau account number display."""
+
+    raw: str
+    digits: str
+    digits_last4: str
+    digits_last5: str
+    digits_last6: str
+    digits_first6: str
+
+    @property
+    def has_digits(self) -> bool:
+        return bool(self.digits)
+
+    def to_debug_dict(self) -> Dict[str, str]:
+        return {
+            "raw": self.raw,
+            "digits": self.digits,
+            "digits_last4": self.digits_last4,
+            "digits_last5": self.digits_last5,
+            "digits_last6": self.digits_last6,
+            "digits_first6": self.digits_first6,
+        }
+
+
+_EMPTY_NORMALIZED = NormalizedAccountNumber("", "", "", "", "", "")
+
+
+def normalize_display(display: str | None) -> NormalizedAccountNumber:
+    """Normalize an ``account_number_display`` value to digits and helpers."""
+
+    raw = str(display or "")
+    digits = re.sub(r"\D", "", raw)
+    last4 = digits[-4:] if len(digits) >= 4 else ""
+    last5 = digits[-5:] if len(digits) >= 5 else ""
+    last6 = digits[-6:] if len(digits) >= 6 else ""
+    bin6 = digits[:6] if len(digits) >= 6 else ""
+    return NormalizedAccountNumber(raw, digits, last4, last5, last6, bin6)
+
+
+@dataclass(frozen=True)
+class AccountNumberMatch:
+    """Best-match metadata between two normalized account numbers."""
+
+    level: str
+    a_bureau: str
+    b_bureau: str
+    a: NormalizedAccountNumber
+    b: NormalizedAccountNumber
+
+    @property
+    def points(self) -> int:
+        return _LEVEL_POINTS.get(self.level, 0)
+
+    def swapped(self) -> "AccountNumberMatch":
+        return AccountNumberMatch(self.level, self.b_bureau, self.a_bureau, self.b, self.a)
+
+
+def match_level(a: NormalizedAccountNumber, b: NormalizedAccountNumber) -> str:
+    """Return the strict account-number level between two normalized numbers."""
+
+    if not (a.has_digits and b.has_digits):
+        return "none"
+
+    if len(a.digits) >= 8 and a.digits == b.digits:
+        return "exact"
+
+    if a.digits_last6 and b.digits_last6:
+        if a.digits_first6 and a.digits_first6 == b.digits_first6 and a.digits_last6 == b.digits_last6:
+            return "last6_bin"
+        if a.digits_last6 == b.digits_last6:
+            return "last6"
+
+    return "none"
+
+
+def best_account_number_match(
+    a_map: Mapping[str, NormalizedAccountNumber],
+    b_map: Mapping[str, NormalizedAccountNumber],
+) -> AccountNumberMatch:
+    """Compute the best bureau pairing by strict account-number level."""
+
+    best_match = AccountNumberMatch("none", "", "", _EMPTY_NORMALIZED, _EMPTY_NORMALIZED)
+    best_rank = _LEVEL_RANK[best_match.level]
+
+    for a_bureau in _BUREAUS:
+        a_norm = a_map.get(a_bureau, _EMPTY_NORMALIZED)
+        for b_bureau in _BUREAUS:
+            b_norm = b_map.get(b_bureau, _EMPTY_NORMALIZED)
+            level = match_level(a_norm, b_norm)
+            rank = _LEVEL_RANK[level]
+            if rank > best_rank:
+                best_rank = rank
+                best_match = AccountNumberMatch(level, a_bureau, b_bureau, a_norm, b_norm)
+
+    return best_match


### PR DESCRIPTION
## Summary
- add a shared account-number normalization and bureau-pair matcher module
- update the merge scorer to recompute account-number scores per bureau pairing and log the winning pair
- expose best-level metadata through parts/highlights/matched pairs and refresh merge tag handling

## Testing
- pytest tests/merge/test_acctnum_normalization.py
- pytest tests/scripts/test_score_bureau_pairs.py
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d69e2a3fd883259fe3f4a30a8be80e