### PR TITLE
Add unit test for hard gate normalization in pack builder

### DIFF
--- a/tests/merge/test_pack_hard_gate.py
+++ b/tests/merge/test_pack_hard_gate.py
@@ -1,0 +1,23 @@
+from backend.core.logic.report_analysis import account_merge
+
+
+def test_should_build_pack_hard_gate_uses_normalized_level() -> None:
+    # Simulate a pair where the normalized account-number level indicates a hard match
+    # even though the raw gate_level does not.
+    acct_aux = {"acctnum_level": "exact_or_known_match"}
+    allow_flags = {
+        "hard_acct": account_merge._sanitize_acct_level(acct_aux["acctnum_level"]) == "exact_or_known_match",
+        "gate_level": "none",
+        "dates_all": False,
+        "dates": False,
+        "total": False,
+    }
+
+    cfg = account_merge.MergeCfg(
+        points={},
+        thresholds={"AI_THRESHOLD": 999},
+        triggers={},
+        tolerances={},
+    )
+
+    assert account_merge._should_build_pack(0, allow_flags, cfg)


### PR DESCRIPTION
## Summary
- add a unit test covering _should_build_pack when the normalized account number level hardens the gate

## Testing
- pytest tests/merge/test_pack_hard_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68d97afc06888325a87df4ef9b4a8307