### PR TITLE
Fix MERGE_V2 hard gate normalization

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1457,11 +1457,13 @@ def score_all_pairs_0_100(
                 "MERGE_V2_DECISION %s", json.dumps(decision_log, sort_keys=True)
             )
 
-            gate_level_norm = level_value
-            if gate_level_norm in {"", "none"}:
-                gate_level_norm = _sanitize_acct_level(gate_level)
+            normalized_level = acct_level
+            if normalized_level in {"", "none"}:
+                normalized_level = level_value
+            if normalized_level in {"", "none"}:
+                normalized_level = _sanitize_acct_level(gate_level)
 
-            normalized_level = level_value if level_value not in {"", "none"} else gate_level_norm
+            gate_level_norm = normalized_level
             hard_acct = normalized_level == "exact_or_known_match"
             dates_all_equal = bool(result.get("dates_all"))
             allow_by_dates = dates_all_equal


### PR DESCRIPTION
## Summary
- ensure MERGE_V2 pair gating defers to normalized account-number matches before falling back to raw gate levels
- add a regression test proving multiple packs are produced when the normalized account number level qualifies the pair

## Testing
- pytest tests/report_analysis/test_account_merge_best_partner.py::test_score_pairs_respect_normalized_hard_gate
- pytest tests/report_analysis/test_account_merge_best_partner.py

------
https://chatgpt.com/codex/tasks/task_b_68d9737a611c8325a6193c460091b539