### PR TITLE
Honor validation mode override when selecting broadcast bureaus

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -398,10 +398,24 @@ def _apply_strength_policy(
     )
 
 
+def _resolve_validation_mode(config: ValidationConfig) -> str:
+    override = os.getenv("VALIDATION_MODE")
+    if override:
+        lowered = override.strip().lower()
+        if lowered in {"broad", "strict"}:
+            return lowered
+    return config.mode
+
+
 def _should_broadcast(config: ValidationConfig) -> bool:
     override = os.getenv("BROADCAST_DISPUTES")
     if override is not None:
         return override.strip() == "1"
+
+    mode = _resolve_validation_mode(config)
+    if mode == "broad":
+        return True
+
     return config.broadcast_disputes
 
 


### PR DESCRIPTION
## Summary
- ensure the validation requirements builder checks the VALIDATION_MODE override before deciding whether to broadcast to all bureaus

## Testing
- pytest tests/test_validation_requirements.py tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dc506707148325808d4120f8142ee4