### PR TITLE
Ensure hard account matches always receive AI packs

### DIFF
--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -171,7 +171,8 @@ def test_build_merge_ai_packs_only_merge_best_filter(tmp_path: Path) -> None:
     _write_json(account_b_dir / "tags.json", [])
 
     packs_only_best = build_merge_ai_packs(sid, runs_root, max_lines_per_side=3)
-    assert packs_only_best == []
+    assert len(packs_only_best) == 1
+    assert packs_only_best[0]["pair"] == {"a": 21, "b": 22}
 
     packs_all = build_merge_ai_packs(
         sid,


### PR DESCRIPTION
## Summary
- ensure build_merge_ai_packs always includes pairs with exact-or-known account number matches, even when only_merge_best filtering is enabled
- add structured logging detailing whether AI pack candidates were considered or skipped and why
- update tests to expect hard account matches to bypass the merge-best-only filter

## Testing
- pytest tests/merge/test_candidate_builder.py tests/report_analysis/test_ai_packs_builder.py tests/core/test_acctnum_visible_match.py

------
https://chatgpt.com/codex/tasks/task_b_68d952687ba48325ad2e490e5b56b353