### PR TITLE
Prioritize strong merge candidates

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1482,8 +1482,8 @@ def score_all_pairs_0_100(
 
         return (
             -level_rank,
-            -identity_val,
             -mid_val,
+            -identity_val,
             -dates_flag,
             soft_flag,
             -total_val,


### PR DESCRIPTION
## Summary
- adjust candidate sorting to prefer higher account-number ranks before applying caps
- prioritize mid and identity scores ahead of date/soft checks so stronger matches are retained when limited

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6aeefb77c8325bdd97a5e99ff7dbb