### PR TITLE
Align AI merge pack tests with hierarchical layout

### DIFF
--- a/docs/account_merge.md
+++ b/docs/account_merge.md
@@ -99,14 +99,14 @@ without altering the underlying part score.
   specific session, run:
 
   ```bash
-  rg "CANDIDATE_(CONSIDERED|SKIPPED)" runs/<sid>/ai_packs/logs.txt
+  rg "CANDIDATE_(CONSIDERED|SKIPPED)" runs/<sid>/ai_packs/merge/logs.txt
   ```
 
 - Account-number normalization logs the winning bureau pair via
   `MERGE_V2_ACCT_BEST`. Inspect those entries with:
 
   ```bash
-  rg "MERGE_V2_ACCT_BEST" runs/<sid>/ai_packs/logs.txt
+  rg "MERGE_V2_ACCT_BEST" runs/<sid>/ai_packs/merge/logs.txt
   ```
 
 These commands make it easy to confirm which account pairs were considered,

--- a/tests/report_analysis/test_account_merge_pairs.py
+++ b/tests/report_analysis/test_account_merge_pairs.py
@@ -4,6 +4,7 @@ from typing import Mapping
 
 import pytest
 
+from backend.core.ai.paths import get_merge_paths
 from backend.core.io.tags import upsert_tag
 from backend.core.logic.report_analysis.account_merge import (
     AI_PACK_SCORE_THRESHOLD,
@@ -161,7 +162,8 @@ def test_account_number_clique_persists_all_pair_packs(
         (29, 39),
     ]
 
-    packs_dir = runs_root / sid / "ai_packs"
+    merge_paths = get_merge_paths(runs_root, sid, create=False)
+    packs_dir = merge_paths["packs_dir"]
     for left, right in expected_pairs:
         first, second = sorted((left, right))
         pack_path = packs_dir / f"pair_{first:03d}_{second:03d}.jsonl"


### PR DESCRIPTION
## Summary
- update the account merge documentation to reference the ai_packs/merge log location
- update AI resolution and report-analysis tests to resolve merge directories through the central path helper
- assert packs, logs, and results are produced under the new merge hierarchy

## Testing
- pytest tests/pipeline/test_ai_resolution_flow.py tests/report_analysis/test_ai_packs_builder.py tests/report_analysis/test_account_merge_pairs.py

------
https://chatgpt.com/codex/tasks/task_b_68dab8b001f48325b7ceeb7dbedb5c17