### PR TITLE
Ensure AI pack gating relies on normalized account levels

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1587,7 +1587,8 @@ def score_all_pairs_0_100(
             )
             return record
 
-        level_value = _sanitize_acct_level(level_value)
+        # ensure the authoritative normalized level flows through
+        level_value = _sanitize_acct_level(normalized_level or level_value)
 
         allowed, allow_reason = _should_build_pack(
             cfg=cfg,
@@ -1597,12 +1598,13 @@ def score_all_pairs_0_100(
         )
 
         considered_message = (
-            "CANDIDATE_CONSIDERED sid=%s i=%s j=%s total=%s gate_level=%s level_value=%s dates_all=%s"
+            "CANDIDATE_CONSIDERED sid=%s i=%s j=%s reason=%s total=%s gate_level=%s level_value=%s dates_all=%s"
         )
         considered_args = (
             sid,
             left,
             right,
+            allow_reason,
             total_score,
             gate_level,
             level_value,

--- a/tests/merge/test_pack_hard_gate.py
+++ b/tests/merge/test_pack_hard_gate.py
@@ -1,26 +1,73 @@
 from backend.core.logic.report_analysis import account_merge
 
 
-def test_should_build_pack_hard_gate_uses_normalized_level() -> None:
-    # Simulate a pair where the normalized account-number level indicates a hard match
-    # even though the raw gate_level does not.
-    acct_aux = {"acctnum_level": "exact_or_known_match"}
-    allow_flags = {
-        "hard_acct": account_merge._sanitize_acct_level(acct_aux["acctnum_level"]) == "exact_or_known_match",
-        "gate_level": "none",
-        "dates_all": False,
-        "dates": False,
-        "total": False,
-    }
-
-    cfg = account_merge.MergeCfg(
+def _make_cfg(*, threshold: int = 999, triggers=None) -> account_merge.MergeCfg:
+    return account_merge.MergeCfg(
         points={},
-        thresholds={"AI_THRESHOLD": 999},
-        triggers={},
+        thresholds={"AI_THRESHOLD": threshold},
+        triggers=triggers or {},
         tolerances={},
     )
 
-    assert account_merge._should_build_pack(0, allow_flags, cfg)
+
+def test_should_build_pack_hard_gate_uses_normalized_level() -> None:
+    normalized_level = account_merge._normalized_account_level(
+        "none", "exact_or_known_match", "none"
+    )
+    level_value = account_merge._sanitize_acct_level("none")
+    level_value = account_merge._sanitize_acct_level(normalized_level or level_value)
+
+    allowed, reason = account_merge._should_build_pack(
+        cfg=_make_cfg(),
+        total_score=0,
+        dates_all_equal=False,
+        level_value=level_value,
+    )
+
+    assert allowed
+    assert reason == "hard_acctnum"
+
+
+def test_should_build_pack_respects_hard_toggle_off() -> None:
+    allowed, reason = account_merge._should_build_pack(
+        cfg=_make_cfg(triggers={"MERGE_AI_ON_HARD_ACCTNUM": False}),
+        total_score=0,
+        dates_all_equal=False,
+        level_value="exact_or_known_match",
+    )
+
+    assert not allowed
+    assert reason == "below_gate"
+
+
+def test_should_build_pack_allows_dates_toggle() -> None:
+    allowed, reason = account_merge._should_build_pack(
+        cfg=_make_cfg(),
+        total_score=0,
+        dates_all_equal=True,
+        level_value="none",
+    )
+
+    assert allowed
+    assert reason == "dates_all"
+
+
+def test_should_build_pack_allows_threshold_even_when_triggers_off() -> None:
+    allowed, reason = account_merge._should_build_pack(
+        cfg=_make_cfg(
+            threshold=27,
+            triggers={
+                "MERGE_AI_ON_HARD_ACCTNUM": False,
+                "MERGE_AI_ON_ALL_DATES": False,
+            },
+        ),
+        total_score=30,
+        dates_all_equal=False,
+        level_value="none",
+    )
+
+    assert allowed
+    assert reason == "over_threshold"
 
 
 def test_normalized_account_level_prefers_level_value() -> None:


### PR DESCRIPTION
## Summary
- ensure the normalized account-number level flows into AI pack gating and include the gate reason in candidate logs
- expand AI pack gating tests to cover trigger combinations and threshold behavior

## Testing
- pytest tests/merge/test_pack_hard_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68d9878915bc8325b6561c72838e5b88