### PR TITLE
Align merge pack storage layout

### DIFF
--- a/tests/pipeline/test_run_manifest.py
+++ b/tests/pipeline/test_run_manifest.py
@@ -143,7 +143,7 @@ def test_get_ai_merge_paths_with_legacy_layout(runs_root):
 
     expected_base = (legacy_dir / "merge").resolve()
     assert paths["base"] == expected_base
-    assert paths["packs_dir"] == legacy_dir.resolve()
+    assert paths["packs_dir"] == (expected_base / "packs").resolve()
     assert paths["results_dir"] == (expected_base / "results").resolve()
     assert paths["index_file"] == legacy_index.resolve()
     assert paths["log_file"] == (expected_base / "logs.txt").resolve()

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -444,9 +444,11 @@ def test_send_ai_merge_packs_records_merge_decision(
     matching = [entry for entry in pairs_entries if entry.get("pair") == [11, 16]]
     assert matching
     assert matching[0].get("ai_result") == result_payload
+    assert matching[0].get("result_file") == pair_result_filename(11, 16)
     reverse = [entry for entry in pairs_entries if entry.get("pair") == [16, 11]]
     assert reverse
     assert reverse[0].get("pack_file") == matching[0].get("pack_file")
+    assert reverse[0].get("result_file") == matching[0].get("result_file")
 
     pair_tag_a = next(
         tag


### PR DESCRIPTION
## Summary
- track canonical merge pack directories in the run manifest while preserving explicit legacy fallbacks
- ensure the merge pack sender prefers helper-resolved paths (including legacy) and writes index entries with result filenames
- extend tests to cover the canonical layout expectations and new index metadata

## Testing
- pytest tests/scripts/test_send_ai_merge_packs.py --maxfail=1
- pytest tests/pipeline/test_run_manifest.py --maxfail=1

------
https://chatgpt.com/codex/tasks/task_b_68dad63aa4b48325bdc383458c7a070b