### PR TITLE
Enhance validation requirements metadata

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Mapping, MutableMapping
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
 
 __all__ = ["compute_inconsistent_fields"]
 
@@ -25,14 +25,20 @@ _DATE_FIELDS = {
     "last_verified",
 }
 _MISSING_SENTINELS = {None, "", "--"}
+_HISTORY_FIELDS = {"two_year_payment_history", "seven_year_history"}
 
 _AMOUNT_SANITIZE_RE = re.compile(r"[,$\s]")
 _AMOUNT_RE = re.compile(r"-?\d+(?:\.\d+)?")
+_HISTORY_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
 
 
 def _is_missing(value: Any) -> bool:
-    if value in _MISSING_SENTINELS:
-        return True
+    try:
+        if value in _MISSING_SENTINELS:
+            return True
+    except TypeError:
+        # Unhashable container values are not considered missing by membership.
+        pass
     if isinstance(value, str) and not value.strip():
         return True
     return False
@@ -83,11 +89,123 @@ def _normalize_date(value: Any) -> str | None:
 
 
 def _normalize_value(field: str, value: Any) -> Any:
+    if field == "two_year_payment_history":
+        return _normalize_two_year_history(value)
+    if field == "seven_year_history":
+        return _normalize_seven_year_history(value)
     if field in _MONEY_FIELDS:
         return _normalize_money(value)
     if field in _DATE_FIELDS or field.endswith("_date"):
         return _normalize_date(value)
     return _normalize_text(value)
+
+
+def _normalize_history_status(value: Any) -> str | None:
+    if value is None or value in _MISSING_SENTINELS:
+        return None
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+    normalized = text.upper().replace(" ", "")
+    return normalized or None
+
+
+def _flatten_history_values(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        # Prefer well-known container keys when present.
+        for key in ("values", "statuses", "history", "entries", "items"):
+            if key in value:
+                return _flatten_history_values(value.get(key))
+        flattened: list[Any] = []
+        for key in sorted(value.keys()):
+            flattened.extend(_flatten_history_values(value[key]))
+        return flattened
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        flattened: list[Any] = []
+        for entry in value:
+            if isinstance(entry, Mapping):
+                if "status" in entry:
+                    flattened.append(entry.get("status"))
+                    continue
+                if "value" in entry:
+                    flattened.append(entry.get("value"))
+                    continue
+            flattened.extend(_flatten_history_values(entry))
+        return flattened
+    if isinstance(value, str):
+        tokens = [token.strip() for token in _HISTORY_TOKEN_RE.findall(value.upper()) if token.strip()]
+        if tokens:
+            return tokens
+        text = value.strip()
+        return [text] if text else []
+    return [value]
+
+
+def _normalize_two_year_history(value: Any) -> tuple[str, ...] | None:
+    if _is_missing(value):
+        return None
+    tokens = []
+    for item in _flatten_history_values(value):
+        token = _normalize_history_status(item)
+        if token:
+            tokens.append(token)
+    if not tokens:
+        return None
+    return tuple(tokens)
+
+
+def _normalize_history_count(value: Any) -> int | float | None:
+    if value is None or value in _MISSING_SENTINELS:
+        return None
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    match = _AMOUNT_RE.search(text)
+    if not match:
+        return None
+    number_text = match.group()
+    try:
+        number = float(number_text)
+    except ValueError:
+        return None
+    if number.is_integer():
+        return int(number)
+    return number
+
+
+def _normalize_seven_year_history(value: Any) -> Any:
+    if _is_missing(value):
+        return None
+    if isinstance(value, Mapping):
+        normalized_items = []
+        for key in sorted(value.keys()):
+            norm_key = _normalize_history_status(key) or ""
+            norm_value = _normalize_history_count(value[key])
+            normalized_items.append((norm_key, norm_value))
+        if not normalized_items:
+            return None
+        return tuple(normalized_items)
+
+    # Fall back to treating it like a sequence of status tokens.
+    tokens = _normalize_two_year_history(value)
+    if not tokens:
+        return None
+    return tokens
 
 
 def compute_inconsistent_fields(bureaus: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, MutableMapping[str, Any]]]:
@@ -98,6 +216,11 @@ def compute_inconsistent_fields(bureaus: Mapping[str, Mapping[str, Any]]) -> Dic
         branch = bureaus.get(bureau)
         if isinstance(branch, Mapping):
             union_fields.update(branch.keys())
