### PR TITLE
Add summary updates for AI merge decisions

### DIFF
--- a/backend/core/logic/tags/compact.py
+++ b/backend/core/logic/tags/compact.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, MutableMapping, Sequence, Union
 
 from backend.core.io.json_io import _atomic_write_json
+from backend.core.logic.report_analysis.account_merge import merge_summary_sections
 from backend.core.merge.acctnum import normalize_level
 
 _IDENTITY_PART_FIELDS = {
@@ -735,6 +736,8 @@ def compact_account_tags(
         summary_data["merge_scoring"] = merge_scoring_summary
     elif "merge_scoring" in summary_data:
         summary_data.pop("merge_scoring", None)
+
+    merge_summary_sections(summary_data)
 
     _write_summary(summary_path, summary_data)
 

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -552,8 +552,11 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
     assert tags_b_first == _expected_minimal_tags(11, timestamp=timestamp)
     assert summary_a_first["merge_explanations"][0]["with"] == 16
     assert any(entry.get("origin") == "ai" for entry in summary_a_first["merge_explanations"])
-    assert summary_b_first["ai_explanations"][0]["decision"] == "merge"
-    assert summary_b_first["ai_explanations"][0]["normalized"] is False
+    ai_entries_b = summary_b_first["ai_explanations"]
+    assert {entry["kind"] for entry in ai_entries_b} == {"ai_decision", "same_account_pair"}
+    ai_decision_b = next(entry for entry in ai_entries_b if entry.get("kind") == "ai_decision")
+    assert ai_decision_b["decision"] == "merge"
+    assert ai_decision_b.get("normalized") is False
 
     payload = auto_ai_tasks.ai_score_step.run(sid, str(runs_root))
     payload = auto_ai_tasks.ai_build_packs_step.run(payload)


### PR DESCRIPTION
## Summary
- extend account_merge to build and deduplicate summary entries for merge pair and AI decision data
- update AI sender workflow to populate merge_pair and ai_explanations entries for both accounts and reuse new helpers
- compact tags summaries with the new merge dedupe logic and align tests with the enhanced summaries

## Testing
- pytest tests/report_analysis/test_account_merge_pairs.py
- pytest tests/scripts/test_send_ai_merge_packs.py
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68d99cb207f8832593018ec62134bbb4