### PR TITLE
Scrub merge summary internals

### DIFF
--- a/backend/core/logic/summary_compact.py
+++ b/backend/core/logic/summary_compact.py
@@ -1,144 +1,112 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import Any
 
 
-def compact_merge_sections(summary: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Mutates a summary dict in-place to keep only compact merge_scoring and merge_explanations.
-    Returns the same dict (for chaining).
-    """
-    ms = summary.get("merge_scoring") or {}
-    me = summary.get("merge_explanations") or []
+_MERGE_SCORING_ALLOWED = {
+    "best_with",
+    "score_total",
+    "reasons",
+    "conflicts",
+    "identity_score",
+    "debt_score",
+    "acctnum_level",
+    "matched_fields",
+    "acctnum_digits_len_a",
+    "acctnum_digits_len_b",
+}
 
-    KEEP_MS = {
-        "best_with",
-        "score_total",
-        "reasons",
-        "conflicts",
-        "identity_score",
-        "debt_score",
-        "acctnum_level",
-        "matched_fields",
-        "acctnum_digits_len_a",
-        "acctnum_digits_len_b",
-    }
+_MERGE_EXPLANATION_ALLOWED = {
+    "kind",
+    "with",
+    "decision",
+    "total",
+    "parts",
+    "matched_fields",
+    "reasons",
+    "conflicts",
+    "strong",
+    "acctnum_level",
+    "acctnum_digits_len_a",
+    "acctnum_digits_len_b",
+}
 
-    def _list_of_str(value: Any) -> list[str] | None:
-        if isinstance(value, set):
-            return sorted((str(v) for v in value))
-        if isinstance(value, (list, tuple)):
-            return [str(v) for v in value]
-        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-            return [str(v) for v in value]
-        return None
+_BANNED_KEYS = {
+    "aux",
+    "by_field_pairs",
+    "matched_pairs",
+    "tiebreaker",
+    "strong_rank",
+    "dates_all",
+    "mid",
+}
 
-    def _safe_int(value: Any) -> int | None:
-        if isinstance(value, bool):  # bool is int subclass; keep explicit bools elsewhere
-            return int(value)
-        if isinstance(value, (int, float)):
-            return int(value)
-        try:
-            return int(str(value))
-        except (TypeError, ValueError):
-            return None
 
-    def _bool(value: Any) -> bool | None:
-        if isinstance(value, bool):
-            return value
-        if value is None:
-            return None
-        return bool(value)
+def _ensure_bool_mapping(value: Any) -> Any:
+    """Return a mapping containing only boolean values when possible."""
 
-    def _filter_ms(d: Dict[str, Any]) -> Dict[str, Any]:
-        out: Dict[str, Any] = {}
-        for key in KEEP_MS:
-            if key not in d:
+    if isinstance(value, Mapping):
+        return {key: bool(val) for key, val in value.items()}
+    return value
+
+
+def _filter_keys(source: Mapping[str, Any], allowed_keys: set[str]) -> dict[str, Any]:
+    """Return a shallow copy containing only allowed keys."""
+
+    filtered: dict[str, Any] = {}
+    for key, value in source.items():
+        if key not in allowed_keys:
+            continue
+        if key == "matched_fields":
+            value = _ensure_bool_mapping(value)
+
+        filtered[key] = deepcopy(value)
+
+    return filtered
+
+
+def _scrub_banned(value: Any) -> Any:
+    """Recursively remove banned keys from dictionaries."""
+
+    if isinstance(value, Mapping):
+        cleaned: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _BANNED_KEYS:
                 continue
-            value = d.get(key)
-            if key in {
-                "best_with",
-                "score_total",
-                "identity_score",
-                "debt_score",
-                "acctnum_digits_len_a",
-                "acctnum_digits_len_b",
-            }:
-                iv = _safe_int(value)
-                if iv is not None:
-                    out[key] = iv
-            elif key in {"reasons", "conflicts"}:
-                list_value = _list_of_str(value)
-                if list_value is not None:
-                    out[key] = list_value
-            elif key == "acctnum_level":
-                if isinstance(value, str):
-                    out[key] = value
-            elif key == "matched_fields":
-                if isinstance(value, Mapping):
-                    out[key] = {k: bool(v) for k, v in value.items()}
-            else:
-                out[key] = value
-        return out
+            cleaned[key] = _scrub_banned(item)
+        return cleaned
 
-    KEEP_ME = {
-        "kind",
-        "with",
-        "decision",
-        "total",
-        "parts",
-        "matched_fields",
-        "reasons",
-        "conflicts",
-        "strong",
-        "acctnum_level",
-        "acctnum_digits_len_a",
-        "acctnum_digits_len_b",
-    }
+    if isinstance(value, list):
+        return [_scrub_banned(item) for item in value]
 
-    def _filter_me(item: Dict[str, Any]) -> Dict[str, Any]:
-        out: Dict[str, Any] = {}
-        for key in KEEP_ME:
-            if key not in item:
+    if isinstance(value, tuple):
+        return tuple(_scrub_banned(item) for item in value)
+
+    return value
+
+
+def compact_merge_sections(summary: dict[str, Any]) -> dict[str, Any]:
+    """Compact merge sections and scrub banned keys from a summary payload."""
+
+    merge_scoring = summary.get("merge_scoring")
+    if isinstance(merge_scoring, Mapping):
+        summary["merge_scoring"] = _filter_keys(merge_scoring, _MERGE_SCORING_ALLOWED)
+
+    merge_explanations = summary.get("merge_explanations")
+    if isinstance(merge_explanations, Sequence) and not isinstance(
+        merge_explanations, (str, bytes, bytearray)
+    ):
+        filtered_explanations = []
+        for entry in merge_explanations:
+            if not isinstance(entry, Mapping):
                 continue
-            value = item.get(key)
-            if key in {"with", "total", "acctnum_digits_len_a", "acctnum_digits_len_b"}:
-                iv = _safe_int(value)
-                if iv is not None:
-                    out[key] = iv
-            elif key == "parts":
-                if isinstance(value, Mapping):
-                    parts: Dict[str, int] = {}
-                    for part_key, part_value in value.items():
-                        iv = _safe_int(part_value)
-                        if iv is not None:
-                            parts[str(part_key)] = iv
-                    out[key] = parts
-            elif key in {"reasons", "conflicts"}:
-                list_value = _list_of_str(value)
-                if list_value is not None:
-                    out[key] = list_value
-            elif key == "matched_fields":
-                if isinstance(value, Mapping):
-                    out[key] = {k: bool(v) for k, v in value.items()}
-            elif key == "strong":
-                bool_value = _bool(value)
-                if bool_value is not None:
-                    out[key] = bool_value
-            elif key == "acctnum_level":
-                if isinstance(value, str):
-                    out[key] = value
-            else:
-                out[key] = value
-        return out
+            filtered = _filter_keys(entry, _MERGE_EXPLANATION_ALLOWED)
+            filtered_explanations.append(filtered)
+        summary["merge_explanations"] = filtered_explanations
 
-    if isinstance(ms, Mapping):
-        summary["merge_scoring"] = _filter_ms(dict(ms))
-    if isinstance(me, list):
-        summary["merge_explanations"] = [
-            _filter_me(dict(item))
-            for item in me
-            if isinstance(item, Mapping)
-        ]
-
+    scrubbed = _scrub_banned(summary)
+    summary.clear()
+    summary.update(scrubbed)
     return summary


### PR DESCRIPTION
## Summary
- rebuild the merge_scoring and merge_explanations sections from whitelisted fields only
- coerce matched_fields maps to boolean flags before persisting
- recursively remove banned merge bookkeeping keys from the summary payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc0d2fe15c8325a27c8a27742ecf83