### PR TITLE
Ensure deterministic adjudicator model configuration

### DIFF
--- a/backend/core/logic/report_analysis/ai_adjudicator.py
+++ b/backend/core/logic/report_analysis/ai_adjudicator.py
@@ -310,9 +310,11 @@ def _build_request_payload(pack: dict) -> tuple[str, dict[str, Any], dict[str, s
         raise RuntimeError("OPENAI_API_KEY is required when AI adjudication is enabled")
 
     model = merge_config.get_ai_model()
-    temperature = _coerce_float(
-        os.getenv("AI_TEMPERATURE_DEFAULT"), getattr(config, "AI_TEMPERATURE_DEFAULT", 0.0)
-    )
+    # Adjudicator requests must be deterministic to ensure parity with the
+    # manual workflow. Force zero temperature and unity top_p rather than
+    # permitting environment overrides that might introduce randomness.
+    temperature = 0.0
+    top_p = 1.0
     max_tokens = _coerce_positive_int(
         os.getenv("AI_MAX_TOKENS"), getattr(config, "AI_MAX_TOKENS", 600)
     )
@@ -321,6 +323,7 @@ def _build_request_payload(pack: dict) -> tuple[str, dict[str, Any], dict[str, s
         "model": model,
         "messages": messages,
         "temperature": temperature,
+        "top_p": top_p,
         "max_tokens": max_tokens,
         "response_format": {"type": "json_object"},
     }
@@ -333,6 +336,7 @@ def _build_request_payload(pack: dict) -> tuple[str, dict[str, Any], dict[str, s
     metadata = {
         "model": model,
         "temperature": temperature,
+        "top_p": top_p,
         "max_tokens": max_tokens,
     }
 

--- a/backend/core/services/ai_client.py
+++ b/backend/core/services/ai_client.py
@@ -38,6 +38,7 @@ class AIClient:
         messages: List[Dict[str, Any]],
         model: str | None = None,
         temperature: float = 0,
+        top_p: float = 1,
         **kwargs: Any,
     ):
         """Proxy to ``chat.completions.create``."""
@@ -54,8 +55,26 @@ class AIClient:
             if sanitized:
                 kwargs["extra_headers"] = sanitized
 
+        # Enforce deterministic parameters regardless of caller provided values.
+        if "frequency_penalty" in kwargs:
+            kwargs.pop("frequency_penalty")
+        if "presence_penalty" in kwargs:
+            kwargs.pop("presence_penalty")
+        if "top_p" in kwargs:
+            kwargs.pop("top_p")
+
+        frequency_penalty = 0
+        presence_penalty = 0
+        top_p_value = top_p
+
         return self._client.chat.completions.create(
-            model=model, messages=messages, temperature=temperature, **kwargs
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            top_p=top_p_value,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            **kwargs,
         )
 
     def response_json(

--- a/tests/report_analysis/test_ai_adjudicator.py
+++ b/tests/report_analysis/test_ai_adjudicator.py
@@ -111,7 +111,7 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
                             "message": {
                                 "content": jsonlib.dumps(
                                     {
-                                        "decision": "merge",
+                                        "decision": "same_account_same_debt",
                                         "confidence": 0.83,
                                         "reason": "accounts align",
                                         "reasons": ["matched creditor names"],
@@ -142,7 +142,7 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     resp = ai_adjudicator.adjudicate_pair(pack)
 
     assert resp == {
-        "decision": "merge",
+        "decision": "same_account_same_debt",
         "confidence": 0.83,
         "reason": "accounts align",
         "reasons": ["matched creditor names"],
@@ -153,6 +153,10 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     assert captured["headers"]["Authorization"] == "Bearer test-key"
     assert captured["payload"]["model"] == "gpt-test"
     assert captured["payload"]["response_format"] == {"type": "json_object"}
+    assert captured["payload"]["temperature"] == 0.0
+    assert captured["payload"]["top_p"] == 1.0
+    assert "frequency_penalty" not in captured["payload"]
+    assert "presence_penalty" not in captured["payload"]
     assert captured["timeout"] == 3.0
 
     ai_adjudicator.persist_ai_decision("case-123", tmp_path, 11, 16, resp)
@@ -166,7 +170,7 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     expected_a = {
         "kind": "merge_result",
         "with": 16,
-        "decision": "merge",
+        "decision": "same_account_same_debt",
         "confidence": 0.83,
         "reason": "accounts align",
         "reasons": ["matched creditor names"],
@@ -176,7 +180,7 @@ def test_adjudicate_pair_enabled_and_persist(monkeypatch, tmp_path):
     expected_b = {
         "kind": "merge_result",
         "with": 11,
-        "decision": "merge",
+        "decision": "same_account_same_debt",
         "confidence": 0.83,
         "reason": "accounts align",
         "reasons": ["matched creditor names"],

--- a/tests/services/test_ai_client_headers.py
+++ b/tests/services/test_ai_client_headers.py
@@ -27,3 +27,7 @@ def test_extra_headers_sanitized():
     )
 
     assert captured["extra_headers"] == {"X-Test": "hllo"}
+    assert captured["temperature"] == 0
+    assert captured["top_p"] == 1
+    assert captured["frequency_penalty"] == 0
+    assert captured["presence_penalty"] == 0


### PR DESCRIPTION
## Summary
- force zero temperature and top_p=1 for manual adjudicator chat completions to match manual settings
- lock the shared AI client to deterministic parameters and extend tests for both call sites

## Testing
- pytest tests/services/test_ai_client_headers.py tests/report_analysis/test_ai_adjudicator.py

------
https://chatgpt.com/codex/tasks/task_b_68dae595c384832593217547ce5ceee4