### PR TITLE
Add MergePaths helper for merge AI directories

### DIFF
--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -1,19 +1,25 @@
-"""Path helpers for AI pack directories."""
+"""Path helpers for AI merge packs."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 
-def ensure_ai_dirs(
-    runs_root: Path,
-    sid: str,
-    kind: str = "merge",
-    *,
-    create: bool = True,
-) -> Dict[str, Path]:
-    """Return the canonical AI pack paths for ``sid``.
+@dataclass(frozen=True)
+class MergePaths:
+    """Resolved filesystem locations for merge AI packs."""
+
+    base: Path
+    packs_dir: Path
+    results_dir: Path
+    log_file: Path
+    index_file: Path
+
+
+def ensure_merge_paths(runs_root: Path, sid: str, create: bool = True) -> MergePaths:
+    """Return the canonical merge AI pack paths for ``sid``.
 
     When ``create`` is ``True`` (the default) the base directory along with the
     ``packs`` and ``results`` subdirectories are created if they do not already
@@ -21,26 +27,21 @@ def ensure_ai_dirs(
     the filesystem.
     """
 
-    base = Path(runs_root) / sid / "ai_packs"
-    if kind:
-        base = base / kind
-
+    base = Path(runs_root) / sid / "ai_packs" / "merge"
     packs_dir = base / "packs"
     results_dir = base / "results"
-    index_file = base / "index.json"
-    log_file = base / "logs.txt"
 
     if create:
         packs_dir.mkdir(parents=True, exist_ok=True)
         results_dir.mkdir(parents=True, exist_ok=True)
 
-    return {
-        "base": base,
-        "packs_dir": packs_dir,
-        "results_dir": results_dir,
-        "index_file": index_file,
-        "log_file": log_file,
-    }
+    return MergePaths(
+        base=base,
+        packs_dir=packs_dir,
+        results_dir=results_dir,
+        log_file=base / "logs.txt",
+        index_file=base / "index.json",
+    )
 
 
 def pair_pack_filename(a_idx: int, b_idx: int) -> str:
@@ -57,10 +58,10 @@ def pair_result_filename(a_idx: int, b_idx: int) -> str:
     return f"pair_{lo:03d}_{hi:03d}.result.json"
 
 
-def get_merge_paths(runs_root: Path, sid: str, *, create: bool = True) -> Dict[str, Path]:
+def get_merge_paths(runs_root: Path, sid: str, *, create: bool = True) -> MergePaths:
     """Return the resolved merge AI pack paths for ``sid``."""
 
-    return ensure_ai_dirs(runs_root, sid, kind="merge", create=create)
+    return ensure_merge_paths(runs_root, sid, create=create)
 
 
 def probe_legacy_ai_packs(runs_root: Path, sid: str) -> Optional[Path]:
@@ -74,3 +75,4 @@ def probe_legacy_ai_packs(runs_root: Path, sid: str) -> Optional[Path]:
         return legacy_dir
 
     return None
