### PR TITLE
Update adjudicator contract decisions and tests

### DIFF
--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -424,26 +424,27 @@ def _serialize_match_flag(value: bool | str | object) -> bool | str:
 
 
 _DECISION_CONTRACT = [
-    "merge",
-    "same_debt",
-    "same_debt_account_diff",
-    "same_account",
-    "same_account_debt_diff",
+    "same_account_same_debt",
+    "same_account_diff_debt",
+    "same_account_debt_unknown",
+    "same_debt_diff_account",
+    "same_debt_account_unknown",
     "different",
 ]
 
 _DECISION_CONTRACT_TEXT = (
-    '"decision": ["merge", "same_debt", "same_debt_account_diff", '
-    '"same_account", "same_account_debt_diff", "different"]'
+    '"decision": ["same_account_same_debt", "same_account_diff_debt", '
+    '"same_account_debt_unknown", "same_debt_diff_account", '
+    '"same_debt_account_unknown", "different"]'
 )
 
 
 _PAIR_TAG_BY_DECISION: dict[str, str] = {
-    "same_account": "same_account_pair",
-    "same_account_debt_diff": "same_account_pair",
-    "merge": "same_account_pair",
-    "same_debt": "same_debt_pair",
-    "same_debt_account_diff": "same_debt_pair",
+    "same_account_same_debt": "same_account_pair",
+    "same_account_diff_debt": "same_account_pair",
+    "same_account_debt_unknown": "same_account_pair",
+    "same_debt_diff_account": "same_debt_pair",
+    "same_debt_account_unknown": "same_debt_pair",
 }
 
 _IDENTITY_PART_FIELDS = {

--- a/tests/ai/test_adjudicator_contract.py
+++ b/tests/ai/test_adjudicator_contract.py
@@ -15,7 +15,7 @@ def test_normalizes_decision_to_match_flags() -> None:
 
     normalized, was_normalized = _normalize_and_validate_decision(payload)
 
-    assert normalized["decision"] == "same_account_debt_diff"
+    assert normalized["decision"] == "same_account_diff_debt"
     assert normalized["reason"] == "inconsistent debt"
     assert normalized["flags"] == {"account_match": True, "debt_match": False}
     assert normalized["normalized"] is True
@@ -33,8 +33,8 @@ def test_keeps_merge_when_flags_strong_match() -> None:
 
     normalized, was_normalized = _normalize_and_validate_decision(payload)
 
-    assert normalized["decision"] == "merge"
+    assert normalized["decision"] == "same_account_same_debt"
     assert normalized["reason"] == "Shared account number and balance"
     assert normalized["flags"] == {"account_match": True, "debt_match": True}
-    assert "normalized" not in normalized
-    assert was_normalized is False
+    assert normalized["normalized"] is True
+    assert was_normalized is True

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -230,7 +230,7 @@ def test_send_ai_merge_packs_records_merge_decision(
         "kind": "ai_decision",
         "tag": "ai_decision",
         "source": "ai_adjudicator",
-        "decision": "merge",
+        "decision": "same_account_same_debt",
         "reason": "Records align cleanly.",
         "flags": {"account_match": True, "debt_match": True},
         "at": "2024-07-01T09:30:00Z",
@@ -244,7 +244,7 @@ def test_send_ai_merge_packs_records_merge_decision(
     pack_payload = json.loads(pack_files[0].read_text(encoding="utf-8"))
     assert pack_payload["pair"] == {"a": 11, "b": 16}
     assert pack_payload["ai_result"] == {
-        "decision": "merge",
+        "decision": "same_account_same_debt",
         "reason": "Records align cleanly.",
         "flags": {"account_match": True, "debt_match": True},
     }
@@ -336,7 +336,7 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
         _assert_pack_messages_with_rules(pack, pack_payload)
         captured_decisions.append({"pack": dict(pack), "timeout": timeout})
         return {
-            "decision": "same_debt",
+            "decision": "same_debt_account_unknown",
             "reason": "Same open date and balance",
             "flags": {"account_match": "unknown", "debt_match": True},
         }
@@ -378,7 +378,7 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
         "tag": "ai_decision",
         "source": "ai_adjudicator",
         "with": 16,
-        "decision": "same_debt",
+        "decision": "same_debt_account_unknown",
         "reason": "Same open date and balance",
         "flags": {"account_match": "unknown", "debt_match": True},
         "at": "2024-06-15T10:00:00Z",
@@ -425,22 +425,22 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
     "decision,flags,expected_pair",
     [
         (
-            "same_account_debt_diff",
+            "same_account_diff_debt",
             {"account_match": True, "debt_match": False},
             "same_account_pair",
         ),
         (
-            "same_debt_account_diff",
+            "same_debt_diff_account",
             {"account_match": False, "debt_match": True},
             "same_debt_pair",
         ),
         (
-            "same_account",
+            "same_account_debt_unknown",
             {"account_match": True, "debt_match": "unknown"},
             "same_account_pair",
         ),
         (
-            "same_debt",
+            "same_debt_account_unknown",
             {"account_match": "unknown", "debt_match": True},
             "same_debt_pair",
         ),
@@ -635,10 +635,10 @@ def test_write_decision_tags_idempotent(tmp_path: Path) -> None:
         sid,
         31,
         32,
-        "same_debt",
+        "same_debt_account_unknown",
         reason,
         "2024-07-01T00:00:00Z",
-        {"decision": "same_debt", "reason": reason},
+        {"decision": "same_debt_account_unknown", "reason": reason},
     )
 
     # Second invocation should update without duplication.
@@ -647,10 +647,10 @@ def test_write_decision_tags_idempotent(tmp_path: Path) -> None:
         sid,
         31,
         32,
-        "same_debt",
+        "same_debt_account_unknown",
         reason,
         "2024-07-01T00:00:00Z",
-        {"decision": "same_debt", "reason": reason},
+        {"decision": "same_debt_account_unknown", "reason": reason},
     )
 
     base = runs_root / sid / "cases" / "accounts"
@@ -662,7 +662,7 @@ def test_write_decision_tags_idempotent(tmp_path: Path) -> None:
         "tag": "ai_decision",
         "source": "ai_adjudicator",
         "with": 32,
-        "decision": "same_debt",
+        "decision": "same_debt_account_unknown",
         "reason": reason,
         "at": "2024-07-01T00:00:00Z",
     }


### PR DESCRIPTION
## Summary
- switch the adjudicator contract to the six canonical decision labels and tighten flag validation
- align the send_ai_merge_packs contract enforcement and pair-tag mappings with the new decision set
- update adjudicator normalization and pipeline tests to expect the normalized decisions and refreshed labels

## Testing
- pytest tests/ai/test_adjudicator_contract.py tests/pipeline/test_ai_resolution_flow.py tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68d9cced91a48325a1f7d29f69ffbf02