+    for history_field in _HISTORY_FIELDS:
+        history_blob = bureaus.get(history_field)
+        if _is_missing(history_blob):
+            continue
+        union_fields.add(history_field)
 
     result: Dict[str, Dict[str, MutableMapping[str, Any]]] = {}
     for field in sorted(union_fields):
@@ -107,8 +230,15 @@ def compute_inconsistent_fields(bureaus: Mapping[str, Mapping[str, Any]]) -> Dic
         all_missing = True
 
         for bureau in _BUREAU_KEYS:
-            branch = bureaus.get(bureau)
-            value = branch.get(field) if isinstance(branch, Mapping) else None
+            if field in _HISTORY_FIELDS:
+                history_blob = bureaus.get(field)
+                if isinstance(history_blob, Mapping):
+                    value = history_blob.get(bureau)
+                else:
+                    value = history_blob
+            else:
+                branch = bureaus.get(bureau)
+                value = branch.get(field) if isinstance(branch, Mapping) else None
             raw[bureau] = value
             norm_value = _normalize_value(field, value)
             normalized[bureau] = norm_value

--- a/backend/core/logic/validation_config.yml
+++ b/backend/core/logic/validation_config.yml
@@ -1,131 +1,207 @@
-schema_version: 1
+schema_version: 2
 
 defaults:
-  category: "unspecified"
+  category: "unknown"
   min_days: 3
+  points: 3
   documents: []
+  strength: "soft"
+  ai_needed: false
 
 fields:
-  # 🟦 Opening & Identification
+  # ---- Open/Identification ----
   account_number_display:
-    category: "open_ident"
+    category: open_ident
     min_days: 2
-    documents: ["account_opening_contract", "monthly_statement", "collection_report"]
+    points: 3
+    documents: [account_opening_contract, monthly_statement, collection_report]
+    strength: soft
+    ai_needed: true         # masking vs true mismatch
 
   date_opened:
-    category: "open_ident"
+    category: open_ident
     min_days: 3
-    documents: ["account_opening_contract", "application_form", "system_audit_log"]
+    points: 3
+    documents: [account_opening_contract, application_form, system_audit_log]
+    strength: strong
+    ai_needed: false
 
   closed_date:
-    category: "open_ident"
+    category: open_ident
     min_days: 6
-    documents: ["closure_letter", "internal_closure_report"]
+    points: 6
+    documents: [closure_letter, internal_closure_report]
+    strength: strong
+    ai_needed: false
 
   account_type:
-    category: "open_ident"
+    category: open_ident
     min_days: 2
-    documents: ["account_opening_contract", "application_form", "monthly_statement"]
+    points: 3
+    documents: [account_opening_contract, application_form, monthly_statement]
+    strength: soft
+    ai_needed: true         # semantic class differences
 
   creditor_type:
-    category: "open_ident"
+    category: open_ident
     min_days: 6
-    documents: ["account_opening_contract", "lender_agreement", "cra_report"]
+    points: 6
+    documents: [account_opening_contract, lender_agreement, cra_report]
+    strength: soft
+    ai_needed: true
 
   account_description:
-    category: "open_ident"
+    category: open_ident
     min_days: 6
-    documents: ["application_form", "account_opening_contract"]
+    points: 6
+    documents: [application_form, account_opening_contract]
+    strength: soft
+    ai_needed: true
 
-  # 🟩 Terms
+  # ---- Terms ----
   high_balance:
-    category: "terms"
+    category: terms
     min_days: 8
-    documents: ["loan_agreement", "monthly_statement", "internal_balance_report"]
+    points: 6
+    documents: [loan_agreement, monthly_statement, internal_balance_report]
+    strength: strong
+    ai_needed: false
 
   credit_limit:
-    category: "terms"
+    category: terms
     min_days: 8
-    documents: ["credit_line_agreement", "limit_change_record", "monthly_statement"]
+    points: 6
+    documents: [credit_line_agreement, limit_change_record, monthly_statement]
+    strength: strong
+    ai_needed: false
 
   term_length:
-    category: "terms"
+    category: terms
     min_days: 3
-    documents: ["loan_agreement", "terms_sheet"]
+    points: 3
+    documents: [loan_agreement, terms_sheet]
+    strength: soft
+    ai_needed: false
 
   payment_amount:
-    category: "terms"
+    category: terms
     min_days: 5
-    documents: ["loan_agreement", "amortization_schedule", "monthly_statement"]
+    points: 6
+    documents: [loan_agreement, amortization_schedule, monthly_statement]
+    strength: strong
+    ai_needed: false
 
   payment_frequency:
