### PR TITLE
Prioritize strong merge candidates and enrich limit logging

### DIFF
--- a/tests/report_analysis/test_account_merge_best_partner.py
+++ b/tests/report_analysis/test_account_merge_best_partner.py
@@ -340,3 +340,8 @@ def test_candidate_limit_prefers_hard_matches(tmp_path, monkeypatch, caplog) -> 
     assert drop_payload["reason"] == "global_limit"
     assert tuple(sorted((drop_payload["i"], drop_payload["j"]))) == (0, 2)
     assert drop_payload["priority"] == "soft_acctnum"
+    assert drop_payload["level"] == "none"
+    assert drop_payload["identity"] == 0
+    assert drop_payload["mid"] == 0
+    assert drop_payload["dates_all"] is False
+    assert drop_payload["soft"] is True


### PR DESCRIPTION
## Summary
- rank merge candidates using account-number strength, identity/mid scores, date matches, and soft flags before applying limits
- restore mid/strong gating signals and expand the soft-account gate to consider masked account numbers
- augment candidate drop logging with structured strength details and extend coverage for the limit log assertions

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py

------
https://chatgpt.com/codex/tasks/task_b_68d6aa83e2148325bb7a49a38138224b