### PR TITLE
Flag missing bureau histories in validation requirements

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -597,6 +597,23 @@ def _build_field_consistency(
             continue
 
         consensus, disagreeing = _determine_consensus(value_groups)
+        if field in _HISTORY_FIELDS and consensus == "unanimous":
+            missing_bureaus = [
+                bureau for bureau, value in normalized.items() if value is None
+            ]
+            present_bureaus = [
+                bureau for bureau, value in normalized.items() if value is not None
+            ]
+            if missing_bureaus and present_bureaus:
+                if len(present_bureaus) == len(missing_bureaus):
+                    consensus = "split"
+                    disagreeing = sorted(missing_bureaus + present_bureaus)
+                elif len(present_bureaus) > len(missing_bureaus):
+                    consensus = "majority"
+                    disagreeing = sorted(missing_bureaus)
+                else:
+                    consensus = "majority"
+                    disagreeing = sorted(present_bureaus)
         details[field] = {
             "consensus": consensus,
             "normalized": dict(normalized),


### PR DESCRIPTION
## Summary
- treat missing versus present bureau history data as a disagreement when building validation requirements
- add a regression test covering the sample scenario to verify strong and soft requirement policies

## Testing
- pytest tests/test_validation_requirements.py -q

------
https://chatgpt.com/codex/tasks/task_b_68dc2f721110832580941c7078b10762