### PR TITLE
Compact stored merge summaries and add retro cleaner

### DIFF
--- a/backend/core/logic/summary_compact.py
+++ b/backend/core/logic/summary_compact.py
@@ -170,7 +170,11 @@ def _normalize_merge_scoring(source: Mapping[str, Any] | None) -> dict[str, Any]
         if digits is not None:
             normalized[key] = digits
 
-    return normalized
+    return {
+        key: normalized[key]
+        for key in _MERGE_SCORING_ALLOWED
+        if key in normalized
+    }
 
 
 def _normalize_merge_explanations(

--- a/devtools/compact_merge_summaries.py
+++ b/devtools/compact_merge_summaries.py
@@ -1,33 +1,62 @@
-import glob
+from __future__ import annotations
+
+import argparse
 import json
-import os
-import sys
+from pathlib import Path
+from typing import Iterable, Sequence
 
 from backend.core.logic.summary_compact import compact_merge_sections
 
-
-def main() -> None:
-    if len(sys.argv) < 2:
-        print("usage: compact_merge_summaries.py <SID>")
-        sys.exit(2)
-    sid = sys.argv[1]
-    root = os.path.join("runs", sid, "cases", "accounts")
-    for path in glob.glob(os.path.join(root, "*")):
-        if not os.path.isdir(path):
-            continue
-        name = os.path.basename(path)
-        if not name.isdigit():
-            continue
-        summary_path = os.path.join(path, "summary.json")
-        if not os.path.isfile(summary_path):
-            continue
-        with open(summary_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        compact_merge_sections(data)
-        with open(summary_path, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False, indent=2)
-    print("ok")
+__all__ = ["main"]
 
 
-if __name__ == "__main__":
-    main()
+def _iter_summary_paths(root: Path) -> Iterable[Path]:
+    """Yield summary.json files under ``root``."""
+
+    if not root.exists():
+        return
+
+    yield from (path for path in root.glob("*/summary.json") if path.is_file())
+
+
+def _compact_summary(path: Path) -> None:
+    """Compact the merge sections for ``path`` in place."""
+
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    compact_merge_sections(data)
+
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Compact merge sections for an existing SID."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compact merge scoring/explanations across all account summaries for the"
+            " provided SID."
+        )
+    )
+    parser.add_argument("sid", help="Run identifier under runs/<SID>/cases/accounts/")
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path("runs") / args.sid / "cases" / "accounts"
+    if not root.exists():
+        parser.error(f"no such run directory: {root}")
+
+    count = 0
+    for summary_path in sorted(_iter_summary_paths(root)):
+        _compact_summary(summary_path)
+        count += 1
+
+    print(f"Compacted {count} summary file(s) under {root}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI
+    raise SystemExit(main())

--- a/tests/devtools/test_compact_merge_summaries.py
+++ b/tests/devtools/test_compact_merge_summaries.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools.compact_merge_summaries import main
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_compact_merge_summaries_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    account_dir = tmp_path / "runs" / "SID123" / "cases" / "accounts" / "0001"
+    account_dir.mkdir(parents=True)
+    summary_path = account_dir / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "merge_scoring": {
+                    "best_with": "2",
+                    "matched_fields": {"foo": 1, "bar": 0},
+                    "aux": {"noise": True},
+                },
+                "merge_explanations": [
+                    {
+                        "kind": "merge_pair",
+                        "with": "3",
+                        "parts": {"match": "4"},
+                        "matched_fields": {"baz": []},
+                        "reasons": ("keep",),
+                        "aux": {"noise": 1},
+                    }
+                ],
+                "aux": {"nested": 1},
+            }
+        )
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(["SID123"])
+
+    assert exit_code == 0
+
+    data = json.loads(summary_path.read_text())
+    assert "aux" not in data
+    assert data["merge_scoring"] == {"best_with": 2, "matched_fields": {"foo": True, "bar": False}}
+    assert data["merge_explanations"] == [
+        {
+            "kind": "merge_pair",
+            "with": 3,
+            "parts": {"match": 4},
+            "matched_fields": {"baz": False},
+            "reasons": ["keep"],
+        }
+    ]


### PR DESCRIPTION
## Summary
- filter merge scoring payloads down to the allowed keys before persisting summaries
- add a CLI tool to retro-compact summary.json files for an existing SID
- cover the compaction CLI with a regression test

## Testing
- pytest tests/core/test_summary_compact.py tests/devtools/test_compact_merge_summaries.py

------
https://chatgpt.com/codex/tasks/task_b_68dc1a61c8408325aa7c563c8818a256