### PR TITLE
Compact merge summary outputs before persisting

### DIFF
--- a/backend/core/io/tags_minimize.py
+++ b/backend/core/io/tags_minimize.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 
 from backend.core.io.tags import read_tags, write_tags_atomic
+from backend.core.logic.summary_compact import compact_merge_sections
 from backend.core.merge.acctnum import normalize_level
 
 
@@ -336,6 +338,8 @@ def compact_account_tags(account_dir: Path) -> None:
         )
 
     if merge_explanations or ai_explanations or summary_path.exists():
+        if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+            compact_merge_sections(summary_data)
         summary_path.write_text(
             json.dumps(summary_data, ensure_ascii=False, indent=2), encoding="utf-8"
         )

--- a/backend/core/logic/intra_polarity.py
+++ b/backend/core/logic/intra_polarity.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Mapping
 from backend.core.io.json_io import update_json_in_place
 from backend.core.io.tags import upsert_tag
 from backend.core.logic.polarity import classify_field_value, load_polarity_config
+from backend.core.logic.summary_compact import compact_merge_sections
 
 logger = logging.getLogger(__name__)
 
@@ -187,9 +188,13 @@ def analyze_account_polarity(sid: str, account_dir: "os.PathLike[str]") -> Dict[
             summary = {}
 
         if summary.get("polarity_check") == polarity_block:
+            if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+                compact_merge_sections(summary)
             return summary
 
         summary["polarity_check"] = polarity_block
+        if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+            compact_merge_sections(summary)
         return summary
 
     try:

--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -16,6 +16,7 @@ import yaml
 from backend.core.io.json_io import _atomic_write_json
 from backend.core.io.tags import read_tags, write_tags_atomic
 from backend.core.logic.consistency import compute_inconsistent_fields
+from backend.core.logic.summary_compact import compact_merge_sections
 
 logger = logging.getLogger(__name__)
 
@@ -184,12 +185,16 @@ def apply_validation_summary(
         if "validation_requirements" in summary_data:
             summary_data.pop("validation_requirements", None)
             summary_path.parent.mkdir(parents=True, exist_ok=True)
+            if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+                compact_merge_sections(summary_data)
             _atomic_write_json(summary_path, summary_data)
         return summary_data
 
     if not isinstance(existing, Mapping) or dict(existing) != dict(payload):
         summary_data["validation_requirements"] = dict(payload)
         summary_path.parent.mkdir(parents=True, exist_ok=True)
+        if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+            compact_merge_sections(summary_data)
         _atomic_write_json(summary_path, summary_data)
 
     return summary_data

--- a/scripts/send_ai_merge_packs.py
+++ b/scripts/send_ai_merge_packs.py
@@ -50,6 +50,7 @@ from backend.core.logic.report_analysis.account_merge import (
     build_summary_merge_entry,
     merge_summary_sections,
 )
+from backend.core.logic.summary_compact import compact_merge_sections
 from backend.core.merge.acctnum import normalize_level
 from backend.pipeline.runs import RunManifest, persist_manifest
 
@@ -438,7 +439,10 @@ def _load_summary(path: Path) -> dict[str, object]:
 
 
 def _write_summary(path: Path, payload: Mapping[str, object]) -> None:
-    serialized = json.dumps(dict(payload), ensure_ascii=False, indent=2)
+    data = dict(payload)
+    if os.getenv("COMPACT_MERGE_SUMMARY", "1") == "1":
+        compact_merge_sections(data)
+    serialized = json.dumps(data, ensure_ascii=False, indent=2)
     path.write_text(f"{serialized}\n", encoding="utf-8")
 
 

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -986,16 +986,14 @@ def test_auto_ai_build_and_send_use_ai_packs_dir(tmp_path, monkeypatch, caplog):
     assert "total" in merge_score_a["reasons"]
     assert merge_score_a["matched_fields"].get("balance_owed") is True
     assert merge_score_a.get("acctnum_level") in {"exact_or_known_match", "none"}
-    assert "account_number" in merge_score_a.get("matched_pairs", {})
-    assert isinstance(merge_score_a["matched_pairs"]["account_number"], list)
+    assert "matched_pairs" not in merge_score_a
 
     merge_score_b = summary_b.get("merge_scoring")
     assert merge_score_b
     assert merge_score_b["best_with"] == 11
     assert merge_score_b["matched_fields"].get("balance_owed") is True
     assert merge_score_b.get("acctnum_level") in {"exact_or_known_match", "none"}
-    assert "account_number" in merge_score_b.get("matched_pairs", {})
-    assert isinstance(merge_score_b["matched_pairs"]["account_number"], list)
+    assert "matched_pairs" not in merge_score_b
 
 
 

--- a/tests/report_analysis/test_tags_compact.py
+++ b/tests/report_analysis/test_tags_compact.py
@@ -109,9 +109,14 @@ def test_compact_tags_moves_verbose_data_to_summary(tmp_path: Path) -> None:
     assert merge_entry["parts"] == {"balance_owed": 31}
     assert merge_entry["conflicts"] == ["amount_conflict:high_balance"]
     assert merge_entry["matched_fields"] == {"balance_owed": True}
-    aux_payload = merge_entry.get("aux", {}) if isinstance(merge_entry.get("aux"), dict) else {}
-    acct_level = merge_entry.get("acctnum_level", aux_payload.get("acctnum_level"))
-    assert acct_level == "none"
+    assert merge_entry.get("acctnum_level") == "none"
+    assert "aux" not in merge_entry
+    assert "matched_pairs" not in merge_entry
+
+    merge_scoring = summary_after.get("merge_scoring", {})
+    if isinstance(merge_scoring, dict):
+        assert "matched_pairs" not in merge_scoring
+        assert "aux" not in merge_scoring
 
     ai_entries = summary_after["ai_explanations"]
     assert isinstance(ai_entries, list)

--- a/tests/scripts/test_send_ai_merge_packs.py
+++ b/tests/scripts/test_send_ai_merge_packs.py
@@ -1256,9 +1256,7 @@ def test_ai_pairing_flow_compaction(
         "account_number": True,
     }
     assert merge_best_entry.get("acctnum_level") in {"exact_or_known_match", "none"}
-    acct_pair = merge_best_entry["matched_pairs"]["account_number"]
-    assert isinstance(acct_pair, list)
-    assert len(acct_pair) == 2
+    assert "matched_pairs" not in merge_best_entry
     assert "acctnum_digits_len_a" in merge_best_entry
     assert "acctnum_digits_len_b" in merge_best_entry
 
@@ -1283,9 +1281,7 @@ def test_ai_pairing_flow_compaction(
     assert merge_score_a["score_total"] >= 0
     assert merge_score_a["matched_fields"].get("balance_owed") is True
     assert merge_score_a.get("acctnum_level") in {"exact_or_known_match", "none"}
-    assert "matched_pairs" in merge_score_a
-    assert "account_number" in merge_score_a["matched_pairs"]
-    assert isinstance(merge_score_a["matched_pairs"]["account_number"], list)
+    assert "matched_pairs" not in merge_score_a
     assert "acctnum_digits_len_a" in merge_score_a
     assert "acctnum_digits_len_b" in merge_score_a
 
@@ -1294,9 +1290,7 @@ def test_ai_pairing_flow_compaction(
     assert merge_score_b["best_with"] == 11
     assert merge_score_b["matched_fields"].get("balance_owed") is True
     assert merge_score_b.get("acctnum_level") in {"exact_or_known_match", "none"}
-    assert "matched_pairs" in merge_score_b
-    assert "account_number" in merge_score_b["matched_pairs"]
-    assert isinstance(merge_score_b["matched_pairs"]["account_number"], list)
+    assert "matched_pairs" not in merge_score_b
     assert "acctnum_digits_len_a" in merge_score_b
     assert "acctnum_digits_len_b" in merge_score_b
 


### PR DESCRIPTION
## Summary
- scrub merge summary payloads immediately before writing summary.json across tag compaction, validation, polarity, and problem case flows
- update tag compaction to retain acctnum_level data while removing banned keys from persisted merge explanations
- adjust summary-focused tests to expect compacted outputs and confirm banned fields are absent

## Testing
- pytest tests/report_analysis/test_tags_compact.py
- pytest tests/scripts/test_send_ai_merge_packs.py::test_send_ai_merge_packs_writes_same_debt_tags -q
- pytest tests/pipeline/test_auto_ai.py::test_run_auto_ai_pipeline_processes_index_and_updates_manifest -q

------
https://chatgpt.com/codex/tasks/task_b_68dc14bbdb848325aff321ad368278a9