### PR TITLE
Refine account number normalization matching

### DIFF
--- a/tests/core/test_acctnum_matching.py
+++ b/tests/core/test_acctnum_matching.py
@@ -11,23 +11,29 @@ MATCH_CASES = [
     (
         "349992*****",
         "3499921234567",
-        "exact_or_known_match",
-        account_merge.POINTS_ACCTNUM_VISIBLE,
+        "none",
+        0,
     ),
     (
         "****6789",
         "123456789",
-        "exact_or_known_match",
-        account_merge.POINTS_ACCTNUM_VISIBLE,
+        "none",
+        0,
     ),
     ("555550*****", "555555*****", "none", 0),
     (
         "****-****-****-0423",
         "X X X X 0423",
+        "none",
+        0,
+    ),
+    ("****-****-****-1111", "....2222", "none", 0),
+    (
+        "M20191",
+        "M20191",
         "exact_or_known_match",
         account_merge.POINTS_ACCTNUM_VISIBLE,
     ),
-    ("****-****-****-1111", "....2222", "none", 0),
 ]
 
 
@@ -50,8 +56,8 @@ def test_account_number_display_is_used_for_matching(cfg: account_merge.MergeCfg
 
     result = account_merge.score_pair_0_100(bureaus_a, bureaus_b, cfg)
 
-    assert result["aux"]["account_number"]["acctnum_level"] == "exact_or_known_match"
-    assert result["parts"]["account_number"] == account_merge.POINTS_ACCTNUM_VISIBLE
+    assert result["aux"]["account_number"]["acctnum_level"] == "none"
+    assert result["parts"]["account_number"] == 0
 
 
 @pytest.mark.parametrize("left,right,expected_level,expected_points", MATCH_CASES)

--- a/tests/core/test_acctnum_visible_match.py
+++ b/tests/core/test_acctnum_visible_match.py
@@ -3,12 +3,18 @@ from backend.core.merge.acctnum import acctnum_match_visible, acctnum_level
 
 def test_substring_left() -> None:
     ok, _ = acctnum_match_visible("349992*****", "3499921234567")
-    assert ok and acctnum_level("349992*****", "3499921234567")[0] == "exact_or_known_match"
+    assert ok
+    level, debug = acctnum_level("349992*****", "3499921234567")
+    assert level == "none"
+    assert debug["why"] == "digit_conflict"
 
 
 def test_substring_right() -> None:
     ok, _ = acctnum_match_visible("****6789", "123456789")
-    assert ok and acctnum_level("****6789", "123456789")[0] == "exact_or_known_match"
+    assert ok
+    level, debug = acctnum_level("****6789", "123456789")
+    assert level == "none"
+    assert debug["why"] == "digit_conflict"
 
 
 def test_conflict_visible_digit() -> None:

--- a/tests/merge/test_acctnum_normalization.py
+++ b/tests/merge/test_acctnum_normalization.py
@@ -23,7 +23,7 @@ def test_normalize_acctnum_handles_mask_only() -> None:
 def test_account_number_level_visible_digits_match() -> None:
     assert (
         account_merge.account_number_level("349992*****", "3499921234567")
-        == "exact_or_known_match"
+        == "none"
     )
 
 
@@ -35,11 +35,12 @@ def test_account_number_level_requires_substring() -> None:
 
 def test_acctnum_match_level_debug_payload() -> None:
     level, debug = account_merge.acctnum_match_level("****6789", "123456789")
-    assert level == "exact_or_known_match"
+    assert level == "none"
     assert debug["short"] == "6789"
     assert debug["long"] == "123456789"
     assert debug["a"]["digits"] == "6789"
     assert debug["b"]["digits"] == "123456789"
+    assert debug.get("why") == "digit_conflict"
 
 
 def test_acctnum_match_level_requires_visible_digits() -> None:


### PR DESCRIPTION
## Summary
- tighten `acctnum_level` so only identical normalized account numbers count as exact matches while preserving detailed debug metadata
- add alphanumeric normalization helper and conflict reasons to distinguish digit-only and alpha-numeric mismatches
- update account-number merge tests to reflect the stricter matching rules and cover identical alphanumeric cases

## Testing
- pytest tests/core/test_acctnum_visible_match.py
- pytest tests/merge/test_acctnum_normalization.py
- pytest tests/core/test_acctnum_matching.py

------
https://chatgpt.com/codex/tasks/task_b_68d9c4b484688325be19452cdb08b287