### PR TITLE
Ensure visible-digit account matches drive candidate selection

### DIFF
--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -833,11 +833,17 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch, caplog):
     assert merge_score_a["score_total"] >= 0
     assert "total" in merge_score_a["reasons"]
     assert merge_score_a["matched_fields"].get("balance_owed") is True
+    assert merge_score_a.get("acctnum_level") in {"exact_or_known_match", "none"}
+    assert "account_number" in merge_score_a.get("matched_pairs", {})
+    assert isinstance(merge_score_a["matched_pairs"]["account_number"], list)
 
     merge_score_b = summary_b.get("merge_scoring")
     assert merge_score_b
     assert merge_score_b["best_with"] == 11
     assert merge_score_b["matched_fields"].get("balance_owed") is True
+    assert merge_score_b.get("acctnum_level") in {"exact_or_known_match", "none"}
+    assert "account_number" in merge_score_b.get("matched_pairs", {})
+    assert isinstance(merge_score_b["matched_pairs"]["account_number"], list)
 
 
 

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -791,7 +791,7 @@ def test_ai_pairing_flow_compaction(
         "last_payment": True,
         "account_number": True,
     }
-    assert "acctnum_level" in merge_entry
+    assert merge_entry.get("acctnum_level") in {"exact_or_known_match", "none"}
     acct_pair = merge_entry["matched_pairs"]["account_number"]
     assert isinstance(acct_pair, list)
     assert len(acct_pair) == 2
@@ -803,9 +803,10 @@ def test_ai_pairing_flow_compaction(
     assert merge_score_a["best_with"] == 16
     assert merge_score_a["score_total"] >= 0
     assert merge_score_a["matched_fields"].get("balance_owed") is True
-    assert "acctnum_level" in merge_score_a
+    assert merge_score_a.get("acctnum_level") in {"exact_or_known_match", "none"}
     assert "matched_pairs" in merge_score_a
     assert "account_number" in merge_score_a["matched_pairs"]
+    assert isinstance(merge_score_a["matched_pairs"]["account_number"], list)
     assert "acctnum_digits_len_a" in merge_score_a
     assert "acctnum_digits_len_b" in merge_score_a
 
@@ -813,9 +814,10 @@ def test_ai_pairing_flow_compaction(
     assert merge_score_b
     assert merge_score_b["best_with"] == 11
     assert merge_score_b["matched_fields"].get("balance_owed") is True
-    assert "acctnum_level" in merge_score_b
+    assert merge_score_b.get("acctnum_level") in {"exact_or_known_match", "none"}
     assert "matched_pairs" in merge_score_b
     assert "account_number" in merge_score_b["matched_pairs"]
+    assert isinstance(merge_score_b["matched_pairs"]["account_number"], list)
     assert "acctnum_digits_len_a" in merge_score_b
     assert "acctnum_digits_len_b" in merge_score_b
 


### PR DESCRIPTION
## Summary
- replace soft account-number heuristics with the visible-digit matcher and emit structured skip logs from the candidate builder so hard account-number pairs bypass caps
- normalize merge summary outputs to always include sanitized acctnum_level values and a deterministic account_number pair list
- extend AI merge pack tests to assert the new summary invariants

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py
- pytest tests/scripts/test_send_ai_merge_packs.py
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d6eeea3db083258296b2b079cef091