+

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -1309,8 +1309,8 @@ def score_all_pairs_0_100(
 
     runs_root = Path(runs_root)
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    packs_dir = merge_paths["packs_dir"]
-    log_file = merge_paths["log_file"]
+    packs_dir = merge_paths.packs_dir
+    log_file = merge_paths.log_file
     cfg = get_merge_cfg()
     ai_threshold = AI_PACK_SCORE_THRESHOLD
     requested_raw = list(idx_list) if idx_list is not None else []

--- a/backend/core/logic/report_analysis/ai_pack.py
+++ b/backend/core/logic/report_analysis/ai_pack.py
@@ -514,7 +514,7 @@ def build_ai_pack_for_pair(
     raw_b_path = accounts_root / str(account_b) / "raw_lines.json"
 
     merge_paths = get_merge_paths(runs_root_path, sid_str, create=True)
-    packs_dir = merge_paths["packs_dir"]
+    packs_dir = merge_paths.packs_dir
 
     first_idx, second_idx = sorted((account_a, account_b))
     pack_path = packs_dir / pair_pack_filename(first_idx, second_idx)

--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -36,7 +36,7 @@ def packs_dir_for(sid: str, *, runs_root: Path | str | None = None) -> Path:
 
     base = Path(runs_root) if runs_root is not None else RUNS_ROOT
     merge_paths = get_merge_paths(base, sid, create=False)
-    return merge_paths["base"]
+    return merge_paths.base
 
 
 def _lock_age_seconds(path: Path, *, now: float | None = None) -> float | None:
@@ -103,8 +103,8 @@ def maybe_queue_auto_ai_pipeline(
 
     runs_root_path = Path(runs_root)
     merge_paths = get_merge_paths(runs_root_path, sid, create=True)
-    base_dir = merge_paths["base"]
-    packs_dir = merge_paths["packs_dir"]
+    base_dir = merge_paths.base
+    packs_dir = merge_paths.packs_dir
     lock_path = base_dir / INFLIGHT_LOCK_FILENAME
     last_ok_path = base_dir / LAST_OK_FILENAME
 
@@ -159,7 +159,7 @@ def maybe_queue_auto_ai_pipeline(
     try:
         base_dir.mkdir(parents=True, exist_ok=True)
         packs_dir.mkdir(parents=True, exist_ok=True)
-        merge_paths["results_dir"].mkdir(parents=True, exist_ok=True)
+        merge_paths.results_dir.mkdir(parents=True, exist_ok=True)
         lock_path.write_text(json.dumps(lock_payload, ensure_ascii=False), encoding="utf-8")
     except OSError:  # pragma: no cover - defensive logging
         logger.warning("AUTO_AI_LOCK_WRITE_FAILED sid=%s path=%s", sid, lock_path)
@@ -496,7 +496,7 @@ def ai_inflight_lock(runs_root: Path, sid: str):
     """
 
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    ai_dir = merge_paths["base"]
+    ai_dir = merge_paths.base
     lock = ai_dir / INFLIGHT_LOCK_FILENAME
     if lock.exists():
         # Someone else is running; caller should skip.
@@ -561,9 +561,9 @@ def _run_auto_ai_pipeline(sid: str):
 
     manifest = RunManifest.for_sid(sid)
     merge_paths = get_merge_paths(RUNS_ROOT, sid, create=True)
-    base_dir = merge_paths["base"]
-    packs_dir = merge_paths["packs_dir"]
-    index_path = merge_paths["index_file"]
+    base_dir = merge_paths.base
+    packs_dir = merge_paths.packs_dir
+    index_path = merge_paths.index_file
 
     index_read_path = index_path
     packs_source_dir = packs_dir

--- a/backend/pipeline/auto_ai_tasks.py
+++ b/backend/pipeline/auto_ai_tasks.py
@@ -42,7 +42,7 @@ def _append_run_log_entry(
     """Append a compact JSON line describing the AI run outcome."""
 
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    logs_path = merge_paths["log_file"]
+    logs_path = merge_paths.log_file
     entry = {
         "sid": sid,
         "at": datetime.now(timezone.utc).isoformat(),
@@ -151,7 +151,7 @@ def _populate_common_paths(payload: MutableMapping[str, object]) -> None:
     runs_root = _resolve_runs_root(payload, sid)
     accounts_dir = runs_root / sid / "cases" / "accounts"
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    pipeline_dir = merge_paths["base"]
+    pipeline_dir = merge_paths.base
     lock_path = pipeline_dir / INFLIGHT_LOCK_FILENAME
     last_ok_path = pipeline_dir / LAST_OK_FILENAME
 
@@ -256,7 +256,7 @@ def ai_build_packs_step(self, prev: Mapping[str, object] | None) -> dict[str, ob
         raise
 
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    index_path = merge_paths["index_file"]
+    index_path = merge_paths.index_file
     if not index_path.exists():
         legacy_dir = probe_legacy_ai_packs(runs_root, sid)
         if legacy_dir is not None:

--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -11,10 +11,10 @@ accounts_dir = base/"cases"/"accounts"
 manifest_path = base/".manifest"
 
 merge_paths = get_merge_paths(pathlib.Path(RUNS_ROOT), SID, create=True)
-PACKS_ROOT = merge_paths["packs_dir"]
-INDEX_PATH = merge_paths["index_file"]
-LOG_PATH = merge_paths["log_file"]
-BASE_DIR = merge_paths["base"]
+PACKS_ROOT = merge_paths.packs_dir
+INDEX_PATH = merge_paths.index_file
+LOG_PATH = merge_paths.log_file
+BASE_DIR = merge_paths.base
 
 def load_json(p: pathlib.Path, default=None):
     try:

--- a/scripts/build_ai_merge_packs.py
+++ b/scripts/build_ai_merge_packs.py
@@ -130,14 +130,14 @@ def main(argv: Sequence[str] | None = None) -> None:
         packs_dir = Path(args.packs_dir)
         packs_dir.mkdir(parents=True, exist_ok=True)
         base_dir = packs_dir.parent
-        index_path = base_dir / merge_paths["index_file"].name
+        index_path = base_dir / merge_paths.index_file.name
         results_dir = base_dir / "results"
         results_dir.mkdir(parents=True, exist_ok=True)
     else:
-        packs_dir = merge_paths["packs_dir"]
-        base_dir = merge_paths["base"]
-        index_path = merge_paths["index_file"]
-        results_dir = merge_paths["results_dir"]
+        packs_dir = merge_paths.packs_dir
+        base_dir = merge_paths.base
+        index_path = merge_paths.index_file
+        results_dir = merge_paths.results_dir
 
     log.info("PACKS_DIR_USED sid=%s dir=%s", sid, packs_dir)
     log.debug("MERGE_RESULTS_DIR sid=%s dir=%s", sid, results_dir)
@@ -229,7 +229,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     pairs_count = len(index_entries)
     if pairs_count > 0:
         if args.packs_dir:
-            index_path = base_dir / merge_paths["index_file"].name
+            index_path = base_dir / merge_paths.index_file.name
         seen_pairs: set[tuple[int, int]] = set()
         pairs_payload: list[dict[str, object]] = []
         for entry in index_entries:

--- a/scripts/preview_ai_pack.py
+++ b/scripts/preview_ai_pack.py
@@ -143,7 +143,7 @@ def preview_pair_pack(
     )
 
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    pack_path = merge_paths["packs_dir"] / pair_pack_filename(a_idx, b_idx)
+    pack_path = merge_paths.packs_dir / pair_pack_filename(a_idx, b_idx)
     print(f"Pack path: {pack_path}")
 
     print("Highlights:")

--- a/scripts/run_ai_merge_flow.py
+++ b/scripts/run_ai_merge_flow.py
@@ -84,16 +84,16 @@ def _resolve_merge_paths(
         packs_dir = Path(override)
         packs_dir.mkdir(parents=True, exist_ok=True)
         base_dir = packs_dir.parent
-        index_path = base_dir / merge_paths["index_file"].name
-        log_path = base_dir / merge_paths["log_file"].name
+        index_path = base_dir / merge_paths.index_file.name
+        log_path = base_dir / merge_paths.log_file.name
         results_dir = base_dir / "results"
         results_dir.mkdir(parents=True, exist_ok=True)
     else:
-        packs_dir = merge_paths["packs_dir"]
-        base_dir = merge_paths["base"]
-        index_path = merge_paths["index_file"]
-        log_path = merge_paths["log_file"]
-        results_dir = merge_paths["results_dir"]
+        packs_dir = merge_paths.packs_dir
+        base_dir = merge_paths.base
+        index_path = merge_paths.index_file
+        log_path = merge_paths.log_file
+        results_dir = merge_paths.results_dir
 
     return {
         "packs_dir": packs_dir,

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -832,11 +832,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     manifest = RunManifest.for_sid(sid)
 
     merge_paths = get_merge_paths(runs_root_path, sid, create=False)
-    base_dir = merge_paths["base"]
-    packs_dir = merge_paths["packs_dir"]
-    results_dir = merge_paths["results_dir"]
-    index_path = merge_paths["index_file"]
-    logs_path = merge_paths["log_file"]
+    base_dir = merge_paths.base
+    packs_dir = merge_paths.packs_dir
+    results_dir = merge_paths.results_dir
+    index_path = merge_paths.index_file
+    logs_path = merge_paths.log_file
 
     def _apply_base_override(base_path: Path) -> None:
         nonlocal base_dir, packs_dir, results_dir, index_path, logs_path

--- a/tests/pipeline/test_ai_resolution_flow.py
+++ b/tests/pipeline/test_ai_resolution_flow.py
@@ -51,7 +51,7 @@ def test_send_packs_normalizes_decisions(
     runs_root = tmp_path / "runs"
     sid = f"flow-{expected_decision}"
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    packs_dir = merge_paths["packs_dir"]
+    packs_dir = merge_paths.packs_dir
 
     pack_filename = "pair_001_002.jsonl"
     pack_payload = {
@@ -77,7 +77,7 @@ def test_send_packs_normalizes_decisions(
             }
         ],
     }
-    _write_json(merge_paths["index_file"], index_payload)
+    _write_json(merge_paths.index_file, index_payload)
 
     accounts_root = runs_root / sid / "cases" / "accounts"
     _write_json(accounts_root / "1" / "tags.json", [])

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -463,7 +463,7 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
     def fake_build_packs(sid_value: str, runs_root_value: Path) -> None:
         assert sid_value == sid
         merge_paths = get_merge_paths(runs_root_value, sid_value, create=True)
-        packs_dir = merge_paths["packs_dir"]
+        packs_dir = merge_paths.packs_dir
         pack_payload = {
             "sid": sid_value,
             "pair": {"a": 11, "b": 16},
@@ -473,7 +473,7 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
         pack_filename = "pair_011_016.jsonl"
         (packs_dir / pack_filename).write_text(json.dumps(pack_payload, ensure_ascii=False) + "\n", encoding="utf-8")
         _write_json(
-            merge_paths["index_file"],
+            merge_paths.index_file,
             {
                 "sid": sid_value,
                 "pairs": [
@@ -526,13 +526,13 @@ def test_auto_ai_chain_idempotent_and_compacts_tags(monkeypatch, tmp_path: Path)
 
     merge_paths = get_merge_paths(runs_root, sid, create=False)
     packs_index = json.loads(
-        merge_paths["index_file"].read_text(encoding="utf-8")
+        merge_paths.index_file.read_text(encoding="utf-8")
     )
     assert packs_index == {"sid": sid, "pairs": [{"a": 11, "b": 16, "pack_file": "pair_011_016.jsonl", "lines_a": 0, "lines_b": 0, "score_total": 0}]}
     assert first_result["packs"] == 1
     assert first_result["pairs"] == 2
 
-    logs_path = merge_paths["log_file"]
+    logs_path = merge_paths.log_file
     first_logs = [
         json.loads(line)
         for line in logs_path.read_text(encoding="utf-8").splitlines()
@@ -734,9 +734,9 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch, caplog):
     packs_info = ai_info.get("packs", {})
     status_info = ai_info.get("status", {})
     merge_paths = get_merge_paths(runs_root, sid, create=False)
-    packs_dir = merge_paths["packs_dir"]
-    log_path = merge_paths["log_file"]
-    results_dir = merge_paths["results_dir"]
+    packs_dir = merge_paths.packs_dir
+    log_path = merge_paths.log_file
+    results_dir = merge_paths.results_dir
     assert Path(packs_info.get("dir")) == merge_base.resolve()
     assert Path(packs_info.get("dir")).exists()
     assert Path(packs_info.get("index")) == index_path.resolve()
@@ -849,7 +849,7 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch, caplog):
         "flags": {"account_match": False, "debt_match": False},
     }
 
-    index_payload = json.loads(merge_paths["index_file"].read_text(encoding="utf-8"))
+    index_payload = json.loads(merge_paths.index_file.read_text(encoding="utf-8"))
     matching = [entry for entry in index_payload.get("pairs", []) if entry.get("pair") == [11, 16]]
     assert matching
     pair_entry = matching[0]

--- a/tests/report_analysis/test_account_merge_pairs.py
+++ b/tests/report_analysis/test_account_merge_pairs.py
@@ -163,7 +163,7 @@ def test_account_number_clique_persists_all_pair_packs(
     ]
 
     merge_paths = get_merge_paths(runs_root, sid, create=False)
-    packs_dir = merge_paths["packs_dir"]
+    packs_dir = merge_paths.packs_dir
     for left, right in expected_pairs:
         first, second = sorted((left, right))
         pack_path = packs_dir / f"pair_{first:03d}_{second:03d}.jsonl"

--- a/tests/report_analysis/test_ai_packs_builder.py
+++ b/tests/report_analysis/test_ai_packs_builder.py
@@ -353,9 +353,9 @@ def test_build_ai_merge_packs_cli_updates_manifest(
     log_messages = [record.getMessage() for record in caplog.records]
 
     merge_paths = get_merge_paths(runs_root, sid, create=False)
-    merge_base = merge_paths["base"]
-    packs_dir = merge_paths["packs_dir"]
-    index_path = merge_paths["index_file"]
+    merge_base = merge_paths.base
+    packs_dir = merge_paths.packs_dir
+    index_path = merge_paths.index_file
     manifest_path = runs_root / sid / "manifest.json"
 
     assert any(f"PACKS_DIR_USED sid={sid}" in message for message in log_messages)
@@ -391,9 +391,9 @@ def test_build_ai_merge_packs_cli_updates_manifest(
     pack_path = packs_dir / pair_entry["pack_file"]
     assert pack_path.exists()
 
-    logs_path = merge_paths["log_file"]
+    logs_path = merge_paths.log_file
     assert not logs_path.exists()
-    results_dir = merge_paths["results_dir"]
+    results_dir = merge_paths.results_dir
     assert results_dir.is_dir()
     assert manifest_path.exists()
 

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -55,7 +55,7 @@ def _create_merge_pack(
     index_entry: Mapping[str, object] | None = None,
 ) -> tuple[dict[str, Path], Path]:
     merge_paths = get_merge_paths(runs_root, sid, create=True)
-    packs_dir = merge_paths["packs_dir"]
+    packs_dir = merge_paths.packs_dir
     pack_filename = pair_pack_filename(a_idx, b_idx)
     pack_path = packs_dir / pack_filename
     pack_path.write_text(
@@ -81,7 +81,7 @@ def _create_merge_pack(
         "pairs": [dict(entry)],
         "pairs_count": 1,
     }
-    merge_paths["index_file"].write_text(
+    merge_paths.index_file.write_text(
         json.dumps(index_payload, ensure_ascii=False),
         encoding="utf-8",
     )
@@ -232,10 +232,10 @@ def test_send_ai_merge_packs_records_merge_decision(
     packs_info = manifest.data.get("ai", {}).get("packs", {})
     status_info = manifest.data.get("ai", {}).get("status", {})
     merge_paths = get_merge_paths(runs_root, sid, create=False)
-    packs_dir = merge_paths["packs_dir"].resolve()
-    base_dir = merge_paths["base"].resolve()
-    logs_path = merge_paths["log_file"].resolve()
-    results_dir = merge_paths["results_dir"].resolve()
+    packs_dir = merge_paths.packs_dir.resolve()
+    base_dir = merge_paths.base.resolve()
+    logs_path = merge_paths.log_file.resolve()
+    results_dir = merge_paths.results_dir.resolve()
     assert Path(packs_info.get("dir")) == base_dir
     assert Path(packs_info.get("dir")).exists()
     assert Path(packs_info.get("index")).exists()
@@ -386,10 +386,10 @@ def test_send_ai_merge_packs_writes_same_debt_tags(
         ]
     }
     merge_paths, _ = _create_merge_pack(runs_root, sid, pack_payload)
-    packs_dir = merge_paths["packs_dir"]
-    base_dir = merge_paths["base"]
-    results_dir = merge_paths["results_dir"]
-    logs_path = merge_paths["log_file"]
+    packs_dir = merge_paths.packs_dir
+    base_dir = merge_paths.base
+    results_dir = merge_paths.results_dir
+    logs_path = merge_paths.log_file
 
     monkeypatch.setenv("ENABLE_AI_ADJUDICATOR", "1")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -558,7 +558,7 @@ def test_send_ai_merge_packs_writes_decision_variants(
 
     send_ai_merge_packs.main(["--sid", sid, "--runs-root", str(runs_root)])
 
-    result_path = merge_paths["results_dir"] / pair_result_filename(11, 16)
+    result_path = merge_paths.results_dir / pair_result_filename(11, 16)
     assert result_path.exists()
 
     account_tags_dir = runs_root / sid / "cases" / "accounts"
@@ -628,8 +628,8 @@ def test_send_ai_merge_packs_logs_failure(monkeypatch: pytest.MonkeyPatch, runs_
         ]
     }
     merge_paths, _ = _create_merge_pack(runs_root, sid, pack_payload, a_idx=1, b_idx=2)
-    packs_dir = merge_paths["packs_dir"]
-    logs_path = merge_paths["log_file"]
+    packs_dir = merge_paths.packs_dir
+    logs_path = merge_paths.log_file
 
     monkeypatch.setenv("ENABLE_AI_ADJUDICATOR", "1")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -725,7 +725,7 @@ def test_send_ai_merge_packs_reads_legacy_layout(
     messages = [record.getMessage() for record in caplog.records]
     assert any(f"SENDER_PACKS_DIR_LEGACY sid={sid}" in message for message in messages)
 
-    result_dir = merge_paths["results_dir"]
+    result_dir = merge_paths.results_dir
     assert result_dir.exists()
     result_path = result_dir / pair_result_filename(11, 16)
     assert result_path.exists()
@@ -736,11 +736,11 @@ def test_send_ai_merge_packs_reads_legacy_layout(
 
     manifest = RunManifest.for_sid(sid)
     packs_info = manifest.data.get("ai", {}).get("packs", {})
-    assert Path(packs_info.get("dir")) == merge_paths["base"].resolve()
+    assert Path(packs_info.get("dir")) == merge_paths.base.resolve()
     assert Path(packs_info.get("index")).exists()
     assert Path(packs_info.get("logs")).exists()
 
-    logs_path = merge_paths["log_file"]
+    logs_path = merge_paths.log_file
     assert logs_path.exists()
     log_lines = logs_path.read_text(encoding="utf-8").splitlines()
     assert any("AI_ADJUDICATOR_RESPONSE" in line for line in log_lines)
@@ -848,8 +848,8 @@ def test_ai_pairing_flow_compaction(
     )
 
     merge_paths = get_merge_paths(runs_root, sid, create=False)
-    packs_dir = merge_paths["packs_dir"]
-    assert merge_paths["index_file"].exists()
+    packs_dir = merge_paths.packs_dir
+    assert merge_paths.index_file.exists()
 
     timestamp = "2024-07-04T12:00:00Z"
 
@@ -868,7 +868,7 @@ def test_ai_pairing_flow_compaction(
 
     send_ai_merge_packs.main(["--sid", sid, "--runs-root", str(runs_root)])
 
-    result_path = merge_paths["results_dir"] / pair_result_filename(11, 16)
+    result_path = merge_paths.results_dir / pair_result_filename(11, 16)
     assert result_path.exists()
 
     for account_dir in (account_a_dir, account_b_dir):


### PR DESCRIPTION
## Summary
- add a MergePaths dataclass and ensure_merge_paths helper for merge AI directories
- update merge pipeline code and scripts to use the centralized MergePaths helper
- adjust tests to use the new helper interface

## Testing
- pytest tests/pipeline/test_run_manifest.py::test_get_ai_merge_paths_defaults -q


------
https://chatgpt.com/codex/tasks/task_b_68dac048e03c83258da75097f286c02d