### PR TITLE
Add validation AI pack configuration support

### DIFF
--- a/backend/core/logic/ai_packs_config.yml
+++ b/backend/core/logic/ai_packs_config.yml
@@ -1,0 +1,8 @@
+validation_packs:
+  enable_write: true
+  enable_infer: true
+  model: gpt-4o-mini
+  weak_limit: 0
+  retry:
+    max_attempts: 3
+    backoff_seconds: [1, 3, 10]

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -44,6 +44,7 @@ from backend.core.logic.validation_requirements import (
 )
 from backend.core.logic.validation_ai_packs import (
     build_validation_ai_packs_for_accounts,
+    load_validation_packs_config_for_run,
 )
 
 __all__ = [
@@ -2911,7 +2912,11 @@ def persist_merge_tags(
         ):
             validation_ai_indices.append(int(idx))
 
-    if validation_ai_indices:
+    config = load_validation_packs_config_for_run(
+        sid, runs_root=runs_root
+    )
+
+    if validation_ai_indices and config.enable_write:
         try:
             build_validation_ai_packs_for_accounts(
                 sid,
@@ -2925,6 +2930,10 @@ def persist_merge_tags(
                 runs_root,
                 validation_ai_indices,
             )
+    elif validation_ai_indices:
+        logger.info(
+            "VALIDATION_AI_PACKS_DISABLED sid=%s indices=%s", sid, validation_ai_indices
+        )
 
     return merge_tags
 


### PR DESCRIPTION
## Summary
- add a central ai_packs_config.yml with validation pack defaults and retry schedule
- update validation pack builder to honor config toggles, weak limits, and retry policy while exposing config loaders
- gate the account merge pipeline on validation pack configuration and extend tests for the new behavior

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py


------
https://chatgpt.com/codex/tasks/task_b_68dc7f6232448325a620f25325b1848e