### PR TITLE
Normalize pipeline dates using shared parser

### DIFF
--- a/backend/core/logic/report_analysis/extractors/tokens.py
+++ b/backend/core/logic/report_analysis/extractors/tokens.py
@@ -80,6 +80,10 @@ DATE_PATTERNS = [
     (re.compile(r"\b(\d{1,2})\.(\d{1,2})\.(\d{4})\b"), ("D", "M", "Y")),
     # Slashes: M/D/YYYY or MM/DD/YYYY
     (re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b"), ("M", "D", "Y")),
+    # Hyphens: M-D-YYYY or MM-DD-YYYY
+    (re.compile(r"\b(\d{1,2})-(\d{1,2})-(\d{4})\b"), ("M", "D", "Y")),
+    # Spaces: M D YYYY or MM DD YYYY
+    (re.compile(r"\b(\d{1,2})\s+(\d{1,2})\s+(\d{4})\b"), ("M", "D", "Y")),
 ]
 
 

--- a/tests/test_date_opened_parsing.py
+++ b/tests/test_date_opened_parsing.py
@@ -20,6 +20,14 @@ def test_parse_date_any_slashes_zero_padded():
     assert parse_date_any("03/09/2020") == "2020-03-09"
 
 
+def test_parse_date_any_spaces():
+    assert parse_date_any("10 8 2025") == "2025-10-08"
+
+
+def test_parse_date_any_hyphen_single_digit():
+    assert parse_date_any("3-9-2020") == "2020-03-09"
+
+
 def test_extractor_maps_date_opened_any_format(monkeypatch):
     monkeypatch.setattr(accounts, "upsert_account_fields", lambda **kwargs: None)
     off_flags = replace(

--- a/tests/test_normalized_provenance.py
+++ b/tests/test_normalized_provenance.py
@@ -75,6 +75,24 @@ def test_derived_date_coercion():
     assert field["sources"] == {"EX": "03/2020"}
 
 
+def test_full_date_with_spaces_normalizes():
+    by_bureau = {"EX": {"Date Opened": "10 8 2025"}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["opened_date"]
+    assert field["status"] == "agreed"
+    assert field["value"] == "2025-10-08"
+    assert field["sources"] == {"EX": "10 8 2025"}
+
+
+def test_unparseable_date_returns_none():
+    by_bureau = {"EX": {"Date Opened": "1.1"}}
+    overlay = apply.build_normalized(by_bureau, REGISTRY)
+    field = overlay["opened_date"]
+    assert field["status"] == "agreed"
+    assert field["value"] is None
+    assert field["sources"] == {"EX": "1.1"}
+
+
 def test_missing_field():
     by_bureau = {"EQ": {}, "TU": {}, "EX": {}}
     overlay = apply.build_normalized(by_bureau, REGISTRY)


### PR DESCRIPTION
## Summary
- integrate the shared date parser into the normalized overlay so auto builds coerce dates consistently
- expand the parser to cover space- and hyphen-delimited dates and treat placeholder strings as nulls
- add regression tests covering the new date formats and normalization behaviour

## Testing
- pytest tests/test_date_opened_parsing.py tests/test_normalized_provenance.py

------
https://chatgpt.com/codex/tasks/task_b_68dc635145e483258ea0cc71a2b917a4