### PR TITLE
Ensure AI packs expose bureau account IDs and last4 guard

### DIFF
--- a/backend/core/logic/report_analysis/ai_adjudicator.py
+++ b/backend/core/logic/report_analysis/ai_adjudicator.py
@@ -58,6 +58,7 @@ SYSTEM_MESSAGE = (
     "Legacy labels such as merge, same_debt, same_debt_account_different, "
     "same_account, same_account_debt_different, and different may appear in "
     "reference material, but you MUST respond with only the six decisions above.\n"
+    "If only last four digits match but stems differ, never choose any same_account_*.\n"
     "If account identifiers DO NOT match, but:\n"
     "- amounts_equal_within_tol is true for positive debt (balance and/or past due), AND\n"
     "- one side is a collection agent (is_collection_agency_*) while the other is an original creditor (is_original_creditor_*), AND\n"

--- a/tests/report_analysis/test_ai_adjudicator_prompt.py
+++ b/tests/report_analysis/test_ai_adjudicator_prompt.py
@@ -47,6 +47,10 @@ def test_build_prompt_from_pack_limits_context(monkeypatch):
     assert set(prompt.keys()) == {"system", "user"}
     assert "expert credit tradeline merge adjudicator" in prompt["system"].lower()
     assert "decision" in prompt["system"]
+    assert (
+        "If only last four digits match but stems differ, never choose any same_account_*"
+        in prompt["system"]
+    )
 
     user_payload = json.loads(prompt["user"])
     assert user_payload["sid"] == "sample-sid"


### PR DESCRIPTION
## Summary
- add bureau-level account number evidence to AI packs and their user payloads
- surface explicit account-number context flags and last-four guardrails in system prompts
- extend pack builder and prompt tests to cover the new evidence and guidance

## Testing
- pytest tests/report_analysis/test_ai_packs_builder.py tests/report_analysis/test_ai_adjudicator_prompt.py

------
https://chatgpt.com/codex/tasks/task_b_68dae8d4a264832589732adbd61185f1