### PR TITLE
Fix missing bureau handling in field consistency

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -382,6 +382,7 @@ def compute_field_consistency(bureaus_json: Dict[str, Any]) -> Dict[str, Any]:
         raw: MutableMapping[str, Any] = {}
         groups: Dict[Any, list[str]] = {}
         missing_bureaus: list[str] = []
+        present_bureaus: list[str] = []
 
         for bureau in _BUREAU_KEYS:
             value = _get_bureau_value(bureaus_json, field, bureau)
@@ -391,6 +392,8 @@ def compute_field_consistency(bureaus_json: Dict[str, Any]) -> Dict[str, Any]:
             normalized[bureau] = norm_value
             if is_missing:
                 missing_bureaus.append(bureau)
+            else:
+                present_bureaus.append(bureau)
             key = ("__missing__",) if is_missing else _freeze_value(field, norm_value)
             groups.setdefault(key, []).append(bureau)
 
@@ -403,7 +406,7 @@ def compute_field_consistency(bureaus_json: Dict[str, Any]) -> Dict[str, Any]:
             "normalized": dict(normalized),
             "raw": dict(raw),
             "disagreeing_bureaus": disagreeing,
-            "missing_bureaus": sorted({bureau for bureau in missing_bureaus}),
+            "missing_bureaus": sorted({bureau for bureau in missing_bureaus}) if present_bureaus else [],
         }
 
     return results

--- a/tests/backend/core/logic/test_consistency.py
+++ b/tests/backend/core/logic/test_consistency.py
@@ -1,0 +1,42 @@
+"""Tests for field consistency logic."""
+
+from backend.core.logic.consistency import compute_field_consistency
+
+
+def test_missing_bureau_is_recorded_and_breaks_unanimous_consensus() -> None:
+    bureaus_json = {
+        "transunion": {"account_status": "open"},
+        "experian": {"account_status": ""},
+        "equifax": {"account_status": "open"},
+    }
+
+    consistency = compute_field_consistency(bureaus_json)
+    account_status = consistency["account_status"]
+
+    assert account_status["missing_bureaus"] == ["experian"]
+    assert account_status["consensus"] == "majority"
+    assert account_status["disagreeing_bureaus"] == ["experian"]
+
+
+def test_history_values_capture_raw_and_missing_bureau_listed() -> None:
+    bureaus_json = {
+        "transunion": {},
+        "experian": {},
+        "equifax": {},
+        "two_year_payment_history": {
+            "transunion": ["30"],
+            "experian": ["OK"],
+            "equifax": None,
+        },
+    }
+
+    consistency = compute_field_consistency(bureaus_json)
+    history = consistency["two_year_payment_history"]
+
+    assert history["raw"] == {
+        "transunion": ["30"],
+        "experian": ["OK"],
+        "equifax": None,
+    }
+    assert history["missing_bureaus"] == ["equifax"]
+    assert history["consensus"] == "split"


### PR DESCRIPTION
## Summary
- ensure field consistency marks bureaus as missing only when others report data
- verify histories carry raw bureau values from the top-level blocks
- add regression tests covering missing bureau consensus and history handling

## Testing
- pytest tests/backend/core/logic/test_consistency.py

------
https://chatgpt.com/codex/tasks/task_b_68dc62a670d08325b61f0c0fafafcd3c