### PR TITLE
Add field consistency snapshots to validation requirements

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -25,7 +25,6 @@ from backend.core.merge.acctnum import acctnum_level
 from backend.core.logic.report_analysis.ai_pack import build_ai_pack_for_pair
 from backend.core.logic.report_analysis import config as merge_config
 from backend.core.logic.summary_compact import compact_merge_sections
-from backend.core.logic.consistency import compute_field_consistency
 from backend.core.logic.validation_requirements import (
     apply_validation_summary,
     build_summary_payload as build_validation_summary_payload,
@@ -2863,12 +2862,9 @@ def persist_merge_tags(
             )
             continue
 
-        requirements, inconsistencies = build_validation_requirements(bureaus_payload)
-        field_consistency = {
-            field: details
-            for field, details in compute_field_consistency(bureaus_payload).items()
-            if field in inconsistencies
-        }
+        requirements, inconsistencies, field_consistency = build_validation_requirements(
+            bureaus_payload
+        )
         summary_payload = build_validation_summary_payload(
             requirements, field_consistency=field_consistency
         )

--- a/tests/test_validation_requirements.py
+++ b/tests/test_validation_requirements.py
@@ -59,7 +59,7 @@ def account_soft_semantics():
 
 
 def _requirements_by_field(bureaus):
-    requirements, inconsistencies = build_validation_requirements(bureaus)
+    requirements, inconsistencies, _ = build_validation_requirements(bureaus)
     by_field = {entry["field"]: entry for entry in requirements}
     return by_field, inconsistencies
 


### PR DESCRIPTION
## Summary
- return the full field consistency snapshot when building validation requirements so downstream writers can reuse it
- persist the snapshot in summary.json even when no requirements remain and reuse it from account_merge and per-account builders
- adjust validation requirement tests to expect history coverage and the expanded payload

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py
- pytest tests/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dc3e2ef9e083258b137d1512c13479