### PR TITLE
Expose validation payloads and add dev runner

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -476,5 +476,10 @@ def build_validation_requirements_for_account(account_dir: str | Path) -> Dict[s
     ]
     sync_validation_tag(tags_path, fields, emit=_should_emit_tags())
 
-    return {"status": "ok", "count": len(requirements), "fields": fields}
+    return {
+        "status": "ok",
+        "count": len(requirements),
+        "fields": fields,
+        "validation_requirements": payload,
+    }
 

--- a/devtools/run_requirements_once.py
+++ b/devtools/run_requirements_once.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import json
+import glob
+
+ROOT = os.getcwd()
+sys.path.insert(0, ROOT)
+
+from backend.core.logic.validation_requirements import build_validation_requirements_for_account
+
+
+sid = sys.argv[1]
+acc_root = os.path.join("runs", sid, "cases", "accounts")
+for p in sorted(
+    [d for d in glob.glob(os.path.join(acc_root, "*")) if os.path.isdir(d)],
+    key=lambda x: int(os.path.basename(x)) if os.path.basename(x).isdigit() else 10**9,
+):
+    s = os.path.join(p, "summary.json")
+    if not os.path.isfile(s):
+        continue
+    res = build_validation_requirements_for_account(p)
+    print(os.path.basename(p), json.dumps(res.get("validation_requirements", {}), ensure_ascii=False))

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -286,6 +286,12 @@ def test_build_validation_requirements_for_account_writes_summary_and_tags(
     assert result["status"] == "ok"
     assert result["count"] == 2
     assert set(result["fields"]) == {"balance_owed", "payment_status"}
+    validation_payload = result["validation_requirements"]
+    assert validation_payload["count"] == 2
+    assert {entry["field"] for entry in validation_payload["requirements"]} == {
+        "balance_owed",
+        "payment_status",
+    }
 
     summary = json.loads((account_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["existing"] is True
@@ -352,6 +358,9 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
     assert result["status"] == "ok"
     assert result["count"] == 0
     assert result["fields"] == []
+    validation_payload = result["validation_requirements"]
+    assert validation_payload["count"] == 0
+    assert validation_payload["requirements"] == []
 
     summary = json.loads((account_dir / "summary.json").read_text(encoding="utf-8"))
     assert "validation_requirements" not in summary


### PR DESCRIPTION
## Summary
- include the validation requirements payload in `build_validation_requirements_for_account` results so callers can inspect strength and AI metadata
- cover the new return contract with tests for populated and empty requirement sets
- add a devtools script to dump per-account validation requirements for a SID

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py
- python devtools/run_requirements_once.py a09686e7-11b9-47a8-a5a0-0fdabc20e220 | head -c 200

------
https://chatgpt.com/codex/tasks/task_b_68dc2e2b3c2c832580af66bed5ec75ae