### PR TITLE
Add per-bureau polarity phase and integrate into AI pipeline

### DIFF
--- a/backend/pipeline/auto_ai_tasks.py
+++ b/backend/pipeline/auto_ai_tasks.py
@@ -661,7 +661,7 @@ def ai_polarity_check_step(self, prev: Mapping[str, object] | None) -> dict[str,
     logger.info("AI_POLARITY_START sid=%s accounts=%d", sid, len(indices))
 
     try:
-        result = polarity.apply_polarity_checks(accounts_dir, indices)
+        result = polarity.apply_polarity_checks(accounts_dir, indices, sid=sid)
     except Exception:  # pragma: no cover - defensive logging
         logger.error("AUTO_AI_POLARITY_FAILED sid=%s dir=%s", sid, accounts_dir, exc_info=True)
         _cleanup_lock(payload, reason="polarity_failed")

--- a/tests/backend/core/logic/test_intra_polarity.py
+++ b/tests/backend/core/logic/test_intra_polarity.py
@@ -39,13 +39,16 @@ def test_analyze_account_polarity_updates_summary(account_dir: Path) -> None:
     result = analyze_account_polarity("sid123", account_dir)
 
     assert result == {
-        "balance_owed": {
-            "transunion": {"polarity": "bad", "severity": "high"},
-            "experian": {"polarity": "good", "severity": "medium"},
-        },
-        "payment_status": {
-            "transunion": {"polarity": "bad", "severity": "high"},
-            "experian": {"polarity": "good", "severity": "medium"},
+        "schema_version": 1,
+        "bureaus": {
+            "transunion": {
+                "balance_owed": {"polarity": "bad", "severity": "high"},
+                "payment_status": {"polarity": "bad", "severity": "high"},
+            },
+            "experian": {
+                "balance_owed": {"polarity": "good", "severity": "medium"},
+                "payment_status": {"polarity": "good", "severity": "medium"},
+            },
         },
     }
 


### PR DESCRIPTION
## Summary
- restructure per-account polarity analysis to persist per-bureau polarity results with a schema version
- add an apply_polarity_checks helper and run the polarity phase within the AI pipeline before compaction
- refresh polarity tests to reflect the new structure and probe behavior

## Testing
- pytest tests/backend/core/logic/test_intra_polarity.py tests/backend/core/logic/test_polarity.py tests/pipeline/test_auto_ai.py -k polarity


------
https://chatgpt.com/codex/tasks/task_b_68db13b8edcc83259e46e58bd0bc5c7d