### PR TITLE
Disable polarity stage in auto AI pipeline

### DIFF
--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -15,7 +15,6 @@ from typing import Iterable, Mapping, MutableMapping, Sequence
 from celery import shared_task
 
 from backend.core.ai.paths import ensure_merge_paths, probe_legacy_ai_packs
-from backend.core.logic.intra_polarity import analyze_account_polarity
 from backend.core.logic.validation_requirements import (
     build_validation_requirements_for_account,
 )
@@ -41,25 +40,6 @@ def packs_dir_for(sid: str, *, runs_root: Path | str | None = None) -> Path:
     base = Path(runs_root) if runs_root is not None else RUNS_ROOT
     merge_paths = ensure_merge_paths(base, sid, create=False)
     return merge_paths.base
-
-
-def polarity_phase_for_all_accounts(sid: str, *, runs_root: Path | str | None = None) -> None:
-    """Run polarity analysis for each account belonging to ``sid``."""
-
-    base_root = Path(runs_root) if runs_root is not None else RUNS_ROOT
-    accounts_root = base_root / sid / "cases" / "accounts"
-    if not accounts_root.exists():
-        return
-
-    for account_dir in sorted(accounts_root.iterdir()):
-        if not account_dir.is_dir():
-            continue
-        try:
-            analyze_account_polarity(sid, account_dir)
-        except Exception:  # pragma: no cover - defensive logging
-            logger.exception(
-                "POLARITY_PHASE_FAILED sid=%s account_dir=%s", sid, account_dir
-            )
 
 
 def _account_sort_key(path: Path) -> tuple[int, object]:
@@ -776,10 +756,7 @@ def _run_auto_ai_pipeline(sid: str):
     persist_manifest(manifest)
     logger.info("AUTO_AI_SENT sid=%s dir=%s", sid, packs_source_dir)
 
-    # === 4) polarity phase (updates per-bureau polarity assessments)
-    polarity_phase_for_all_accounts(sid, runs_root=RUNS_ROOT)
-
-    # === 5) compact tags (keep only tags; push explanations to summary.json)
+    # === 4) compact tags (keep only tags; push explanations to summary.json)
     compact_tags_for_sid(sid)
     manifest.set_ai_compacted()
     persist_manifest(manifest)


### PR DESCRIPTION
## Summary
- remove the polarity phase helper and stop invoking it from the auto AI pipeline so polarity never runs automatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbfddead288325860ff22d7b518b79