### PR TITLE
Improve merge context flags for collection agencies

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -363,6 +363,7 @@ _TOLERANCE_DEFAULTS: Dict[str, Union[int, float]] = {
     "AMOUNT_TOL_RATIO": 0.01,
     "LAST_PAYMENT_DAY_TOL": 7,
     "COUNT_ZERO_PAYMENT_MATCH": 0,
+    "CA_DATE_MONTH_TOL": 6,
 }
 
 def get_merge_cfg(env: Optional[Mapping[str, str]] = None) -> MergeCfg:


### PR DESCRIPTION
## Summary
- add a configurable CA date month tolerance to the merge tolerances
- expand AI pack context flags to better detect collection agencies and relax date plausibility when both sides are CA accounts
- cover the new collection detection and tolerance paths with dedicated tests

## Testing
- pytest tests/report_analysis/test_ai_packs_builder.py

------
https://chatgpt.com/codex/tasks/task_b_68dacb2ada908325bbda4f1ae538fdc0