### PR TITLE
Add validation requirement pipeline for bureau inconsistencies

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -1,0 +1,131 @@
+"""Utilities for cross-bureau field consistency detection."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Mapping, MutableMapping
+
+__all__ = ["compute_inconsistent_fields"]
+
+
+_BUREAU_KEYS = ("transunion", "experian", "equifax")
+_MONEY_FIELDS = {
+    "balance_owed",
+    "past_due_amount",
+    "high_balance",
+    "credit_limit",
+    "payment_amount",
+}
+_DATE_FIELDS = {
+    "date_opened",
+    "closed_date",
+    "last_payment",
+    "date_of_last_activity",
+    "date_reported",
+    "last_verified",
+}
+_MISSING_SENTINELS = {None, "", "--"}
+
+_AMOUNT_SANITIZE_RE = re.compile(r"[,$\s]")
+_AMOUNT_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def _is_missing(value: Any) -> bool:
+    if value in _MISSING_SENTINELS:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _normalize_money(value: Any) -> float | None:
+    if _is_missing(value):
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    negative = False
+    if text.startswith("(") and text.endswith(")"):
+        negative = True
+        text = text[1:-1]
+
+    cleaned = _AMOUNT_SANITIZE_RE.sub("", text)
+    match = _AMOUNT_RE.search(cleaned)
+    if not match:
+        return None
+
+    try:
+        number = float(match.group())
+    except ValueError:
+        return None
+
+    if negative and number >= 0:
+        number = -number
+    return number
+
+
+def _normalize_text(value: Any) -> str | None:
+    if _is_missing(value):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    normalized = " ".join(text.split()).lower()
+    return normalized or None
+
+
+def _normalize_date(value: Any) -> str | None:
+    return _normalize_text(value)
+
+
+def _normalize_value(field: str, value: Any) -> Any:
+    if field in _MONEY_FIELDS:
+        return _normalize_money(value)
+    if field in _DATE_FIELDS or field.endswith("_date"):
+        return _normalize_date(value)
+    return _normalize_text(value)
+
+
+def compute_inconsistent_fields(bureaus: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, MutableMapping[str, Any]]]:
+    """Return fields whose normalized values differ between bureaus."""
+
+    union_fields = set()
+    for bureau in _BUREAU_KEYS:
+        branch = bureaus.get(bureau)
+        if isinstance(branch, Mapping):
+            union_fields.update(branch.keys())
+
+    result: Dict[str, Dict[str, MutableMapping[str, Any]]] = {}
+    for field in sorted(union_fields):
+        normalized: MutableMapping[str, Any] = {}
+        raw: MutableMapping[str, Any] = {}
+        distinct = set()
+        all_missing = True
+
+        for bureau in _BUREAU_KEYS:
+            branch = bureaus.get(bureau)
+            value = branch.get(field) if isinstance(branch, Mapping) else None
+            raw[bureau] = value
+            norm_value = _normalize_value(field, value)
+            normalized[bureau] = norm_value
+            if norm_value is not None:
+                all_missing = False
+                distinct.add(norm_value)
+            else:
+                distinct.add(None)
+
+        if all_missing:
+            continue
+
+        # Remove the placeholder None when other values exist to check actual disagreement.
+        if None in distinct and len(distinct) > 1:
+            distinct.remove(None)
+
+        if len(distinct) > 1:
+            result[field] = {"normalized": dict(normalized), "raw": dict(raw)}
+
+    return result

--- a/backend/core/logic/validation_config.yml
+++ b/backend/core/logic/validation_config.yml
@@ -1,0 +1,131 @@
+schema_version: 1
+
+defaults:
+  category: "unspecified"
+  min_days: 3
+  documents: []
+
+fields:
+  # 🟦 Opening & Identification
+  account_number_display:
+    category: "open_ident"
+    min_days: 2
+    documents: ["account_opening_contract", "monthly_statement", "collection_report"]
+
+  date_opened:
+    category: "open_ident"
+    min_days: 3
+    documents: ["account_opening_contract", "application_form", "system_audit_log"]
+
+  closed_date:
+    category: "open_ident"
+    min_days: 6
+    documents: ["closure_letter", "internal_closure_report"]
+
+  account_type:
+    category: "open_ident"
+    min_days: 2
+    documents: ["account_opening_contract", "application_form", "monthly_statement"]
+
+  creditor_type:
+    category: "open_ident"
+    min_days: 6
+    documents: ["account_opening_contract", "lender_agreement", "cra_report"]
+
+  account_description:
+    category: "open_ident"
+    min_days: 6
+    documents: ["application_form", "account_opening_contract"]
+
+  # 🟩 Terms
+  high_balance:
+    category: "terms"
+    min_days: 8
+    documents: ["loan_agreement", "monthly_statement", "internal_balance_report"]
+
+  credit_limit:
+    category: "terms"
+    min_days: 8
+    documents: ["credit_line_agreement", "limit_change_record", "monthly_statement"]
+
+  term_length:
+    category: "terms"
+    min_days: 3
+    documents: ["loan_agreement", "terms_sheet"]
+
+  payment_amount:
+    category: "terms"
+    min_days: 5
+    documents: ["loan_agreement", "amortization_schedule", "monthly_statement"]
+
+  payment_frequency:
+    category: "terms"
+    min_days: 3
+    documents: ["loan_agreement", "terms_sheet", "monthly_statement"]
+
+  # 🟨 Activity & Balances
+  balance_owed:
+    category: "activity"
+    min_days: 8
+    documents: ["monthly_statement", "balance_report", "collection_report"]
+
+  last_payment:
+    category: "activity"
+    min_days: 3
+    documents: ["monthly_statement", "payment_receipt", "internal_payment_log"]
+
+  past_due_amount:
+    category: "activity"
+    min_days: 8
+    documents: ["monthly_statement", "collection_report", "delinquency_notice"]
+
+  date_of_last_activity:
+    category: "activity"
+    min_days: 12
+    documents: ["monthly_statement", "system_activity_log", "internal_report"]
+
+  # 🟥 Status/Collections/CRA
+  account_status:
+    category: "status"
+    min_days: 12
+    documents: ["monthly_statement", "cra_report", "cra_audit_log"]
+
+  payment_status:
+    category: "status"
+    min_days: 25
+    documents: ["collection_notes", "chargeoff_statement", "monthly_statement"]
+
+  account_rating:
+    category: "status"
+    min_days: 18
+    documents: ["cra_report", "cra_audit_log"]
+
+  creditor_remarks:
+    category: "status"
+    min_days: 25
+    documents: ["collection_notes", "customer_letters", "cra_log"]
+
+  dispute_status:
+    category: "status"
+    min_days: 6
+    documents: ["cra_audit_log", "eoscar_system"]
+
+  date_reported:
+    category: "status"
+    min_days: 3
+    documents: ["cra_reporting_log", "cra_report"]
+
+  last_verified:
+    category: "status"
+    min_days: 6
+    documents: ["internal_audit_log", "verification_report"]
+
+  two_year_payment_history:
+    category: "history"
+    min_days: 18
+    documents: ["monthly_statements_2y", "internal_payment_history"]
+
+  seven_year_history:
+    category: "history"
+    min_days: 25
+    documents: ["cra_report_7y", "cra_audit_logs", "collection_history"]

--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -1,0 +1,228 @@
+"""Build and persist validation requirements derived from bureau mismatches."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+import yaml
+
+from backend.core.io.json_io import _atomic_write_json
+from backend.core.io.tags import read_tags, write_tags_atomic
+from backend.core.logic.consistency import compute_inconsistent_fields
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ValidationRule",
+    "ValidationConfig",
+    "load_validation_config",
+    "build_validation_requirements",
+    "build_summary_payload",
+    "apply_validation_summary",
+    "sync_validation_tag",
+]
+
+
+_VALIDATION_TAG_KIND = "validation_required"
+_CONFIG_PATH = Path(__file__).with_name("validation_config.yml")
+
+
+@dataclass(frozen=True)
+class ValidationRule:
+    """Metadata describing the validation needed for a field."""
+
+    category: str
+    min_days: int
+    documents: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidationConfig:
+    defaults: ValidationRule
+    fields: Mapping[str, ValidationRule]
+
+
+def _coerce_documents(raw: Any, fallback: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(raw, (str, bytes)):
+        return tuple(fallback)
+    if isinstance(raw, Iterable):
+        collected: List[str] = []
+        for entry in raw:
+            if entry is None:
+                continue
+            text = str(entry).strip()
+            if text:
+                collected.append(text)
+        if collected:
+            return tuple(collected)
+    return tuple(fallback)
+
+
+def _coerce_min_days(raw: Any, fallback: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return int(fallback)
+
+
+def _coerce_category(raw: Any, fallback: str) -> str:
+    if raw is None:
+        return str(fallback)
+    text = str(raw).strip()
+    return text or str(fallback)
+
+
+@lru_cache(maxsize=1)
+def load_validation_config(path: str | Path = _CONFIG_PATH) -> ValidationConfig:
+    """Load validation metadata from YAML configuration."""
+
+    config_path = Path(path)
+    try:
+        raw_text = config_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning("VALIDATION_CONFIG_MISSING path=%s", config_path)
+        defaults = ValidationRule("unspecified", 3, tuple())
+        return ValidationConfig(defaults=defaults, fields={})
+
+    try:
+        loaded = yaml.safe_load(raw_text) or {}
+    except yaml.YAMLError:
+        logger.exception("VALIDATION_CONFIG_PARSE_FAILED path=%s", config_path)
+        loaded = {}
+
+    defaults_raw = loaded.get("defaults") if isinstance(loaded, Mapping) else None
+    if isinstance(defaults_raw, Mapping):
+        default_category = _coerce_category(defaults_raw.get("category"), "unspecified")
+        default_min_days = _coerce_min_days(defaults_raw.get("min_days"), 3)
+        default_documents = _coerce_documents(defaults_raw.get("documents"), ())
+    else:
+        default_category = "unspecified"
+        default_min_days = 3
+        default_documents = tuple()
+
+    defaults = ValidationRule(default_category, default_min_days, default_documents)
+
+    fields_cfg: Dict[str, ValidationRule] = {}
+    fields_raw = loaded.get("fields") if isinstance(loaded, Mapping) else None
+    if isinstance(fields_raw, Mapping):
+        for key, value in fields_raw.items():
+            if not isinstance(value, Mapping):
+                continue
+            category = _coerce_category(value.get("category"), defaults.category)
+            min_days = _coerce_min_days(value.get("min_days"), defaults.min_days)
+            documents = _coerce_documents(value.get("documents"), defaults.documents)
+            fields_cfg[str(key)] = ValidationRule(category, min_days, documents)
+
+    return ValidationConfig(defaults=defaults, fields=fields_cfg)
+
+
+def build_validation_requirements(
+    bureaus: Mapping[str, Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return validation requirements for fields with cross-bureau inconsistencies."""
+
+    config = load_validation_config()
+    inconsistencies = compute_inconsistent_fields(bureaus)
+
+    requirements: List[Dict[str, Any]] = []
+    for field in sorted(inconsistencies.keys()):
+        rule = config.fields.get(field, config.defaults)
+        requirements.append(
+            {
+                "field": field,
+                "category": rule.category,
+                "min_days": rule.min_days,
+                "documents": list(rule.documents),
+            }
+        )
+
+    return requirements
+
+
+def build_summary_payload(requirements: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    """Build the summary.json payload for validation requirements."""
+
+    entries = [dict(item) for item in requirements]
+    return {"requirements": entries, "count": len(entries)}
+
+
+def _load_summary(summary_path: Path) -> MutableMapping[str, Any]:
+    try:
+        raw = summary_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except Exception:
+        return {}
+    if not isinstance(loaded, Mapping):
+        return {}
+    return dict(loaded)
+
+
+def apply_validation_summary(
+    summary_path: Path,
+    payload: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Update ``summary.json`` with validation requirements when they changed."""
+
+    summary_data = _load_summary(summary_path)
+    existing = summary_data.get("validation_requirements")
+
+    count = int(payload.get("count") or 0)
+    if count <= 0:
+        if "validation_requirements" in summary_data:
+            summary_data.pop("validation_requirements", None)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_json(summary_path, summary_data)
+        return summary_data
+
+    if not isinstance(existing, Mapping) or dict(existing) != dict(payload):
+        summary_data["validation_requirements"] = dict(payload)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(summary_path, summary_data)
+
+    return summary_data
+
+
+def sync_validation_tag(
+    tag_path: Path,
+    fields: Sequence[str],
+    *,
+    emit: bool,
+) -> None:
+    """Ensure ``tags.json`` reflects the validation requirements state."""
+
+    try:
+        tags = read_tags(tag_path)
+    except ValueError:
+        logger.exception("VALIDATION_TAG_READ_FAILED path=%s", tag_path)
+        return
+
+    filtered = [tag for tag in tags if tag.get("kind") != _VALIDATION_TAG_KIND]
+    changed = len(filtered) != len(tags)
+
+    if emit and fields:
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        entry = {
+            "kind": _VALIDATION_TAG_KIND,
+            "fields": list(fields),
+            "at": timestamp,
+        }
+        filtered.append(entry)
+        changed = True
+
+    if changed:
+        try:
+            write_tags_atomic(tag_path, filtered)
+        except Exception:  # pragma: no cover - defensive file IO
+            logger.exception("VALIDATION_TAG_WRITE_FAILED path=%s", tag_path)
+

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -1,0 +1,87 @@
+import json
+
+from backend.core.logic.consistency import compute_inconsistent_fields
+from backend.core.logic.validation_requirements import (
+    apply_validation_summary,
+    build_summary_payload,
+    build_validation_requirements,
+    sync_validation_tag,
+)
+
+
+def test_compute_inconsistent_fields_detects_money_and_text():
+    bureaus = {
+        "transunion": {"balance_owed": "$100.00", "account_status": "Open"},
+        "experian": {"balance_owed": "100", "account_status": "open"},
+        "equifax": {"balance_owed": "200", "account_status": "Closed"},
+    }
+
+    inconsistencies = compute_inconsistent_fields(bureaus)
+
+    assert "balance_owed" in inconsistencies
+    assert inconsistencies["balance_owed"]["normalized"]["equifax"] == 200.0
+    assert "account_status" in inconsistencies
+    assert inconsistencies["account_status"]["normalized"]["transunion"] == "open"
+
+
+def test_build_validation_requirements_uses_config_and_defaults():
+    bureaus = {
+        "transunion": {"balance_owed": "100", "mystery_field": "abc"},
+        "experian": {"balance_owed": "200", "mystery_field": "xyz"},
+        "equifax": {"balance_owed": "200", "mystery_field": "xyz"},
+    }
+
+    requirements = build_validation_requirements(bureaus)
+    fields = [entry["field"] for entry in requirements]
+
+    assert fields == ["balance_owed", "mystery_field"]
+
+    balance_rule = next(entry for entry in requirements if entry["field"] == "balance_owed")
+    assert balance_rule["category"] == "activity"
+    assert balance_rule["min_days"] == 8
+    assert "monthly_statement" in balance_rule["documents"]
+
+    mystery_rule = next(entry for entry in requirements if entry["field"] == "mystery_field")
+    assert mystery_rule["category"] == "unspecified"
+    assert mystery_rule["min_days"] == 3
+    assert mystery_rule["documents"] == []
+
+
+def test_apply_validation_summary_and_sync_validation_tag(tmp_path):
+    summary_path = tmp_path / "summary.json"
+    tag_path = tmp_path / "tags.json"
+
+    summary_path.write_text(json.dumps({"existing": True}), encoding="utf-8")
+    tag_payload = [
+        {"kind": "other", "value": 1},
+        {"kind": "validation_required", "fields": ["old"], "at": "2024-01-01T00:00:00Z"},
+    ]
+    tag_path.write_text(json.dumps(tag_payload), encoding="utf-8")
+
+    requirements = [
+        {"field": "balance_owed", "category": "activity", "min_days": 8, "documents": []}
+    ]
+    payload = build_summary_payload(requirements)
+
+    apply_validation_summary(summary_path, payload)
+    summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary_data["validation_requirements"]["count"] == 1
+    assert summary_data["existing"] is True
+
+    sync_validation_tag(tag_path, ["balance_owed"], emit=True)
+    tags = json.loads(tag_path.read_text(encoding="utf-8"))
+    validation_tags = [tag for tag in tags if tag.get("kind") == "validation_required"]
+    assert len(validation_tags) == 1
+    assert validation_tags[0]["fields"] == ["balance_owed"]
+    assert validation_tags[0]["at"].endswith("Z")
+    other_tags = [tag for tag in tags if tag.get("kind") == "other"]
+    assert other_tags == [{"kind": "other", "value": 1}]
+
+    empty_payload = build_summary_payload([])
+    apply_validation_summary(summary_path, empty_payload)
+    summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert "validation_requirements" not in summary_data
+
+    sync_validation_tag(tag_path, [], emit=True)
+    tags = json.loads(tag_path.read_text(encoding="utf-8"))
+    assert all(tag.get("kind") != "validation_required" for tag in tags)


### PR DESCRIPTION
## Summary
- add consistency analyzer and validation metadata config to describe per-field requirements
- populate summary.json with validation_requirements and optionally sync tags after merge processing
- cover validation requirement helpers with unit tests

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dbf5c28b608325897ffb43760a0d8c