### PR TITLE
Update adjudicator prompts and decision contract

### DIFF
--- a/backend/core/logic/report_analysis/ai_adjudicator.py
+++ b/backend/core/logic/report_analysis/ai_adjudicator.py
@@ -31,11 +31,11 @@ HIGHLIGHT_KEYS: tuple[str, ...] = (
 )
 
 ALLOWED_DECISIONS: tuple[str, ...] = (
-    "merge",
-    "same_debt",
-    "same_debt_account_different",
-    "same_account",
-    "same_account_debt_different",
+    "same_account_same_debt",
+    "same_account_diff_debt",
+    "same_account_debt_unknown",
+    "same_debt_diff_account",
+    "same_debt_account_unknown",
     "different",
 )
 
@@ -47,11 +47,21 @@ SYSTEM_MESSAGE = (
     "supporting evidence but cannot override conflicts backed by strong signals. "
     "Creditor names may appear with aliases, abbreviations, or formatting "
     "differences—treat reasonable variants as referring to the same source when "
-    "supported by other evidence. Respond ONLY with strict JSON following this "
-    "schema: {\"decision\": \"merge|same_debt|same_debt_account_different|same_account|"
-    "same_account_debt_different|different\", \"reason\": \"short natural language\", "
-    "\"flags\": {\"account_match\": true|false|\"unknown\", \"debt_match\": "
-    "true|false|\"unknown\"}}. Do not add commentary or extra keys."
+    "supported by other evidence.\n"
+    "Allowed decisions (exact strings, choose one):\n"
+    "- same_account_same_debt        # accounts align and refer to the same debt\n"
+    "- same_account_diff_debt        # same account, but debt details clearly differ\n"
+    "- same_account_debt_unknown     # same account, debt status cannot be confirmed\n"
+    "- same_debt_diff_account        # same debt, but reported under a different account\n"
+    "- same_debt_account_unknown     # same debt, account identity cannot be confirmed\n"
+    "- different                     # neither the account nor the debt matches\n"
+    "Legacy labels such as merge, same_debt, same_debt_account_different, "
+    "same_account, same_account_debt_different, and different may appear in "
+    "reference material, but you MUST respond with only the six decisions above.\n"
+    "Return strict JSON only: {\"decision\":\"<one above>\", "
+    "\"reason\":\"short natural language\", \"flags\":{\"account_match\":true|false|"
+    "\"unknown\",\"debt_match\":true|false|\"unknown\"}}. Do not add commentary or "
+    "extra keys."
 )
 
 
@@ -178,13 +188,13 @@ def _expected_decision_for_flags(account_flag: bool | str, debt_flag: bool | str
     )
 
     mapping = {
-        ("true", "true"): "merge",
-        ("true", "false"): "same_account_debt_different",
-        ("true", "unknown"): "same_account",
-        ("false", "true"): "same_debt_account_different",
+        ("true", "true"): "same_account_same_debt",
+        ("true", "false"): "same_account_diff_debt",
+        ("true", "unknown"): "same_account_debt_unknown",
+        ("false", "true"): "same_debt_diff_account",
         ("false", "false"): "different",
         ("false", "unknown"): "different",
-        ("unknown", "true"): "same_debt",
+        ("unknown", "true"): "same_debt_account_unknown",
         ("unknown", "false"): "different",
         ("unknown", "unknown"): "different",
     }

