### PR TITLE
Add validation requirements step to auto AI pipeline

### DIFF
--- a/backend/core/config/__init__.py
+++ b/backend/core/config/__init__.py
@@ -14,10 +14,15 @@ code, which keeps orchestrator logic straightforward and easy to test.
 from __future__ import annotations
 
 from .flags import env_bool
+from backend.config import ENABLE_VALIDATION_REQUIREMENTS, VALIDATION_DEBUG
 
 # Whether to remove trace files after Stage-A export.  Defaulted ``False`` so
 # cleanup occurs in the Celery chain; tests may override via the
 # ``CLEANUP_AFTER_EXPORT`` environment variable.
 CLEANUP_AFTER_EXPORT: bool = env_bool("CLEANUP_AFTER_EXPORT", False)
 
-__all__ = ["CLEANUP_AFTER_EXPORT"]
+__all__ = [
+    "CLEANUP_AFTER_EXPORT",
+    "ENABLE_VALIDATION_REQUIREMENTS",
+    "VALIDATION_DEBUG",
+]


### PR DESCRIPTION
## Summary
- expose validation requirement flags via `backend.core.config` so pipeline steps can reuse them
- invoke the validation requirements builder after tag compaction for both direct and Celery auto-AI flows

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py (fails: normalization assertions)


------
https://chatgpt.com/codex/tasks/task_b_68dc5b2f1970832596133038fc04cf16