### PR TITLE
Add rule identifiers to polarity keyword config

### DIFF
--- a/backend/core/logic/polarity_config.yml
+++ b/backend/core/logic/polarity_config.yml
@@ -22,20 +22,30 @@ fields:
   payment_status:
     type: text
     bad_keywords:
-      - "collection"
-      - "chargeoff"
-      - "charge-off"
-      - "repossession"
-      - "late 120"
-      - "late 90"
+      - id: PAYMENT_STATUS_COLLECTION
+        pattern: '(?i)\bcollection\b'
+      - id: PAYMENT_STATUS_CHARGEOFF
+        pattern: '(?i)charge[- ]?off|collection/chargeoff'
+      - id: PAYMENT_STATUS_REPOSSESSION
+        pattern: '(?i)repossession'
+      - id: PAYMENT_STATUS_LATE_120
+        pattern: '(?i)late\s*120'
+      - id: PAYMENT_STATUS_LATE_90
+        pattern: '(?i)late\s*90'
     good_keywords:
-      - "paid in full"
-      - "paid as agreed"
-      - "current"
-      - "never late"
+      - id: PAYMENT_STATUS_PAID_IN_FULL
+        pattern: '(?i)paid\s+in\s+full|\bPIF\b'
+      - id: PAYMENT_STATUS_PAID_AS_AGREED
+        pattern: '(?i)paid\s+as\s+agreed'
+      - id: PAYMENT_STATUS_CURRENT
+        pattern: '(?i)\bcurrent\b'
+      - id: PAYMENT_STATUS_NEVER_LATE
+        pattern: '(?i)never\s+late'
     neutral_keywords:
-      - "unknown"
-      - "--"
+      - id: PAYMENT_STATUS_UNKNOWN
+        pattern: '(?i)unknown'
+      - id: PAYMENT_STATUS_PLACEHOLDER
+        pattern: '^\s*--\s*$'
     default: unknown
     weights:
       bad: high
@@ -44,9 +54,27 @@ fields:
 
   account_status:
     type: text
-    bad_keywords: [ "collection", "chargeoff", "repossession" ]
-    good_keywords: [ "closed - paid", "paid", "current" ]
-    neutral_keywords: [ "open", "closed", "--" ]
+    bad_keywords:
+      - id: ACCOUNT_STATUS_COLLECTION
+        pattern: '(?i)\bcollection\b'
+      - id: ACCOUNT_STATUS_CHARGEOFF
+        pattern: '(?i)charge[- ]?off'
+      - id: ACCOUNT_STATUS_REPOSSESSION
+        pattern: '(?i)repossession'
+    good_keywords:
+      - id: ACCOUNT_STATUS_CLOSED_PAID
+        pattern: '(?i)closed\s*-\s*paid'
+      - id: ACCOUNT_STATUS_PAID
+        pattern: '(?i)\bpaid\b'
+      - id: ACCOUNT_STATUS_CURRENT
+        pattern: '(?i)\bcurrent\b'
+    neutral_keywords:
+      - id: ACCOUNT_STATUS_OPEN
+        pattern: '(?i)\bopen\b'
+      - id: ACCOUNT_STATUS_CLOSED
+        pattern: '(?i)\bclosed\b'
+      - id: ACCOUNT_STATUS_PLACEHOLDER
+        pattern: '^\s*--\s*$'
     default: unknown
     weights: { bad: high, good: medium, neutral: low }
 
@@ -73,29 +101,61 @@ fields:
   creditor_remarks:
     type: text
     bad_keywords:
-      - "placed for collection"
-      - "assigned to attorney"
-      - "internal collections"
-      - "charged off"
+      - id: CREDITOR_REMARKS_PLACED_FOR_COLLECTION
+        pattern: '(?i)placed\s+for\s+collection'
+      - id: CREDITOR_REMARKS_ASSIGNED_TO_ATTORNEY
+        pattern: '(?i)assigned\s+to\s+attorney'
+      - id: CREDITOR_REMARKS_INTERNAL_COLLECTIONS
+        pattern: '(?i)internal\s+collections'
+      - id: CREDITOR_REMARKS_CHARGED_OFF
+        pattern: '(?i)charged\s+off'
     good_keywords:
-      - "dispute resolved - consumer agrees"
-      - "paid/settled"
-    neutral_keywords: [ "account information disputed", "--" ]
+      - id: CREDITOR_REMARKS_DISPUTE_RESOLVED
+        pattern: '(?i)dispute\s+resolved\s*-\s*consumer\s+agrees'
+      - id: CREDITOR_REMARKS_PAID_SETTLED
+        pattern: '(?i)paid/settled'
+    neutral_keywords:
+      - id: CREDITOR_REMARKS_ACCOUNT_DISPUTED
+        pattern: '(?i)account\s+information\s+disputed'
+      - id: CREDITOR_REMARKS_PLACEHOLDER
+        pattern: '^\s*--\s*$'
     default: neutral
     weights: { bad: medium, good: low, neutral: low }
 
   account_type:
     type: text
