### PR TITLE
Process all AI packs and persist results

### DIFF
--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -210,10 +210,12 @@ def main(argv: Sequence[str] | None = None) -> None:
             {
                 "a": a_idx,
                 "b": b_idx,
+                "pair": [a_idx, b_idx],
                 "pack_file": pack_filename,
                 "lines_a": len(context_a),
                 "lines_b": len(context_b),
                 "score_total": score_total,
+                "score": score_total,
             }
         )
 
@@ -223,6 +225,13 @@ def main(argv: Sequence[str] | None = None) -> None:
         index_payload = {
             "sid": sid,
             "packs": index_entries,
+            "pairs": [
+                {
+                    "pair": [entry["a"], entry["b"]],
+                    "score": entry.get("score", entry.get("score_total", 0)),
+                }
+                for entry in index_entries
+            ],
             "pairs_count": pairs_count,
         }
         _write_index(index_path, index_payload)

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -819,6 +819,21 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch, caplog):
         },
     ]
 
+    pack_files = sorted(packs_dir.glob("pair_*.jsonl"))
+    assert pack_files
+    pack_payload = json.loads(pack_files[0].read_text(encoding="utf-8"))
+    assert pack_payload["ai_result"] == {
+        "decision": "different",
+        "reason": "These tradelines describe the same debt from different collectors.",
+        "flags": {"account_match": False, "debt_match": False},
+    }
+
+    index_payload = json.loads((packs_dir / "index.json").read_text(encoding="utf-8"))
+    matching = [entry for entry in index_payload.get("pairs", []) if entry.get("pair") == [11, 16]]
+    assert matching
+    pair_entry = matching[0]
+    assert pair_entry.get("ai_result") == pack_payload["ai_result"]
+
     summary_a = json.loads((account_a / "summary.json").read_text(encoding="utf-8"))
     summary_b = json.loads((account_b / "summary.json").read_text(encoding="utf-8"))
 

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -370,6 +370,11 @@ def test_build_ai_merge_packs_cli_updates_manifest(
     assert isinstance(pair_entry["lines_a"], int)
     assert isinstance(pair_entry["lines_b"], int)
     assert isinstance(pair_entry["score_total"], int)
+    assert pair_entry["pair"] == [11, 16]
+    assert pair_entry["score"] == pair_entry["score_total"]
+
+    minimal_pairs = index_payload.get("pairs", [])
+    assert minimal_pairs == [{"pair": [11, 16], "score": pair_entry["score_total"]}]
 
     logs_path = out_dir / "logs.txt"
     assert not logs_path.exists()


### PR DESCRIPTION
## Summary
- ensure build index entries include pair identifiers and scores for every pack
- update the AI sender to iterate over all pair_*.jsonl packs, retry missing results, and persist ai_result/ai_error payloads back to packs and index.json
- extend regression tests to assert ai_result propagation into packs and index entries

## Testing
- `pytest tests/scripts/test_send_ai_merge_packs.py tests/pipeline/test_auto_ai.py`


------
https://chatgpt.com/codex/tasks/task_b_68d99a498f988325b1fb2226a83a92a1