### PR TITLE
Add visible account number substring regression tests

### DIFF
--- a/tests/core/test_acctnum_visible_match.py
+++ b/tests/core/test_acctnum_visible_match.py
@@ -1,0 +1,21 @@
+from backend.core.merge.acctnum import acctnum_match_visible, acctnum_level
+
+
+def test_substring_left() -> None:
+    ok, _ = acctnum_match_visible("349992*****", "3499921234567")
+    assert ok and acctnum_level("349992*****", "3499921234567")[0] == "exact_or_known_match"
+
+
+def test_substring_right() -> None:
+    ok, _ = acctnum_match_visible("****6789", "123456789")
+    assert ok and acctnum_level("****6789", "123456789")[0] == "exact_or_known_match"
+
+
+def test_conflict_visible_digit() -> None:
+    ok, _ = acctnum_match_visible("555550*****", "555555*****")
+    assert not ok and acctnum_level("555550*****", "555555*****")[0] == "none"
+
+
+def test_identical_full_numbers() -> None:
+    ok, _ = acctnum_match_visible("349992123456789", "349992123456789")
+    assert ok


### PR DESCRIPTION
## Summary
- add regression tests covering account-number visible digit substring matching cases

## Testing
- pytest tests/core/test_acctnum_visible_match.py tests/core/test_acctnum_matching.py

------
https://chatgpt.com/codex/tasks/task_b_68d6e57b47a48325b0da056d0a8649f7