### PR TITLE
Add AI resolution summary entries with normalized metadata

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -2217,9 +2217,21 @@ def build_summary_ai_entries(
     if reason_text:
         ai_result_payload["reason"] = reason_text
 
-    decision_entry["flags"] = final_flags
+    decision_entry["flags"] = dict(final_flags)
     decision_entry["ai_result"] = dict(ai_result_payload)
     entries.append(decision_entry)
+
+    resolution_entry: Dict[str, Any] = {
+        "kind": "ai_resolution",
+        "with": partner,
+        "normalized": normalized_flag,
+        "decision": normalized_decision or "different",
+        "flags": dict(final_flags),
+        "ai_result": dict(ai_result_payload),
+    }
+    if reason_text:
+        resolution_entry["reason"] = reason_text
+    entries.append(resolution_entry)
 
     pair_kind = AI_PAIR_KIND_BY_DECISION.get(normalized_decision or "")
     if pair_kind:

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -553,10 +553,19 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
     assert summary_a_first["merge_explanations"][0]["with"] == 16
     assert any(entry.get("origin") == "ai" for entry in summary_a_first["merge_explanations"])
     ai_entries_b = summary_b_first["ai_explanations"]
-    assert {entry["kind"] for entry in ai_entries_b} == {"ai_decision", "same_account_pair"}
+    assert {entry["kind"] for entry in ai_entries_b} == {
+        "ai_decision",
+        "ai_resolution",
+        "same_account_pair",
+    }
     ai_decision_b = next(entry for entry in ai_entries_b if entry.get("kind") == "ai_decision")
     assert ai_decision_b["decision"] == "merge"
     assert ai_decision_b.get("normalized") is False
+    ai_resolution_b = next(
+        entry for entry in ai_entries_b if entry.get("kind") == "ai_resolution"
+    )
+    assert ai_resolution_b["decision"] == "merge"
+    assert ai_resolution_b.get("normalized") is False
 
     payload = auto_ai_tasks.ai_score_step.run(sid, str(runs_root))
     payload = auto_ai_tasks.ai_build_packs_step.run(payload)

--- a/tests/report_analysis/test_account_merge_pairs.py
+++ b/tests/report_analysis/test_account_merge_pairs.py
@@ -208,6 +208,13 @@ def test_build_summary_ai_entries_normalizes_aliases() -> None:
     assert ai_entry["normalized"] is True
     assert ai_entry["ai_result"]["decision"] == "same_debt_account_unknown"
 
+    resolution_entry = next(
+        entry for entry in entries if entry.get("kind") == "ai_resolution"
+    )
+    assert resolution_entry["decision"] == "same_debt_account_unknown"
+    assert resolution_entry["normalized"] is True
+    assert resolution_entry["ai_result"]["decision"] == "same_debt_account_unknown"
+
     pair_entry = next(entry for entry in entries if entry.get("kind") == "same_debt_pair")
     assert pair_entry["ai_result"]["decision"] == "same_debt_account_unknown"
     assert "same_debt_account_unclear" in pair_entry.get("notes", [])

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -789,24 +789,44 @@ def test_ai_pairing_flow_compaction(
 
     ai_a = summary_a["ai_explanations"]
     kinds_a = {item["kind"] for item in ai_a}
-    assert kinds_a == {"ai_decision", "same_account_pair"}
+    assert kinds_a == {"ai_decision", "ai_resolution", "same_account_pair"}
     ai_entry_a = next(item for item in ai_a if item.get("kind") == "ai_decision")
     assert ai_entry_a["with"] == 16
     assert ai_entry_a.get("normalized") is False
     assert "reason" in ai_entry_a
     assert "same debt" in ai_entry_a["reason"].lower()
+    resolution_entry_a = next(
+        item for item in ai_a if item.get("kind") == "ai_resolution"
+    )
+    assert resolution_entry_a["with"] == 16
+    assert resolution_entry_a.get("normalized") is False
+    assert resolution_entry_a.get("flags") == {
+        "account_match": False,
+        "debt_match": False,
+    }
+    assert "same debt" in resolution_entry_a.get("reason", "").lower()
     pair_entry_a = next(item for item in ai_a if item.get("kind") == "same_account_pair")
     assert pair_entry_a["with"] == 16
     assert "same debt" in pair_entry_a.get("reason", "").lower()
 
     ai_b = summary_b["ai_explanations"]
     kinds_b = {item["kind"] for item in ai_b}
-    assert kinds_b == {"ai_decision", "same_account_pair"}
+    assert kinds_b == {"ai_decision", "ai_resolution", "same_account_pair"}
     ai_entry_b = next(item for item in ai_b if item.get("kind") == "ai_decision")
     assert ai_entry_b["with"] == 11
     assert ai_entry_b.get("normalized") is False
     assert "reason" in ai_entry_b
     assert "same debt" in ai_entry_b["reason"].lower()
+    resolution_entry_b = next(
+        item for item in ai_b if item.get("kind") == "ai_resolution"
+    )
+    assert resolution_entry_b["with"] == 11
+    assert resolution_entry_b.get("normalized") is False
+    assert resolution_entry_b.get("flags") == {
+        "account_match": False,
+        "debt_match": False,
+    }
+    assert "same debt" in resolution_entry_b.get("reason", "").lower()
     pair_entry_b = next(item for item in ai_b if item.get("kind") == "same_account_pair")
     assert pair_entry_b["with"] == 11
     assert "same debt" in pair_entry_b.get("reason", "").lower()


### PR DESCRIPTION
## Summary
- add ai_resolution summary entries alongside ai_decision and reuse normalized decision metadata
- extend tag compaction to surface ai_resolution entries with consistent flag defaults and ai_result payloads
- update tests covering merge summary helpers, tag compaction, and AI send flow expectations

## Testing
- pytest tests/report_analysis/test_account_merge_pairs.py
- pytest tests/report_analysis/test_tags_compact.py::test_compact_tags_moves_verbose_data_to_summary
- pytest tests/scripts/test_send_ai_merge_packs.py::test_ai_pairing_flow_compaction

------
https://chatgpt.com/codex/tasks/task_b_68d9c80d1d0083258e54664718018fc5