### PR TITLE
Enforce deterministic account number matching semantics

### DIFF
--- a/backend/core/io/tags_minimize.py
+++ b/backend/core/io/tags_minimize.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 
 from backend.core.io.tags import read_tags, write_tags_atomic
+from backend.core.merge.acctnum import normalize_level
 
 
 def _coerce_int(value: Any) -> Any:
@@ -207,8 +208,8 @@ def _merge_explanation_from_tag(tag: Mapping[str, Any]) -> dict[str, Any] | None
 
     aux = tag.get("aux")
     if isinstance(aux, Mapping):
-        acct_level = aux.get("acctnum_level")
-        if _has_value(acct_level):
+        acct_level = normalize_level(aux.get("acctnum_level"))
+        if acct_level != "none":
             payload.setdefault("acctnum_level", acct_level)
         matched_fields = aux.get("matched_fields")
         if isinstance(matched_fields, Mapping) and matched_fields:

--- a/backend/core/logic/report_analysis/ai_packs.py
+++ b/backend/core/logic/report_analysis/ai_packs.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
 
 from backend.core.io.tags import read_tags
+from backend.core.merge.acctnum import normalize_level
 from backend.core.logic.normalize import last4 as normalize_last4
 from backend.core.logic.normalize import normalize_acctnum
 from backend.core.logic.report_analysis.account_merge import get_merge_cfg
@@ -345,7 +346,9 @@ def _build_highlights(tag_payload: Mapping[str, object]) -> Mapping[str, object]
         "debt_score": debt_score,
         "matched_fields": dict(aux.get("matched_fields", {})) if isinstance(aux, Mapping) else {},
         "conflicts": conflicts,
-        "acctnum_level": str(aux.get("acctnum_level", "none")) if isinstance(aux, Mapping) else "none",
+        "acctnum_level": normalize_level(aux.get("acctnum_level"))
+        if isinstance(aux, Mapping)
+        else "none",
     }
 
 

--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -26,7 +26,7 @@ def first_n_lines(raw_lines, n):
     out = []
     for row in raw_lines:
         t = str(row.get("text","")).strip()
-        if not t: 
+        if not t:
             continue
         # דלג על בלוקים הארוכים של payment history
         if re.search(r"(Two-Year Payment History|Days Late - 7 Year History)", t, re.I):
@@ -35,6 +35,13 @@ def first_n_lines(raw_lines, n):
         if len(out) >= n:
             break
     return out
+
+
+def _normalize_level(value):
+    if isinstance(value, str) and value.strip().lower() == "exact_or_known_match":
+        return "exact_or_known_match"
+    return "none"
+
 
 def build_prompt(pair_summary, context_a, context_b):
     # SYSTEM + USER messages
@@ -57,7 +64,9 @@ def build_prompt(pair_summary, context_a, context_b):
             "strong": pair_summary.get("strong"),
             "mid_sum": pair_summary.get("mid"),
             "dates_all": pair_summary.get("dates"),
-            "acctnum_level": pair_summary.get("aux",{}).get("acctnum_level"),
+            "acctnum_level": _normalize_level(
+                pair_summary.get("aux",{}).get("acctnum_level")
+            ),
             "parts": pair_summary.get("parts",{})
         },
         "tolerances_hint": {
@@ -99,7 +108,9 @@ for pr in pairs:
             "account_number_b": pr["record"].get("aux",{}).get("acct_num_b"),
         },
         "highlights": {
-            "acctnum_level": pr["record"].get("aux",{}).get("acctnum_level"),
+            "acctnum_level": _normalize_level(
+                pr["record"].get("aux",{}).get("acctnum_level")
+            ),
             "matched_fields": pr["record"].get("aux",{}).get("matched_fields"),
             "parts": pr["record"].get("parts"),
             "total": pr["record"].get("total"),
@@ -117,7 +128,7 @@ for pr in pairs:
               "strong": pr["record"].get("strong"),
               "mid": pr["record"].get("mid"),
               "dates": pr["record"].get("dates_all"),
-              "aux": {"acctnum_level": pr["record"].get("aux",{}).get("acctnum_level")},
+                "aux": {"acctnum_level": _normalize_level(pr["record"].get("aux",{}).get("acctnum_level"))},
               "parts": pr["record"].get("parts",{})
             },
             context_a, context_b

