### PR TITLE
Compact merge summary sections

### DIFF
--- a/backend/core/logic/summary_compact.py
+++ b/backend/core/logic/summary_compact.py
@@ -1,4 +1,6 @@
-from typing import Dict, Any, List
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Sequence
 
 
 def compact_merge_sections(summary: Dict[str, Any]) -> Dict[str, Any]:
@@ -22,11 +24,54 @@ def compact_merge_sections(summary: Dict[str, Any]) -> Dict[str, Any]:
         "acctnum_digits_len_b",
     }
 
+    def _list_of_str(value: Any) -> list[str] | None:
+        if isinstance(value, set):
+            return sorted((str(v) for v in value))
+        if isinstance(value, (list, tuple)):
+            return [str(v) for v in value]
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            return [str(v) for v in value]
+        return None
+
+    def _safe_int(value: Any) -> int | None:
+        if isinstance(value, bool):  # bool is int subclass; keep explicit bools elsewhere
+            return int(value)
+        if isinstance(value, (int, float)):
+            return int(value)
+        try:
+            return int(str(value))
+        except (TypeError, ValueError):
+            return None
+
+    def _bool(value: Any) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        return bool(value)
+
     def _filter_ms(d: Dict[str, Any]) -> Dict[str, Any]:
-        out = {k: d.get(k) for k in KEEP_MS if k in d}
-        # force matched_fields booleans only
-        if "matched_fields" in out and isinstance(out["matched_fields"], dict):
-            out["matched_fields"] = {k: bool(v) for k, v in out["matched_fields"].items()}
+        out: Dict[str, Any] = {}
+        for key in KEEP_MS:
+            if key not in d:
+                continue
+            value = d.get(key)
+            if key in {"best_with", "score_total", "identity_score", "debt_score", "acctnum_digits_len_a", "acctnum_digits_len_b"}:
+                iv = _safe_int(value)
+                if iv is not None:
+                    out[key] = iv
+            elif key in {"reasons", "conflicts"}:
+                list_value = _list_of_str(value)
+                if list_value is not None:
+                    out[key] = list_value
+            elif key == "acctnum_level":
+                if isinstance(value, str):
+                    out[key] = value
+            elif key == "matched_fields":
+                if isinstance(value, Mapping):
+                    out[key] = {k: bool(v) for k, v in value.items()}
+            else:
+                out[key] = value
         return out
 
     KEEP_ME = {
@@ -45,15 +90,48 @@ def compact_merge_sections(summary: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     def _filter_me(item: Dict[str, Any]) -> Dict[str, Any]:
-        out = {k: item.get(k) for k in KEEP_ME if k in item}
-        # force matched_fields booleans only
-        if "matched_fields" in out and isinstance(out["matched_fields"], dict):
-            out["matched_fields"] = {k: bool(v) for k, v in out["matched_fields"].items()}
+        out: Dict[str, Any] = {}
+        for key in KEEP_ME:
+            if key not in item:
+                continue
+            value = item.get(key)
+            if key in {"with", "total", "acctnum_digits_len_a", "acctnum_digits_len_b"}:
+                iv = _safe_int(value)
+                if iv is not None:
+                    out[key] = iv
+            elif key == "parts":
+                if isinstance(value, Mapping):
+                    parts: Dict[str, int] = {}
+                    for part_key, part_value in value.items():
+                        iv = _safe_int(part_value)
+                        if iv is not None:
+                            parts[str(part_key)] = iv
+                    out[key] = parts
+            elif key in {"reasons", "conflicts"}:
+                list_value = _list_of_str(value)
+                if list_value is not None:
+                    out[key] = list_value
+            elif key == "matched_fields":
+                if isinstance(value, Mapping):
+                    out[key] = {k: bool(v) for k, v in value.items()}
+            elif key == "strong":
+                bool_value = _bool(value)
+                if bool_value is not None:
+                    out[key] = bool_value
+            elif key == "acctnum_level":
+                if isinstance(value, str):
+                    out[key] = value
+            else:
+                out[key] = value
         return out
 
-    if ms:
-        summary["merge_scoring"] = _filter_ms(ms)
+    if isinstance(ms, Mapping):
+        summary["merge_scoring"] = _filter_ms(dict(ms))
     if isinstance(me, list):
-        summary["merge_explanations"] = [_filter_me(x) for x in me]
+        summary["merge_explanations"] = [
+            _filter_me(dict(item))
+            for item in me
+            if isinstance(item, Mapping)
+        ]
 
     return summary

--- a/devtools/compact_merge_summaries.py
+++ b/devtools/compact_merge_summaries.py
@@ -1,0 +1,33 @@
+import glob
+import json
+import os
+import sys
+
+from backend.core.logic.summary_compact import compact_merge_sections
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: compact_merge_summaries.py <SID>")
+        sys.exit(2)
+    sid = sys.argv[1]
+    root = os.path.join("runs", sid, "cases", "accounts")
+    for path in glob.glob(os.path.join(root, "*")):
+        if not os.path.isdir(path):
+            continue
+        name = os.path.basename(path)
+        if not name.isdigit():
+            continue
+        summary_path = os.path.join(path, "summary.json")
+        if not os.path.isfile(summary_path):
+            continue
+        with open(summary_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        compact_merge_sections(data)
+        with open(summary_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/core/test_summary_compact.py
+++ b/tests/core/test_summary_compact.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from backend.core.logic.summary_compact import compact_merge_sections
+
+
+def test_compact_merge_sections_filters_and_normalizes() -> None:
+    summary = {
+        "merge_scoring": {
+            "best_with": "2",
+            "score_total": 42.0,
+            "reasons": ("foo", "bar"),
+            "conflicts": {"baz", "qux"},
+            "identity_score": "7",
+            "debt_score": None,
+            "acctnum_level": "strong",
+            "matched_fields": {"name": 1, "ssn": "yes", "phone": 0},
+            "acctnum_digits_len_a": "4",
+            "acctnum_digits_len_b": 5,
+            "extra": "remove me",
+        },
+        "merge_explanations": [
+            {
+                "kind": "merge_pair",
+                "with": "3",
+                "decision": "ai",
+                "total": 10.5,
+                "parts": {"match": "8", "conflict": 1.2, "noop": None},
+                "matched_fields": {"name": "true", "phone": []},
+                "reasons": ["keep"],
+                "conflicts": ("drop",),
+                "strong": 0,
+                "acctnum_level": "medium",
+                "acctnum_digits_len_a": "6",
+                "acctnum_digits_len_b": "7",
+                "tiebreaker": "remove",
+            },
+            "not a mapping",
+        ],
+        "untouched": {"stay": True},
+    }
+
+    compact_merge_sections(summary)
+
+    assert summary["merge_scoring"] == {
+        "best_with": 2,
+        "score_total": 42,
+        "reasons": ["foo", "bar"],
+        "conflicts": ["baz", "qux"],
+        "identity_score": 7,
+        "acctnum_level": "strong",
+        "matched_fields": {"name": True, "ssn": True, "phone": False},
+        "acctnum_digits_len_a": 4,
+        "acctnum_digits_len_b": 5,
+    }
+
+    assert summary["merge_explanations"] == [
+        {
+            "kind": "merge_pair",
+            "with": 3,
+            "decision": "ai",
+            "total": 10,
+            "parts": {"match": 8, "conflict": 1},
+            "matched_fields": {"name": True, "phone": False},
+            "reasons": ["keep"],
+            "conflicts": ["drop"],
+            "strong": False,
+            "acctnum_level": "medium",
+            "acctnum_digits_len_a": 6,
+            "acctnum_digits_len_b": 7,
+        }
+    ]
+
+    assert summary["untouched"] == {"stay": True}


### PR DESCRIPTION
## Summary
- shrink merge summary compaction to retain only the required fields and normalize types
- add a regression test to cover merge summary compaction behavior
- provide a utility script for retroactively compacting existing run artifacts

## Testing
- pytest tests/core/test_summary_compact.py

------
https://chatgpt.com/codex/tasks/task_b_68dc067546108325b3e58a80b6a77980