### PR TITLE
Update merge AI pipeline paths and result handling

### DIFF
--- a/backend/core/logic/tags/compact.py
+++ b/backend/core/logic/tags/compact.py
@@ -470,8 +470,9 @@ def _ai_explanations_from_tag(
                 response_payload = existing_response
         if _has_value(response_payload):
             payload["raw_response"] = response_payload
+        ai_result_decision = normalized_decision if not decision else decision
         ai_result_payload: dict[str, object] = {
-            "decision": normalized_decision,
+            "decision": ai_result_decision,
             "flags": {key: final_flags[key] for key in ("account_match", "debt_match")},
         }
         if reason_text:
@@ -487,7 +488,7 @@ def _ai_explanations_from_tag(
         }
         if partner is not None:
             resolution_entry["with"] = partner
-        resolution_entry["decision"] = normalized_decision
+        resolution_entry["decision"] = ai_result_decision
         if reason_text is not None:
             resolution_entry["reason"] = reason_text
         entries.append(resolution_entry)


### PR DESCRIPTION
## Summary
- resolve merge AI pack locations via the centralized helper and persist adjudication JSON into merge/results while mirroring packs for backwards compatibility
- update the auto-AI pipeline tasks to use the resolver, fall back to legacy packs when necessary, and duplicate run logs in the legacy location
- preserve original decision aliases when compacting AI tags so summaries surface the same terminology

## Testing
- pytest tests/pipeline/test_auto_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68daadad06f083259b90e16944ad5822