### PR TITLE
Populate validation AI packs with weak field data

### DIFF
--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from backend.core.ai.paths import (
     ValidationAccountPaths,
@@ -46,11 +47,19 @@ def build_validation_ai_packs_for_accounts(
     validation_paths = ensure_validation_paths(runs_root_path, sid, create=True)
 
     created: list[ValidationAccountPaths] = []
+    accounts_root = runs_root_path / sid / "cases" / "accounts"
+
     for idx in normalized_indices:
         account_paths = ensure_validation_account_paths(
             validation_paths, idx, create=True
         )
         _ensure_placeholder_files(account_paths)
+
+        summary = _load_summary(accounts_root, idx)
+        weak_items = _collect_weak_items(summary)
+        pack_payload = {"weak_items": weak_items}
+        _write_pack(account_paths.pack_file, pack_payload)
+
         created.append(account_paths)
 
     manifest_path = runs_root_path / sid / "manifest.json"
@@ -88,4 +97,159 @@ def _ensure_file(path: Path, default_contents: str) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(default_contents, encoding="utf-8")
+
+
+def _load_summary(accounts_root: Path, account_idx: int) -> Mapping[str, Any] | None:
+    """Return the parsed summary.json payload for ``account_idx`` if present."""
+
+    summary_path = accounts_root / str(account_idx) / "summary.json"
+    try:
+        raw_text = summary_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        log.warning(
+            "VALIDATION_SUMMARY_READ_FAILED account=%s path=%s",
+            account_idx,
+            summary_path,
+            exc_info=True,
+        )
+        return None
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        log.warning(
+            "VALIDATION_SUMMARY_INVALID_JSON account=%s path=%s",
+            account_idx,
+            summary_path,
+            exc_info=True,
+        )
+        return None
+
+    if not isinstance(payload, Mapping):
+        log.warning(
+            "VALIDATION_SUMMARY_INVALID_TYPE account=%s path=%s type=%s",
+            account_idx,
+            summary_path,
+            type(payload).__name__,
+        )
+        return None
+
+    return payload
+
+
+def _collect_weak_items(summary: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    """Extract validation requirements that require AI adjudication."""
+
+    if not isinstance(summary, Mapping):
+        return []
+
+    validation = summary.get("validation_requirements")
+    if not isinstance(validation, Mapping):
+        return []
+
+    requirements = validation.get("requirements")
+    if not isinstance(requirements, Sequence):
+        return []
+
+    field_consistency = validation.get("field_consistency")
+    if isinstance(field_consistency, Mapping):
+        consistency_map: Mapping[str, Any] = field_consistency
+    else:
+        consistency_map = {}
+
+    weak_items: list[dict[str, Any]] = []
+
+    for entry in requirements:
+        if not isinstance(entry, Mapping):
+            continue
+
+        if not entry.get("ai_needed"):
+            continue
+
+        raw_field = entry.get("field")
+        if raw_field is None:
+            continue
+
+        field = str(raw_field)
+
+        documents = entry.get("documents")
+        if isinstance(documents, Sequence) and not isinstance(
+            documents, (str, bytes, bytearray)
+        ):
+            documents_list = [str(doc) for doc in documents]
+        elif documents is None:
+            documents_list = []
+        else:
+            documents_list = [str(documents)]
+
+        item: dict[str, Any] = {
+            "field": field,
+            "category": entry.get("category"),
+            "min_days": entry.get("min_days"),
+            "documents": documents_list,
+        }
+
+        consistency_details = consistency_map.get(field)
+        if isinstance(consistency_details, Mapping):
+            item["consensus"] = consistency_details.get("consensus")
+
+            disagreeing = consistency_details.get("disagreeing_bureaus")
+            if isinstance(disagreeing, Sequence) and not isinstance(
+                disagreeing, (str, bytes, bytearray)
+            ):
+                item["disagreeing_bureaus"] = sorted(str(b) for b in disagreeing)
+            else:
+                item["disagreeing_bureaus"] = []
+
+            missing = consistency_details.get("missing_bureaus")
+            if isinstance(missing, Sequence) and not isinstance(
+                missing, (str, bytes, bytearray)
+            ):
+                item["missing_bureaus"] = sorted(str(b) for b in missing)
+            else:
+                item["missing_bureaus"] = []
+
+            raw_values = consistency_details.get("raw")
+            raw_map = raw_values if isinstance(raw_values, Mapping) else {}
+
+            normalized_values = consistency_details.get("normalized")
+            normalized_map = (
+                normalized_values if isinstance(normalized_values, Mapping) else {}
+            )
+
+            values: dict[str, dict[str, Any]] = {}
+            for bureau in ("transunion", "experian", "equifax"):
+                values[bureau] = {
+                    "raw": raw_map.get(bureau),
+                    "normalized": normalized_map.get(bureau),
+                }
+
+            item["values"] = values
+        else:
+            item["consensus"] = None
+            item["disagreeing_bureaus"] = []
+            item["missing_bureaus"] = []
+            item["values"] = {
+                bureau: {"raw": None, "normalized": None}
+                for bureau in ("transunion", "experian", "equifax")
+            }
+
+        weak_items.append(item)
+
+    return weak_items
+
+
+def _write_pack(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write ``payload`` to ``path`` as JSON."""
+
+    try:
+        serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    except TypeError:
+        log.exception("VALIDATION_PACK_SERIALIZE_FAILED path=%s", path)
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(serialized + "\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- read account validation summaries and extract the requirements flagged for AI review
- persist weak-field metadata and bureau-level values into each validation pack
- adjust validation AI pack tests to cover the generated payloads while keeping other artifacts intact

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68dc7b8d104483258b039a5106f4328a