### PR TITLE
Guard validation debug dump with env flag

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -682,7 +682,7 @@ def build_validation_requirements_for_account(account_dir: str | Path) -> Dict[s
     )
     summary_after = apply_validation_summary(summary_path, payload)
 
-    debug_enabled = os.getenv("VALIDATION_DEBUG_DUMP") == "1"
+    debug_enabled = os.getenv("VALIDATION_DEBUG") == "1"
     debug_key = "validation_debug"
 
     if debug_enabled:


### PR DESCRIPTION
## Summary
- gate the validation_debug section behind the VALIDATION_DEBUG=1 flag to avoid noisy summaries by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc580a099083259cd820e503a9b699