--- a/scripts/adjudicate_pairs.py
+++ b/scripts/adjudicate_pairs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from backend.core.io.tags import read_tags
+from backend.core.merge.acctnum import normalize_level
 from backend.core.logic.report_analysis.ai_adjudicator import (
     adjudicate_pair,
     persist_ai_decision,
@@ -75,7 +76,7 @@ def _extract_highlights_from_tag(tag: Mapping[str, Any] | None) -> dict[str, Any
     except (TypeError, ValueError):
         total = None
 
-    acctnum_level = str(aux.get("acctnum_level", "none") or "none")
+    acctnum_level = normalize_level(aux.get("acctnum_level"))
 
     return {
         "total": total,

--- a/scripts/preview_ai_pack.py
+++ b/scripts/preview_ai_pack.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from backend.core.io.tags import read_tags
+from backend.core.merge.acctnum import normalize_level
 from backend.core.logic.report_analysis.ai_pack import build_ai_pack_for_pair
 from backend.pipeline.runs import RUNS_ROOT_ENV
 
@@ -70,7 +71,7 @@ def _extract_highlights_from_tag(tag: Mapping[str, Any] | None) -> dict[str, Any
     except (TypeError, ValueError):
         total = None
 
-    acctnum_level = str(aux.get("acctnum_level", "none") or "none")
+    acctnum_level = normalize_level(aux.get("acctnum_level"))
 
     return {
         "total": total,

--- a/scripts/score_bureau_pairs.py
+++ b/scripts/score_bureau_pairs.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from backend.core.logic.report_analysis.account_merge import score_all_pairs_0_100
+from backend.core.merge.acctnum import normalize_level
 
 
 DEFAULT_RUNS_ROOT = Path(os.environ.get("RUNS_ROOT", "runs"))
@@ -109,7 +110,7 @@ def _sanitize_parts(parts: Optional[Mapping[str, Any]]) -> Dict[str, int]:
 
 
 def _extract_aux_payload(aux: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
-    acct_level = "none"
+    acct_level = normalize_level(None)
     by_field_pairs: Dict[str, List[str]] = {}
     acct_digits_len_a: Optional[int] = None
     acct_digits_len_b: Optional[int] = None
@@ -118,8 +119,8 @@ def _extract_aux_payload(aux: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
         acct_aux = aux.get("account_number")
         if isinstance(acct_aux, Mapping):
             level = acct_aux.get("acctnum_level")
-            if isinstance(level, str) and level:
-                acct_level = level
+            if level is not None:
+                acct_level = normalize_level(level)
             len_a = acct_aux.get("acctnum_digits_len_a")
             len_b = acct_aux.get("acctnum_digits_len_b")
             try:

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -28,6 +28,7 @@ from backend.core.ai.adjudicator import (
     decide_merge_or_different,
 )
 from backend.core.io.tags import read_tags, upsert_tag
+from backend.core.merge.acctnum import normalize_level
 from backend.pipeline.runs import RunManifest, persist_manifest
 
 log = logging.getLogger(__name__)
@@ -523,7 +524,7 @@ def _write_decision_tags_resolved(
             reasons = unique_reasons
             matched_fields: dict[str, bool] = {}
             aux_payload = merge_tag.get("aux")
-            acctnum_level = "none"
+            acctnum_level = normalize_level(None)
             if isinstance(aux_payload, MappingABC):
                 raw_matched = aux_payload.get("matched_fields")
                 if isinstance(raw_matched, MappingABC):
@@ -531,8 +532,7 @@ def _write_decision_tags_resolved(
                         str(field): bool(flag) for field, flag in raw_matched.items()
                     }
                 acct_val = aux_payload.get("acctnum_level")
-                if isinstance(acct_val, str) and acct_val:
-                    acctnum_level = acct_val
+                acctnum_level = normalize_level(acct_val)
             merge_summary: dict[str, object] = {
                 "best_with": other_idx,
                 "score_total": score_total_int,

--- a/scripts/smoke_problem_candidates.py
+++ b/scripts/smoke_problem_candidates.py
@@ -15,6 +15,7 @@ except Exception:
 
 from collections import Counter
 from backend.core.logic.report_analysis.problem_extractor import detect_problem_accounts
+from backend.core.merge.acctnum import normalize_level
 from backend.pipeline.runs import RunManifest
 
 
@@ -318,7 +319,7 @@ def _build_merge_summary(
             "best": best_match.get("account_index"),
             "score": best_score,
             "decision": pair_decision or account_decision,
-            "acctnum_level": aux.get("acctnum_level"),
+            "acctnum_level": normalize_level(aux.get("acctnum_level")),
             "balowed_ok": bool(combined_reasons.get("balance_only_triggers_ai")),
             "reasons": [],
         }


### PR DESCRIPTION
## Summary
- normalize account-number levels to the strict substring rule and expose a helper for reuse
- clamp merge summaries, tags, and scripts to only emit `exact_or_known_match` or `none` and persist matched bureau pairs
- update downstream tooling to report sanitized account-number levels and carry the winning bureau pair

## Testing
- pytest tests/core/test_acctnum_matching.py
- pytest tests/report_analysis/test_account_merge_score_pair.py
- pytest tests/scripts/test_score_bureau_pairs.py
- pytest tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d6e2671c1083258e4b49eee8ea61bb