### PR TITLE
Register validation validation AI pack paths in manifest

### DIFF
--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -55,7 +55,17 @@ def build_validation_ai_packs_for_accounts(
 
     manifest_path = runs_root_path / sid / "manifest.json"
     manifest = RunManifest.load_or_create(manifest_path, sid)
-    manifest.upsert_validation_packs_dir(validation_paths.base)
+    if created:
+        last_account = created[-1]
+        index_path = validation_paths.base / "index.json"
+        manifest.upsert_validation_packs_dir(
+            validation_paths.base,
+            account_dir=last_account.base,
+            results_dir=last_account.results_dir,
+            index_file=index_path,
+        )
+    else:
+        manifest.upsert_validation_packs_dir(validation_paths.base)
 
     log.info(
         "VALIDATION_AI_PACKS_INITIALIZED sid=%s base=%s accounts=%s",

--- a/tests/core/logic/test_validation_ai_packs.py
+++ b/tests/core/logic/test_validation_ai_packs.py
@@ -55,6 +55,17 @@ def test_builder_creates_validation_structure(
     assert validation_section["accounts_dir"] == str(base_dir.resolve())
     assert isinstance(validation_section["last_prepared_at"], str)
 
+    packs_validation = manifest_data["ai"]["packs"]["validation"]
+    assert packs_validation["base"] == str(base_dir.resolve())
+    packs_path = Path(packs_validation["packs"])
+    assert packs_path.parent == base_dir.resolve()
+    assert packs_path.name in created_indices
+    expected_results = (packs_path / "results").resolve()
+    assert packs_validation["results"] == str(expected_results)
+    expected_index = (base_dir / "index.json").resolve()
+    assert packs_validation["index"] == str(expected_index)
+    assert isinstance(packs_validation["last_built_at"], str)
+
 
 def test_builder_preserves_existing_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- add validation pack metadata scaffold to run manifests alongside existing merge pack entries
- persist the latest validation account directory, results folder, index path, and timestamp whenever packs are created
- extend validation AI pack builder tests to cover the new manifest structure

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py


------
https://chatgpt.com/codex/tasks/task_b_68dc79d468888325ac73d503a30d4f20