### PR TITLE
Trigger validation AI pack builder after validation summaries

### DIFF
--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -1,0 +1,44 @@
+"""Helpers for building validation AI adjudication packs."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Sequence
+
+log = logging.getLogger(__name__)
+
+
+def _normalize_indices(indices: Iterable[int | str]) -> list[int]:
+    normalized: set[int] = set()
+    for idx in indices:
+        try:
+            normalized.add(int(str(idx)))
+        except Exception:
+            continue
+    return sorted(normalized)
+
+
+def build_validation_ai_packs_for_accounts(
+    sid: str,
+    *,
+    account_indices: Sequence[int | str],
+    runs_root: Path | str | None = None,
+) -> None:
+    """Trigger validation AI pack building for the provided account indices.
+
+    This is a lightweight shim that simply logs the request for now. The actual
+    pack construction logic will be implemented in subsequent iterations.
+    """
+
+    normalized_indices = _normalize_indices(account_indices)
+    if not normalized_indices:
+        return
+
+    log.info(
+        "VALIDATION_AI_PACKS_TRIGGER sid=%s runs_root=%s accounts=%s",
+        sid,
+        str(runs_root) if runs_root is not None else None,
+        ",".join(str(idx) for idx in normalized_indices),
+    )
+


### PR DESCRIPTION
## Summary
- call a new validation AI pack builder when validation requirements contain weak entries
- collect account indices with ai_needed requirements during validation summary persistence
- add a temporary validation AI pack builder shim that logs the trigger

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py::test_build_validation_requirements_for_account_writes_summary_and_tags -q


------
https://chatgpt.com/codex/tasks/task_b_68dc777c1c4c8325be3053d9b64d56af