### PR TITLE
Add validation AI pack build logging

### DIFF
--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -24,6 +24,7 @@ class ValidationPaths:
     """Resolved filesystem locations for validation AI packs."""
 
     base: Path
+    log_file: Path
 
 
 def ensure_validation_paths(
@@ -34,7 +35,7 @@ def ensure_validation_paths(
     base_path = (Path(runs_root) / sid / "ai_packs" / "validation").resolve()
     if create:
         base_path.mkdir(parents=True, exist_ok=True)
-    return ValidationPaths(base=base_path)
+    return ValidationPaths(base=base_path, log_file=base_path / "logs.txt")
 
 
 def ensure_validation_account_paths(


### PR DESCRIPTION
## Summary
- add atomic logging for validation AI pack builds
- expose the validation AI log path in the ValidationPaths helper
- extend validation AI pack tests to cover log entries

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68dc8247e4c883258010ba9512a94374