### PR TITLE
Improve logging for hard account-number matches

### DIFF
--- a/tests/core/test_acctnum_visible_digits.py
+++ b/tests/core/test_acctnum_visible_digits.py
@@ -2,20 +2,27 @@ from backend.core.merge.acctnum import acctnum_visible_match
 
 
 def test_visible_digits_prefix_match() -> None:
-    ok, debug = acctnum_visible_match("349992*****", "3499921234")
+    ok, debug = acctnum_visible_match("349992*****", "3499921234567")
     assert ok
     assert debug["short"] == "349992"
-    assert debug["long"].startswith("349992")
+    assert debug["long"] == "3499921234567"
+    assert debug["match_offset"] == "0"
+    assert debug["why"] == ""
 
 
 def test_visible_digits_suffix_match() -> None:
     ok, debug = acctnum_visible_match("****6789", "123456789")
     assert ok
     assert debug["short"] == "6789"
-    assert debug["long"].endswith("6789")
+    assert debug["long"] == "123456789"
+    assert debug["match_offset"] == "5"
+    assert debug["why"] == ""
 
 
 def test_visible_digits_conflict() -> None:
     ok, debug = acctnum_visible_match("555550*****", "555555*****")
     assert not ok
+    assert debug["short"] == "555550"
+    assert debug["long"] == "555555"
+    assert debug["match_offset"] == ""
     assert debug["why"] == "visible_digits_conflict"

--- a/tests/merge/test_candidate_builder.py
+++ b/tests/merge/test_candidate_builder.py
@@ -36,8 +36,8 @@ def test_hard_pairs_bypass_per_account_caps(tmp_path, monkeypatch) -> None:
     accounts_root = tmp_path / sid / "cases" / "accounts"
 
     bureaus_28 = {"transunion": {"account_number_display": "349992*****"}}
-    bureaus_29 = {"experian": {"account_number_display": "3499921234"}}
-    bureaus_39 = {"equifax": {"account_number_display": "3499921234"}}
+    bureaus_29 = {"experian": {"account_number_display": "3499921234567"}}
+    bureaus_39 = {"equifax": {"account_number_display": "3499921234567"}}
 
     _write_account_payload(accounts_root, 28, bureaus_28)
     _write_account_payload(accounts_root, 29, bureaus_29)


### PR DESCRIPTION
## Summary
- add structured candidate considered/skipped logging with account-number match details
- persist hard account-number scoring metadata so hard matches always bypass caps and limits
- update regression tests for visible digit matching and candidate builder scenarios

## Testing
- pytest tests/core/test_acctnum_visible_digits.py tests/merge/test_candidate_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68d954a18d8c8325a0a3fbda63a75396