### PR TITLE
Ensure hard acctnum candidates bypass limits

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -736,13 +736,21 @@ def _log_candidate_considered(
     allow_flags: Mapping[str, Any],
     total: Any,
     gate_level: Any,
+    *,
+    allowed: bool,
+    reason: str,
 ) -> None:
     _candidate_logger.info(
-        "CANDIDATE_CONSIDERED sid=%s i=%s j=%s hard_acct=%s total=%s gate=%s",
+        (
+            "CANDIDATE_CONSIDERED sid=%s i=%s j=%s hard_acct=%s allowed=%s "
+            "reason=%s total=%s gate=%s"
+        ),
         sid,
         i,
         j,
         bool(allow_flags.get("hard_acct")),
+        allowed,
+        reason,
         total,
         gate_level,
     )
@@ -1468,6 +1476,8 @@ def score_all_pairs_0_100(
                     dict(allow_flags),
                     total_score,
                     gate_level,
+                    allowed=allowed,
+                    reason=reason,
                 )
                 return record
 

--- a/backend/core/merge/acctnum.py
+++ b/backend/core/merge/acctnum.py
@@ -122,20 +122,27 @@ def acctnum_visible_match(a_raw: str, b_raw: str) -> tuple[bool, dict[str, dict[
         "short": "",
         "long": "",
         "why": "",
+        "match_offset": "",
     }
 
     if not a_digits or not b_digits:
         debug["why"] = "missing_visible_digits"
         return False, debug
 
-    short, long_ = (a_digits, b_digits) if len(a_digits) <= len(b_digits) else (b_digits, a_digits)
+    short, long_ = (
+        (a_digits, b_digits)
+        if len(a_digits) <= len(b_digits)
+        else (b_digits, a_digits)
+    )
     debug["short"] = short
     debug["long"] = long_
 
-    if short in long_:
+    offset = long_.find(short)
+    if offset != -1:
+        debug["match_offset"] = str(offset)
         return True, debug
 
-    debug["why"] = "visible_digits_mismatch"
+    debug["why"] = "visible_digits_conflict"
     return False, debug
 
 

--- a/tests/core/test_acctnum_visible_digits.py
+++ b/tests/core/test_acctnum_visible_digits.py
@@ -18,4 +18,4 @@ def test_visible_digits_suffix_match() -> None:
 def test_visible_digits_conflict() -> None:
     ok, debug = acctnum_visible_match("555550*****", "555555*****")
     assert not ok
-    assert debug["why"] == "visible_digits_mismatch"
+    assert debug["why"] == "visible_digits_conflict"


### PR DESCRIPTION
## Summary
- add richer debug output for visible-digit account number matching and surface conflicts explicitly
- include reason/allowed fields in candidate logging so hard account-number pairs are transparent and never blocked by limits

## Testing
- pytest tests/core/test_acctnum_visible_digits.py tests/report_analysis/test_account_merge_best_partner.py

------
https://chatgpt.com/codex/tasks/task_b_68d950423b948325a2c77d5e2441d16e