-    bad_keywords: [ "collection" ]
-    good_keywords: [ "installment", "revolving", "mortgage" ]
-    neutral_keywords: [ "--" ]
+    bad_keywords:
+      - id: ACCOUNT_TYPE_COLLECTION
+        pattern: '(?i)\bcollection\b'
+    good_keywords:
+      - id: ACCOUNT_TYPE_INSTALLMENT
+        pattern: '(?i)installment'
+      - id: ACCOUNT_TYPE_REVOLVING
+        pattern: '(?i)revolving'
+      - id: ACCOUNT_TYPE_MORTGAGE
+        pattern: '(?i)mortgage'
+    neutral_keywords:
+      - id: ACCOUNT_TYPE_PLACEHOLDER
+        pattern: '^\s*--\s*$'
     default: unknown
     weights: { bad: medium, good: low, neutral: low }
 
   creditor_type:
     type: text
-    bad_keywords: [ "collection agencies", "debt buyers" ]
-    good_keywords: [ "bank credit cards", "auto financing" ]
-    neutral_keywords: [ "all banks", "--" ]
+    bad_keywords:
+      - id: CREDITOR_TYPE_COLLECTION_AGENCY
+        pattern: '(?i)collection\s+agencies'
+      - id: CREDITOR_TYPE_DEBT_BUYER
+        pattern: '(?i)debt\s+buyers'
+    good_keywords:
+      - id: CREDITOR_TYPE_BANK_CREDIT_CARDS
+        pattern: '(?i)bank\s+credit\s+cards'
+      - id: CREDITOR_TYPE_AUTO_FINANCING
+        pattern: '(?i)auto\s+financing'
+    neutral_keywords:
+      - id: CREDITOR_TYPE_ALL_BANKS
+        pattern: '(?i)all\s+banks'
+      - id: CREDITOR_TYPE_PLACEHOLDER
+        pattern: '^\s*--\s*$'
     default: neutral
     weights: { bad: medium, good: low, neutral: low }

--- a/tests/backend/core/logic/test_polarity.py
+++ b/tests/backend/core/logic/test_polarity.py
@@ -105,9 +105,15 @@ def test_classify_text_field(monkeypatch, tmp_path: Path) -> None:
             "fields": {
                 "payment_status": {
                     "type": "text",
-                    "bad_keywords": ["collection"],
-                    "good_keywords": ["paid in full"],
-                    "neutral_keywords": ["--"],
+                    "bad_keywords": [
+                        {"id": "PAYMENT_STATUS_COLLECTION", "pattern": "collection"}
+                    ],
+                    "good_keywords": [
+                        {"id": "PAYMENT_STATUS_PAID_IN_FULL", "pattern": "paid in full"}
+                    ],
+                    "neutral_keywords": [
+                        {"id": "PAYMENT_STATUS_PLACEHOLDER", "pattern": "--"}
+                    ],
                     "default": "unknown",
                     "weights": {"bad": "high", "good": "medium", "neutral": "low"},
                 }
@@ -119,7 +125,7 @@ def test_classify_text_field(monkeypatch, tmp_path: Path) -> None:
     assert bad["polarity"] == "bad"
     assert bad["severity"] == "high"
     assert bad["value_norm"] == "account in collection"
-    assert bad["rule_hit"] == "collection"
+    assert bad["rule_hit"] == "PAYMENT_STATUS_COLLECTION"
     assert bad["reason"] == "matched bad keyword 'collection'"
     assert bad["evidence"]["matched_keyword"] == "collection"
 
@@ -127,7 +133,7 @@ def test_classify_text_field(monkeypatch, tmp_path: Path) -> None:
     assert good["polarity"] == "good"
     assert good["severity"] == "medium"
     assert good["value_norm"] == "paid in full"
-    assert good["rule_hit"] == "paid in full"
+    assert good["rule_hit"] == "PAYMENT_STATUS_PAID_IN_FULL"
     assert good["reason"] == "matched good keyword 'paid in full'"
 
     default = polarity.classify_field_value("payment_status", "unknown status")


### PR DESCRIPTION
## Summary
- add identifiers and regex patterns to polarity keyword definitions
- update polarity classifier to surface keyword rule ids and evidence
- adjust polarity tests to cover the new keyword configuration format

## Testing
- pytest tests/backend/core/logic/test_polarity.py

------
https://chatgpt.com/codex/tasks/task_b_68dbf4386c2c8325a8e4b86369bf7331