-    category: "terms"
+    category: terms
     min_days: 3
-    documents: ["loan_agreement", "terms_sheet", "monthly_statement"]
+    points: 3
+    documents: [loan_agreement, terms_sheet, monthly_statement]
+    strength: soft
+    ai_needed: false
 
-  # 🟨 Activity & Balances
+  # ---- Activity ----
   balance_owed:
-    category: "activity"
+    category: activity
     min_days: 8
-    documents: ["monthly_statement", "balance_report", "collection_report"]
+    points: 6
+    documents: [monthly_statement, balance_report, collection_report]
+    strength: strong
+    ai_needed: false
 
   last_payment:
-    category: "activity"
+    category: activity
     min_days: 3
-    documents: ["monthly_statement", "payment_receipt", "internal_payment_log"]
+    points: 3
+    documents: [monthly_statement, payment_receipt, internal_payment_log]
+    strength: strong
+    ai_needed: false
 
   past_due_amount:
-    category: "activity"
+    category: activity
     min_days: 8
-    documents: ["monthly_statement", "collection_report", "delinquency_notice"]
+    points: 6
+    documents: [monthly_statement, collection_report, delinquency_notice]
+    strength: strong
+    ai_needed: false
 
   date_of_last_activity:
-    category: "activity"
+    category: activity
     min_days: 12
-    documents: ["monthly_statement", "system_activity_log", "internal_report"]
+    points: 8
+    documents: [monthly_statement, system_activity_log, internal_report]
+    strength: strong
+    ai_needed: false
 
-  # 🟥 Status/Collections/CRA
+  # ---- Status / Reporting ----
   account_status:
-    category: "status"
+    category: status
     min_days: 12
-    documents: ["monthly_statement", "cra_report", "cra_audit_log"]
+    points: 8
+    documents: [monthly_statement, cra_report, cra_audit_log]
+    strength: strong   # strong only when disagreement (open vs closed)
+    ai_needed: false
 
   payment_status:
-    category: "status"
+    category: status
     min_days: 25
-    documents: ["collection_notes", "chargeoff_statement", "monthly_statement"]
+    points: 12
+    documents: [collection_notes, chargeoff_statement, monthly_statement]
+    strength: strong
+    ai_needed: false
 
   account_rating:
-    category: "status"
+    category: status
     min_days: 18
-    documents: ["cra_report", "cra_audit_log"]
+    points: 10
+    documents: [cra_report, cra_audit_log]
+    strength: soft     # semantics differ across bureaus
+    ai_needed: true
 
   creditor_remarks:
-    category: "status"
+    category: status
     min_days: 25
-    documents: ["collection_notes", "customer_letters", "cra_log"]
+    points: 12
+    documents: [collection_notes, customer_letters, cra_log]
+    strength: soft
+    ai_needed: true     # free text needs LLM to judge usefulness
 
   dispute_status:
-    category: "status"
+    category: status
     min_days: 6
-    documents: ["cra_audit_log", "eoscar_system"]
+    points: 6
+    documents: [cra_audit_log, eoscar_system]
+    strength: strong
+    ai_needed: false
 
   date_reported:
-    category: "status"
+    category: status
     min_days: 3
-    documents: ["cra_reporting_log", "cra_report"]
+    points: 3
+    documents: [cra_reporting_log, cra_report]
+    strength: strong
+    ai_needed: false
 
   last_verified:
-    category: "status"
+    category: status
     min_days: 6
-    documents: ["internal_audit_log", "verification_report"]
+    points: 6
+    documents: [internal_audit_log, verification_report]
+    strength: strong
+    ai_needed: false
 
+  # ---- Histories (NEW: must implement robust compare) ----
   two_year_payment_history:
-    category: "history"
+    category: history
     min_days: 18
-    documents: ["monthly_statements_2y", "internal_payment_history"]
+    points: 10
+    documents: [monthly_statements_2y, internal_payment_history]
+    strength: strong
+    ai_needed: false
 
   seven_year_history:
-    category: "history"
+    category: history
     min_days: 25
-    documents: ["cra_report_7y", "cra_audit_logs", "collection_history"]
+    points: 12
+    documents: [cra_report_7y, cra_audit_logs, collection_history]
+    strength: strong
+    ai_needed: false


### PR DESCRIPTION
## Summary
- add strength and ai_needed metadata to validation configuration entries and document histories
- extend validation requirement loading to expose the new flags when generating requirements
- improve history normalization for two-year and seven-year payment fields with dedicated tests

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dc240f6c1c8325860c061e02ccc16e