### PR TITLE
Refactor account-number matching to new substring rule

### DIFF
--- a/backend/core/merge/acctnum.py
+++ b/backend/core/merge/acctnum.py
@@ -93,13 +93,15 @@ def acctnum_match_visible(a_raw: str, b_raw: str) -> tuple[bool, dict[str, str]]
     a = _digits_only(a_raw)
     b = _digits_only(b_raw)
 
-    if not a or not b:
-        short, long_ = (a, b) if len(a) <= len(b) else (b, a)
+    short, long_ = (a, b) if len(a) <= len(b) else (b, a)
+
+    if not short or not long_:
         return False, {"short": short, "long": long_, "why": "empty"}
 
-    short, long_ = (a, b) if len(a) <= len(b) else (b, a)
-    ok = short in long_
-    return ok, {"short": short, "long": long_}
+    if short in long_:
+        return True, {"short": short, "long": long_, "why": "substring"}
+
+    return False, {"short": short, "long": long_, "why": "mismatch"}
 
 
 def acctnum_level(a_raw: str, b_raw: str) -> tuple[str, dict[str, str]]:

--- a/tests/merge/test_acctnum_normalization.py
+++ b/tests/merge/test_acctnum_normalization.py
@@ -7,19 +7,17 @@ from backend.core.logic.report_analysis import account_merge
 def test_normalize_acctnum_collapses_masks() -> None:
     result = account_merge.normalize_acctnum("**** ****1234")
     assert result["digits"] == "1234"
-    assert result["digits_last4"] == "1234"
-    assert result["digits_last6"] is None
     assert result["canon_mask"] == "*1234"
     assert result["has_digits"] is True
+    assert result["visible_digits"] == 4
 
 
 def test_normalize_acctnum_handles_mask_only() -> None:
     result = account_merge.normalize_acctnum("****")
     assert result["digits"] == ""
-    assert result["digits_last4"] is None
-    assert result["digits_last6"] is None
     assert result["canon_mask"] == "*"
     assert result["has_digits"] is False
+    assert result["visible_digits"] == 0
 
 
 def test_account_number_level_visible_digits_match() -> None:

--- a/tests/report_analysis/test_merge_cfg.py
+++ b/tests/report_analysis/test_merge_cfg.py
@@ -6,7 +6,7 @@ def _clear_env(monkeypatch):
         "AI_THRESHOLD",
         "AUTO_MERGE_THRESHOLD",
         "MERGE_AI_ON_BALOWED_EXACT",
-        "MERGE_AI_ON_ACCTNUM_LEVEL",
+        "MERGE_AI_ON_HARD_ACCTNUM",
         "MERGE_AI_ON_MID_K",
         "MERGE_AI_ON_ALL_DATES",
         "AMOUNT_TOL_ABS",
@@ -27,7 +27,7 @@ def test_get_merge_cfg_defaults(monkeypatch):
     assert cfg.thresholds["AI_THRESHOLD"] == 26
     assert cfg.thresholds["AUTO_MERGE_THRESHOLD"] == 70
     assert cfg.triggers["MERGE_AI_ON_BALOWED_EXACT"] is True
-    assert cfg.triggers["MERGE_AI_ON_ACCTNUM_LEVEL"] == "exact_or_known_match"
+    assert cfg.triggers["MERGE_AI_ON_HARD_ACCTNUM"] is True
     assert cfg.triggers["MERGE_AI_ON_MID_K"] == 26
     assert cfg.triggers["MERGE_AI_ON_ALL_DATES"] is True
     assert cfg.tolerances["AMOUNT_TOL_ABS"] == 50.0
@@ -41,7 +41,7 @@ def test_get_merge_cfg_env_overrides():
         "AI_THRESHOLD": "33",
         "AUTO_MERGE_THRESHOLD": "80",
         "MERGE_AI_ON_BALOWED_EXACT": "0",
-        "MERGE_AI_ON_ACCTNUM_LEVEL": "NONE",
+        "MERGE_AI_ON_HARD_ACCTNUM": "0",
         "MERGE_AI_ON_MID_K": "30",
         "MERGE_AI_ON_ALL_DATES": "0",
         "AMOUNT_TOL_ABS": "75.5",
@@ -55,7 +55,7 @@ def test_get_merge_cfg_env_overrides():
     assert cfg.thresholds["AI_THRESHOLD"] == 33
     assert cfg.thresholds["AUTO_MERGE_THRESHOLD"] == 80
     assert cfg.triggers["MERGE_AI_ON_BALOWED_EXACT"] is False
-    assert cfg.triggers["MERGE_AI_ON_ACCTNUM_LEVEL"] == "none"
+    assert cfg.triggers["MERGE_AI_ON_HARD_ACCTNUM"] is False
     assert cfg.triggers["MERGE_AI_ON_MID_K"] == 30
     assert cfg.triggers["MERGE_AI_ON_ALL_DATES"] is False
     assert cfg.tolerances["AMOUNT_TOL_ABS"] == 75.5

--- a/tests/scripts/test_score_bureau_pairs.py
+++ b/tests/scripts/test_score_bureau_pairs.py
@@ -70,7 +70,7 @@ def test_score_bureau_pairs_cli_helpers(runs_root: Path) -> None:
     assert row["i"] == 1 and row["j"] == 2
     assert row["decision"] == "auto"
     assert row["strong_flag"] is True
-    assert row["acctnum_level"] == "exact"
+    assert row["acctnum_level"] == "exact_or_known_match"
     assert "balance_owed" in row["parts"]
     assert row["parts"]["balance_owed"] == 31
     assert row["matched_pairs_map"]["balance_owed"] == ["transunion", "transunion"]
@@ -78,7 +78,7 @@ def test_score_bureau_pairs_cli_helpers(runs_root: Path) -> None:
     merge_tags = build_merge_tags(scores)
     assert merge_tags[1]["decision"] == "auto"
     assert merge_tags[1]["score_total"] >= 70
-    assert merge_tags[1]["aux"]["acctnum_level"] == "exact"
+    assert merge_tags[1]["aux"]["acctnum_level"] == "exact_or_known_match"
     assert merge_tags[2]["decision"] == "auto"
 
 


### PR DESCRIPTION
## Summary
- switch account-number matching to the visible-digit substring rule and expose enhanced debug logging
- simplify merge gating by replacing MERGE_AI_ON_ACCTNUM_LEVEL with MERGE_AI_ON_HARD_ACCTNUM and removing last4/5/6 metadata
- adjust merge candidate prioritization/tests so only hard substring matches earn account-number points and packs

## Testing
- pytest tests/core/test_acctnum_matching.py tests/merge/test_acctnum_normalization.py tests/report_analysis/test_merge_cfg.py tests/report_analysis/test_account_merge_best_partner.py tests/scripts/test_score_bureau_pairs.py

------
https://chatgpt.com/codex/tasks/task_b_68d6de258f8c83259ccf2e87d540755e