### PR TITLE
Add validation AI pack scaffolding

### DIFF
--- a/backend/pipeline/runs.py
+++ b/backend/pipeline/runs.py
@@ -103,6 +103,13 @@ class RunManifest:
                     "last_built_at": None,
                     "logs": None,
                 },
+                "validation": {
+                    "base": None,
+                    "dir": None,
+                    "accounts": None,
+                    "accounts_dir": None,
+                    "last_prepared_at": None,
+                },
                 "status": {
                     "enqueued": False,
                     "built": False,
@@ -309,6 +316,16 @@ class RunManifest:
                 "logs": None,
             },
         )
+        ai.setdefault(
+            "validation",
+            {
+                "base": None,
+                "dir": None,
+                "accounts": None,
+                "accounts_dir": None,
+                "last_prepared_at": None,
+            },
+        )
         status = ai.setdefault(
             "status",
             {
@@ -342,6 +359,31 @@ class RunManifest:
 
         if not (prefer_existing_index and packs.get("index")):
             packs["index"] = str(merge_paths.index_file)
+
+    def _ensure_validation_section(self) -> dict[str, object]:
+        ai = self.data.setdefault("ai", {})
+        validation = ai.setdefault(
+            "validation",
+            {
+                "base": None,
+                "dir": None,
+                "accounts": None,
+                "accounts_dir": None,
+                "last_prepared_at": None,
+            },
+        )
+        return validation
+
+    def upsert_validation_packs_dir(self, base_dir: Path) -> "RunManifest":
+        validation = self._ensure_validation_section()
+        resolved = Path(base_dir).resolve()
+        resolved_str = str(resolved)
+        validation["base"] = resolved_str
+        validation["dir"] = resolved_str
+        validation["accounts"] = resolved_str
+        validation["accounts_dir"] = resolved_str
+        validation["last_prepared_at"] = _utc_now()
+        return self.save()
 
     def upsert_ai_packs_dir(self, packs_dir: Path) -> "RunManifest":
         packs, _ = self._ensure_ai_section()

--- a/tests/core/logic/test_validation_ai_packs.py
+++ b/tests/core/logic/test_validation_ai_packs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ai.paths import (
+    ensure_validation_account_paths,
+    ensure_validation_paths,
+)
+from backend.core.logic.validation_ai_packs import build_validation_ai_packs_for_accounts
+from backend.pipeline.runs import RUNS_ROOT_ENV
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_builder_creates_validation_structure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sid = "sid-validation"
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+
+    build_validation_ai_packs_for_accounts(
+        sid,
+        account_indices=[14, "15", "14"],
+        runs_root=runs_root,
+    )
+
+    validation_paths = ensure_validation_paths(runs_root, sid, create=False)
+    base_dir = validation_paths.base
+
+    created_indices = {"14", "15"}
+    for idx in created_indices:
+        account_paths = ensure_validation_account_paths(
+            validation_paths, idx, create=False
+        )
+        assert account_paths.pack_file.exists()
+        assert account_paths.prompt_file.exists()
+        assert account_paths.model_results_file.exists()
+        assert _read(account_paths.pack_file).strip() == "{}"
+        assert _read(account_paths.model_results_file).strip() == "{}"
+
+    manifest_path = runs_root / sid / "manifest.json"
+    assert manifest_path.exists()
+
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    validation_section = manifest_data["ai"]["validation"]
+    assert validation_section["base"] == str(base_dir.resolve())
+    assert validation_section["dir"] == str(base_dir.resolve())
+    assert validation_section["accounts"] == str(base_dir.resolve())
+    assert validation_section["accounts_dir"] == str(base_dir.resolve())
+    assert isinstance(validation_section["last_prepared_at"], str)
+
+
+def test_builder_preserves_existing_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sid = "sid-existing"
+    runs_root = tmp_path / "runs"
+    monkeypatch.setenv(RUNS_ROOT_ENV, str(runs_root))
+
+    validation_paths = ensure_validation_paths(runs_root, sid, create=True)
+    account_paths = ensure_validation_account_paths(
+        validation_paths, 42, create=True
+    )
+
+    account_paths.pack_file.write_text("{\"preseed\": true}\n", encoding="utf-8")
+    account_paths.prompt_file.write_text("Existing prompt", encoding="utf-8")
+    account_paths.model_results_file.write_text(
+        "{\"status\": \"done\"}\n", encoding="utf-8"
+    )
+
+    build_validation_ai_packs_for_accounts(
+        sid,
+        account_indices=[42],
+        runs_root=runs_root,
+    )
+
+    assert _read(account_paths.pack_file) == "{\"preseed\": true}\n"
+    assert _read(account_paths.prompt_file) == "Existing prompt"
+    assert _read(account_paths.model_results_file) == "{\"status\": \"done\"}\n"


### PR DESCRIPTION
## Summary
- add path utilities for validation AI pack directories and account-level files
- update the validation AI builder to create scaffold files and register the base directory in the manifest
- extend the run manifest with validation metadata and add tests for the new builder behavior

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68dc78841de88325a15a99d5577b044f