### PR TITLE
Add atomic JSON update helper for polarity summary updates

### DIFF
--- a/backend/core/io/json_io.py
+++ b/backend/core/io/json_io.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 def _atomic_write_json(path: Path, payload: Any) -> None:
@@ -19,5 +20,41 @@ def _atomic_write_json(path: Path, payload: Any) -> None:
     tmp.replace(path)
 
 
-__all__ = ["_atomic_write_json"]
+def update_json_in_place(
+    path: Path | str, update_fn: Callable[[Any], Any | None]
+) -> Any:
+    """Update ``path`` JSON atomically using ``update_fn``.
+
+    The existing JSON payload (or ``{}`` when the file is missing) is deep-copied
+    before ``update_fn`` is invoked so callers can mutate the provided object.
+    When ``update_fn`` returns ``None`` the mutated value is written back. If the
+    payload is unchanged the file is left untouched.
+    """
+
+    json_path = Path(path)
+
+    try:
+        raw = json_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        current_payload: Any = {}
+    else:
+        try:
+            current_payload = json.loads(raw)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid JSON content in {json_path}") from exc
+
+    original_snapshot = copy.deepcopy(current_payload)
+    working_copy = copy.deepcopy(current_payload)
+
+    result = update_fn(working_copy)
+    new_payload = working_copy if result is None else result
+
+    if new_payload == original_snapshot:
+        return new_payload
+
+    _atomic_write_json(json_path, new_payload)
+    return new_payload
+
+
+__all__ = ["_atomic_write_json", "update_json_in_place"]
 

--- a/tests/backend/core/io/test_json_io.py
+++ b/tests/backend/core/io/test_json_io.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.core.io.json_io import update_json_in_place
+
+
+def test_update_json_in_place_creates_file(tmp_path: Path) -> None:
+    target = tmp_path / "data.json"
+
+    def _apply(payload: object) -> dict[str, object]:
+        data = dict(payload) if isinstance(payload, dict) else {}
+        data["value"] = 3
+        return data
+
+    result = update_json_in_place(target, _apply)
+
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"value": 3}
+    assert result == {"value": 3}
+
+
+def test_update_json_in_place_skips_when_unchanged(tmp_path: Path) -> None:
+    target = tmp_path / "data.json"
+    target.write_text(json.dumps({"value": 1}, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    before_stat = target.stat()
+
+    def _noop(payload: object) -> dict[str, object]:
+        if isinstance(payload, dict):
+            return dict(payload)
+        return {}
+
+    result = update_json_in_place(target, _noop)
+
+    after_stat = target.stat()
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"value": 1}
+    assert result == {"value": 1}
+    assert before_stat.st_mtime_ns == after_stat.st_mtime_ns


### PR DESCRIPTION
## Summary
- add an `update_json_in_place` helper that performs atomic JSON updates and skips redundant writes
- reuse the helper when persisting intra-polarity results to `summary.json`, keeping existing probe behavior and logging
- cover the new helper with focused unit tests

## Testing
- pytest tests/backend/core/logic/test_intra_polarity.py tests/backend/core/io/test_json_io.py

------
https://chatgpt.com/codex/tasks/task_b_68db15995df083258b0709f2f2d4d66f