### PR TITLE
Refactor merge pack production to centralized paths

### DIFF
--- a/backend/core/logic/report_analysis/ai_pack.py
+++ b/backend/core/logic/report_analysis/ai_pack.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from datetime import date, datetime
 from typing import Iterable, Mapping
 
+from backend.core.ai.paths import get_merge_paths, pair_pack_filename
+
 from . import config as merge_config
 
 WANTED_CONTEXT_KEYS: list[str] = [
@@ -511,11 +513,11 @@ def build_ai_pack_for_pair(
     raw_a_path = accounts_root / str(account_a) / "raw_lines.json"
     raw_b_path = accounts_root / str(account_b) / "raw_lines.json"
 
-    pack_dir = runs_root_path / sid_str / "ai_packs"
-    pack_dir.mkdir(parents=True, exist_ok=True)
+    merge_paths = get_merge_paths(runs_root_path, sid_str, create=True)
+    packs_dir = merge_paths["packs_dir"]
 
     first_idx, second_idx = sorted((account_a, account_b))
-    pack_path = pack_dir / f"pair_{first_idx:03d}_{second_idx:03d}.jsonl"
+    pack_path = packs_dir / pair_pack_filename(first_idx, second_idx)
     payload: dict
 
     try:

--- a/scripts/preview_ai_pack.py
+++ b/scripts/preview_ai_pack.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import Any, Mapping
 
+from backend.core.ai.paths import get_merge_paths, pair_pack_filename
 from backend.core.io.tags import read_tags
 from backend.core.merge.acctnum import normalize_level
 from backend.core.logic.report_analysis.ai_pack import build_ai_pack_for_pair
@@ -141,7 +142,8 @@ def preview_pair_pack(
         )
     )
 
-    pack_path = runs_root / sid / "ai_packs" / f"{a_idx:03d}-{b_idx:03d}.json"
+    merge_paths = get_merge_paths(runs_root, sid, create=True)
+    pack_path = merge_paths["packs_dir"] / pair_pack_filename(a_idx, b_idx)
     print(f"Pack path: {pack_path}")
 
     print("Highlights:")


### PR DESCRIPTION
## Summary
- use the centralized merge path resolver in the merge scoring flow and pack builder to target `merge/packs`
- update the merge pack generation scripts to rely on `get_merge_paths`, ensure results directories, and emit canonical pair filenames
- refresh helper scripts (quick build, preview, run flow) to honor the new directory layout and manifest expectations

## Testing
- python -m compileall backend/core/logic/report_analysis/account_merge.py backend/core/logic/report_analysis/ai_pack.py scripts/build_ai_merge_packs.py scripts/_build_ai_packs_quick.py scripts/run_ai_merge_flow.py scripts/preview_ai_pack.py

------
https://chatgpt.com/codex/tasks/task_b_68daab29091c8325baec2ad2399077a0