--- a/backend/core/logic/report_analysis/ai_packs.py
+++ b/backend/core/logic/report_analysis/ai_packs.py
@@ -27,13 +27,16 @@ SYSTEM_PROMPT = (
     "describe the same obligation. Consider high-precision cues (account numbers, "
     "balances, dates) and lender/brand name variants. Use the numeric summary as a "
     "hint but override it if context contradicts the data.\n"
-    "Allowed decisions (exact strings): merge, same_debt, same_debt_account_different, "
-    "same_account, same_account_debt_different, different.\n"
-    "When account identifiers align but debt facts conflict, choose "
-    "same_account_debt_different. When debt details align but tradelines are clearly "
-    "different, choose same_debt_account_different. If identifiers align yet debt is "
-    "uncertain, choose same_account; if debt aligns but account identity is unclear, "
-    "choose same_debt. Only pick merge when BOTH account and debt match.\n"
+    "Allowed decisions (exact strings, choose one):\n"
+    "- same_account_same_debt        # accounts align and refer to the same debt\n"
+    "- same_account_diff_debt        # same account, but debt details clearly differ\n"
+    "- same_account_debt_unknown     # same account, debt status cannot be confirmed\n"
+    "- same_debt_diff_account        # same debt, but reported under a different account\n"
+    "- same_debt_account_unknown     # same debt, account identity cannot be confirmed\n"
+    "- different                     # neither the account nor the debt matches\n"
+    "Legacy labels (merge, same_debt, same_debt_account_different, same_account, "
+    "same_account_debt_different, different) may appear in reference material, but "
+    "you MUST respond using only the six decisions above.\n"
     "Return strict JSON only: {\"decision\":\"<one above>\",\"reason\":\"short natural "
     "language\",\"flags\":{\"account_match\":true|false|\"unknown\",\"debt_match\":true|false|"
     "\"unknown\"}}. Do not add commentary or extra keys."
@@ -603,11 +606,11 @@ def build_merge_ai_packs(
             "context": {"a": context_a, "b": context_b},
             "output_contract": {
                 "decision": [
-                    "merge",
-                    "same_debt",
-                    "same_debt_account_different",
-                    "same_account",
-                    "same_account_debt_different",
+                    "same_account_same_debt",
+                    "same_account_diff_debt",
+                    "same_account_debt_unknown",
+                    "same_debt_diff_account",
+                    "same_debt_account_unknown",
                     "different",
                 ],
                 "reason": "short natural language",

--- a/backend/core/logic/report_analysis/ai_sender.py
+++ b/backend/core/logic/report_analysis/ai_sender.py
@@ -24,30 +24,30 @@ RETRY_BACKOFF_SECONDS: Sequence[float] = (1.0, 3.0, 7.0)
 MAX_RETRIES = len(RETRY_BACKOFF_SECONDS)
 
 ALLOWED_DECISIONS = {
-    "merge",
-    "same_debt",
-    "same_debt_account_different",
-    "same_account",
-    "same_account_debt_different",
+    "same_account_same_debt",
+    "same_account_diff_debt",
+    "same_account_debt_unknown",
+    "same_debt_diff_account",
+    "same_debt_account_unknown",
     "different",
 }
 
 PAIR_TAG_BY_DECISION: dict[str, str] = {
-    "merge": "same_account_pair",
-    "same_account": "same_account_pair",
-    "same_account_debt_different": "same_account_pair",
-    "same_debt": "same_debt_pair",
-    "same_debt_account_different": "same_debt_pair",
+    "same_account_same_debt": "same_account_pair",
+    "same_account_diff_debt": "same_account_pair",
+    "same_account_debt_unknown": "same_account_pair",
+    "same_debt_diff_account": "same_debt_pair",
+    "same_debt_account_unknown": "same_debt_pair",
 }
 
 _EXPECTED_DECISION_BY_FLAGS = {
-    ("true", "true"): "merge",
-    ("true", "false"): "same_account_debt_different",
-    ("true", "unknown"): "same_account",
-    ("false", "true"): "same_debt_account_different",
+    ("true", "true"): "same_account_same_debt",
+    ("true", "false"): "same_account_diff_debt",
+    ("true", "unknown"): "same_account_debt_unknown",
+    ("false", "true"): "same_debt_diff_account",
     ("false", "false"): "different",
     ("false", "unknown"): "different",
-    ("unknown", "true"): "same_debt",
+    ("unknown", "true"): "same_debt_account_unknown",
     ("unknown", "false"): "different",
     ("unknown", "unknown"): "different",
 }

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -143,11 +143,11 @@ def test_build_merge_ai_packs_curates_context_and_prompt(tmp_path: Path) -> None
     assert user_payload["ids"]["account_number_a_last4"] == "9451"
     assert user_payload["ids"]["account_number_b_last4"] == "9451"
     assert user_payload["output_contract"]["decision"] == [
-        "merge",
-        "same_debt",
-        "same_debt_account_different",
-        "same_account",
-        "same_account_debt_different",
+        "same_account_same_debt",
+        "same_account_diff_debt",
+        "same_account_debt_unknown",
+        "same_debt_diff_account",
+        "same_debt_account_unknown",
         "different",
     ]
     assert user_payload["output_contract"]["flags"] == {


### PR DESCRIPTION
## Summary
- update the adjudicator system prompts to document the six new decision labels and return contract
- align decision validation/mapping logic, pack metadata, and tests with the renamed decisions so the pipeline accepts the new outputs

## Testing
- pytest tests/report_analysis/test_ai_packs_builder.py tests/report_analysis/test_ai_adjudicator_prompt.py

------
https://chatgpt.com/codex/tasks/task_b_68d9b839d9d88325b9a130d4da8d7869