### PR TITLE
Add strength metadata to validation requirements and improve history normalization

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -510,6 +510,10 @@ def _build_field_consistency(
                     value = history_blob.get(bureau)
                 else:
                     value = history_blob
+                if value is None:
+                    branch = bureaus.get(bureau)
+                    if isinstance(branch, Mapping):
+                        value = branch.get(field)
             else:
                 branch = bureaus.get(bureau)
                 value = branch.get(field) if isinstance(branch, Mapping) else None


### PR DESCRIPTION
## Summary
- include strength and ai_needed fields in validation requirements while enforcing runtime strength policy defaults
- ensure history comparisons read two- and seven-year data from either shared or bureau branches for consistent normalization
- expand validation requirement tests to cover new metadata and history scenarios

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dc2a8ee1e88325a3a1beada62afdd8