### PR TITLE
Ensure hard account-number auto matches produce AI packs

### DIFF
--- a/backend/core/logic/report_analysis/ai_packs.py
+++ b/backend/core/logic/report_analysis/ai_packs.py
@@ -423,8 +423,11 @@ def _collect_pair_entries(accounts_root: Path) -> tuple[Dict[tuple[int, int], Li
             if kind not in allowed_kinds:
                 continue
             decision = str(tag.get("decision", "")).lower()
+            acct_level = _extract_acct_level(tag)
             if decision != "ai":
-                continue
+                is_hard_auto = decision == "auto" and acct_level == "exact_or_known_match"
+                if not is_hard_auto:
+                    continue
             partner = tag.get("with")
             try:
                 partner_idx = int(partner)


### PR DESCRIPTION
## Summary
- allow hard account-number matches with auto decisions to be collected for AI pack building
- add regression test guaranteeing auto-decision hard matches still produce packs

## Testing
- pytest tests/report_analysis/test_ai_packs_builder.py -vv

------
https://chatgpt.com/codex/tasks/task_b_68d96736870883258d93011fe7ec131c