### PR TITLE
Refactor merge AI pack tooling to use canonical path helpers

### DIFF
--- a/backend/core/logic/report_analysis/ai_pack.py
+++ b/backend/core/logic/report_analysis/ai_pack.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from datetime import date, datetime
 from typing import Iterable, Mapping
 
-from backend.core.ai.paths import get_merge_paths, pair_pack_filename
+from backend.core.ai.paths import ensure_merge_paths, pair_pack_filename
 
 from . import config as merge_config
 
@@ -513,7 +513,7 @@ def build_ai_pack_for_pair(
     raw_a_path = accounts_root / str(account_a) / "raw_lines.json"
     raw_b_path = accounts_root / str(account_b) / "raw_lines.json"
 
-    merge_paths = get_merge_paths(runs_root_path, sid_str, create=True)
+    merge_paths = ensure_merge_paths(runs_root_path, sid_str, create=True)
     packs_dir = merge_paths.packs_dir
 
     first_idx, second_idx = sorted((account_a, account_b))

--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -1,7 +1,7 @@
 ﻿import os, json, re, pathlib, time
 from datetime import datetime
 
-from backend.core.ai.paths import get_merge_paths, pair_pack_filename
+from backend.core.ai.paths import ensure_merge_paths, pair_pack_filename
 
 RUNS_ROOT = os.environ.get("RUNS_ROOT", "runs")
 SID = os.environ.get("SID") or "'+$SID+'"
@@ -10,7 +10,7 @@ base = pathlib.Path(RUNS_ROOT)/SID
 accounts_dir = base/"cases"/"accounts"
 manifest_path = base/".manifest"
 
-merge_paths = get_merge_paths(pathlib.Path(RUNS_ROOT), SID, create=True)
+merge_paths = ensure_merge_paths(pathlib.Path(RUNS_ROOT), SID, create=True)
 PACKS_ROOT = merge_paths.packs_dir
 INDEX_PATH = merge_paths.index_file
 LOG_PATH = merge_paths.log_file


### PR DESCRIPTION
## Summary
- route ai pack writers through the shared ensure_merge_paths helper so packs land under merge/packs
- normalize override handling in the CLI helpers to derive index and log files from the MergePaths metadata
- update the quick pack builder and run flow scripts to rely on canonical pack filenames and directories

## Testing
- pytest tests/scripts/test_run_ai_merge_flow.py
- pytest tests/scripts/test_send_ai_merge_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68dac1f27294832599b59be26adc82e5