### PR TITLE
Fix hard account gate normalization and add telemetry fields

### DIFF
--- a/tests/merge/test_pack_hard_gate.py
+++ b/tests/merge/test_pack_hard_gate.py
@@ -21,3 +21,28 @@ def test_should_build_pack_hard_gate_uses_normalized_level() -> None:
     )
 
     assert account_merge._should_build_pack(0, allow_flags, cfg)
+
+
+def test_normalized_account_level_prefers_level_value() -> None:
+    assert (
+        account_merge._normalized_account_level(
+            "none", "exact_or_known_match", "none"
+        )
+        == "exact_or_known_match"
+    )
+
+
+def test_normalized_account_level_falls_back_to_acct_level() -> None:
+    assert (
+        account_merge._normalized_account_level(
+            "exact_or_known_match", "none", "none"
+        )
+        == "exact_or_known_match"
+    )
+
+
+def test_normalized_account_level_uses_gate_level_last() -> None:
+    assert (
+        account_merge._normalized_account_level("none", "none", "exact_or_known_match")
+        == "exact_or_known_match"
+    )


### PR DESCRIPTION
## Summary
- derive the authoritative account-number level through a dedicated helper that prefers normalized values
- log CANDIDATE_ADDED and CANDIDATE_SKIPPED events with normalized hard-gate context in ai_packs logs
- extend hard gate unit tests to cover normalized level resolution fallbacks

## Testing
- pytest tests/merge/test_pack_hard_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68d97ba67ae08325a3f35fc28d10e6af