### PR TITLE
Ensure visible-digit matches bypass candidate caps

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1444,6 +1444,18 @@ def score_all_pairs_0_100(
             allow_by_dates = dates_all_equal
             allow_by_total = ai_threshold > 0 and total_score >= ai_threshold
 
+            mid_sum = int(result.get("mid_sum", 0) or 0)
+            identity_sum = int(result.get("identity_sum", 0) or 0)
+            soft_match = False
+            if not hard_acct:
+                soft_match = _detect_soft_acct_match(left_bureaus, right_bureaus)
+
+            priority_category, priority_subscore, priority_label = _priority_category(
+                level_value, allow_by_dates, allow_by_total
+            )
+            if soft_match and priority_label == "default":
+                priority_label = "soft_acctnum"
+
             if hard_acct:
                 admit_reason = "hard_account_number"
                 allowed = True
@@ -1456,38 +1468,6 @@ def score_all_pairs_0_100(
             else:
                 admit_reason = "below_threshold_no_acctnum"
                 allowed = False
-
-            logger.info(
-                "CANDIDATE_CONSIDERED sid=%s i=%s j=%s reason=%s score=%s acct=%s dates_all=%s",
-                sid,
-                left,
-                right,
-                admit_reason,
-                total_score,
-                level_value,
-                dates_all_equal,
-            )
-
-            if not allowed:
-                logger.info(
-                    "CANDIDATE_SKIPPED sid=%s i=%s j=%s reason=%s",
-                    sid,
-                    left,
-                    right,
-                    admit_reason,
-                )
-
-            mid_sum = int(result.get("mid_sum", 0) or 0)
-            identity_sum = int(result.get("identity_sum", 0) or 0)
-            soft_match = False
-            if not hard_acct:
-                soft_match = _detect_soft_acct_match(left_bureaus, right_bureaus)
-
-            priority_category, priority_subscore, priority_label = _priority_category(
-                level_value, allow_by_dates, allow_by_total
-            )
-            if soft_match and priority_label == "default":
-                priority_label = "soft_acctnum"
 
             record = {
                 "left": left,
@@ -1514,6 +1494,17 @@ def score_all_pairs_0_100(
                 },
             }
             candidate_records.append(record)
+
+            logger.info(
+                "CANDIDATE_CONSIDERED sid=%s i=%s j=%s reason=%s score=%s acct=%s dates_all=%s",
+                sid,
+                left,
+                right,
+                admit_reason,
+                total_score,
+                level_value,
+                dates_all_equal,
+            )
 
             if not allowed:
                 _log_candidate_skipped(

--- a/backend/core/merge/acctnum.py
+++ b/backend/core/merge/acctnum.py
@@ -109,12 +109,22 @@ def _digits(s: str) -> str:
 def acctnum_visible_match(a_raw: str, b_raw: str) -> Tuple[bool, Dict[str, str]]:
     a = _digits(a_raw)
     b = _digits(b_raw)
+
+    debug: Dict[str, str] = {"a": a, "b": b, "short": "", "long": "", "why": ""}
+
     if not a or not b:
-        return False, {"a": a, "b": b, "short": "", "long": ""}
+        debug["why"] = "missing_visible_digits"
+        return False, debug
 
     short, long_ = (a, b) if len(a) <= len(b) else (b, a)
-    ok = short in long_
-    return ok, {"a": a, "b": b, "short": short, "long": long_}
+    debug["short"] = short
+    debug["long"] = long_
+
+    if short in long_:
+        return True, debug
+
+    debug["why"] = "visible_digits_mismatch"
+    return False, debug
 
 
 def acctnum_match_visible(a_raw: str, b_raw: str) -> Tuple[bool, Dict[str, str]]:

--- a/tests/core/test_acctnum_visible_digits.py
+++ b/tests/core/test_acctnum_visible_digits.py
@@ -1,0 +1,21 @@
+from backend.core.merge.acctnum import acctnum_visible_match
+
+
+def test_visible_digits_prefix_match() -> None:
+    ok, debug = acctnum_visible_match("349992*****", "3499921234")
+    assert ok
+    assert debug["short"] == "349992"
+    assert debug["long"].startswith("349992")
+
+
+def test_visible_digits_suffix_match() -> None:
+    ok, debug = acctnum_visible_match("****6789", "123456789")
+    assert ok
+    assert debug["short"] == "6789"
+    assert debug["long"].endswith("6789")
+
+
+def test_visible_digits_conflict() -> None:
+    ok, debug = acctnum_visible_match("555550*****", "555555*****")
+    assert not ok
+    assert debug["why"] == "visible_digits_mismatch"

--- a/tests/merge/test_candidate_builder.py
+++ b/tests/merge/test_candidate_builder.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+from backend.core.logic.report_analysis import account_merge
+
+
+def _write_account_payload(base: Path, idx: int, bureaus: dict) -> None:
+    account_dir = base / str(idx)
+    account_dir.mkdir(parents=True, exist_ok=True)
+    (account_dir / "bureaus.json").write_text(
+        json.dumps(bureaus, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (account_dir / "summary.json").write_text(
+        json.dumps({"account_index": idx}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (account_dir / "raw_lines.json").write_text("[]\n", encoding="utf-8")
+
+
+def _all_pairs(scores: dict[int, dict[int, dict]]) -> set[tuple[int, int]]:
+    pairs: set[tuple[int, int]] = set()
+    for left, partner_map in scores.items():
+        for right in partner_map:
+            if left == right:
+                continue
+            pair = (left, right) if left < right else (right, left)
+            pairs.add(pair)
+    return pairs
+
+
+def test_hard_pairs_bypass_per_account_caps(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MAX_CANDIDATES_PER_ACCOUNT", "1")
+    monkeypatch.setenv("MERGE_CANDIDATE_LIMIT", "1")
+
+    sid = "SID-HARD"
+    accounts_root = tmp_path / sid / "cases" / "accounts"
+
+    bureaus_28 = {"transunion": {"account_number_display": "349992*****"}}
+    bureaus_29 = {"experian": {"account_number_display": "3499921234"}}
+    bureaus_39 = {"equifax": {"account_number_display": "3499921234"}}
+
+    _write_account_payload(accounts_root, 28, bureaus_28)
+    _write_account_payload(accounts_root, 29, bureaus_29)
+    _write_account_payload(accounts_root, 39, bureaus_39)
+
+    scores = account_merge.score_all_pairs_0_100(sid, [28, 29, 39], runs_root=tmp_path)
+
+    built_pairs = _all_pairs(scores)
+    assert built_pairs == {(28, 29), (28, 39), (29, 39)}
+
+    for left, right in built_pairs:
+        result = scores[left][right]
+        acct_aux = result["aux"]["account_number"]
+        assert acct_aux["acctnum_level"] == "exact_or_known_match"
+        assert result["total"] >= account_merge.POINTS_ACCTNUM_VISIBLE
+
+
+def test_account_number_points_open_score_gate(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AI_THRESHOLD", "27")
+
+    sid = "SID-THRESHOLD"
+    accounts_root = tmp_path / sid / "cases" / "accounts"
+
+    bureaus_a = {"transunion": {"account_number_display": "123456789"}}
+    bureaus_b = {"experian": {"account_number_display": "123456789"}}
+
+    _write_account_payload(accounts_root, 0, bureaus_a)
+    _write_account_payload(accounts_root, 1, bureaus_b)
+
+    scores = account_merge.score_all_pairs_0_100(sid, [0, 1], runs_root=tmp_path)
+
+    result = scores[0][1]
+    acct_aux = result["aux"]["account_number"]
+
+    assert result["total"] == account_merge.POINTS_ACCTNUM_VISIBLE
+    assert acct_aux["acctnum_level"] == "exact_or_known_match"
+    assert "strong:account_number" in result["triggers"]


### PR DESCRIPTION
## Summary
- enrich the visible-digit account-number matcher with detailed debug context
- adjust candidate scoring to log skip reasons after computing signals and preserve hard matches
- add regression tests covering visible-digit matching and hard pair candidate limits

## Testing
- pytest tests/core/test_acctnum_visible_digits.py tests/merge/test_candidate_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68d6f213074c83258136bedf1b1d356c