### PR TITLE
Fix AI pack gating and logging behaviour

### DIFF
--- a/tests/report_analysis/test_merge_cfg.py
+++ b/tests/report_analysis/test_merge_cfg.py
@@ -24,7 +24,7 @@ def test_get_merge_cfg_defaults(monkeypatch):
     cfg = get_merge_cfg()
 
     assert sum(cfg.points.values()) == 100
-    assert cfg.thresholds["AI_THRESHOLD"] == 26
+    assert cfg.thresholds["AI_THRESHOLD"] == 27
     assert cfg.thresholds["AUTO_MERGE_THRESHOLD"] == 70
     assert cfg.triggers["MERGE_AI_ON_BALOWED_EXACT"] is True
     assert cfg.triggers["MERGE_AI_ON_HARD_ACCTNUM"] is True


### PR DESCRIPTION
## Summary
- ensure the AI pack candidate logger writes to runs/<sid>/ai_packs/logs.txt with the provided runs_root
- update gating to build packs whenever hard account numbers, matching dates, or scores above the AI threshold are present, and raise the default threshold to 27

## Testing
- pytest tests/report_analysis/test_merge_cfg.py
- pytest tests/report_analysis/test_account_merge_pairs.py::test_account_number_clique_persists_all_pair_packs -q
- pytest tests/report_analysis/test_account_merge_best_partner.py -q

------
https://chatgpt.com/codex/tasks/task_b_68d988b6a5c88325aef153fb9c7363c2