### PR TITLE
Update manifest metadata for validation AI packs

### DIFF
--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -26,6 +26,9 @@ class ValidationPaths:
     """Resolved filesystem locations for validation AI packs."""
 
     base: Path
+    packs_dir: Path
+    results_dir: Path
+    index_file: Path
     log_file: Path
 
 
@@ -35,9 +38,23 @@ def ensure_validation_paths(
     """Return the canonical validation AI pack paths for ``sid``."""
 
     base_path = (Path(runs_root) / sid / "ai_packs" / "validation").resolve()
+    packs_dir = base_path / "packs"
+    results_dir = base_path / "results"
+    index_file = base_path / "index.json"
+    log_file = base_path / "logs.txt"
+
     if create:
         base_path.mkdir(parents=True, exist_ok=True)
-    return ValidationPaths(base=base_path, log_file=base_path / "logs.txt")
+        packs_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
+
+    return ValidationPaths(
+        base=base_path,
+        packs_dir=packs_dir.resolve(),
+        results_dir=results_dir.resolve(),
+        index_file=index_file.resolve(strict=False),
+        log_file=log_file.resolve(strict=False),
+    )
 
 
 def ensure_validation_account_paths(

--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -355,16 +355,23 @@ def build_validation_ai_packs_for_accounts(
     manifest = RunManifest.load_or_create(manifest_path, sid)
     if created:
         last_account = created[-1]
-        index_path = validation_paths.base / "index.json"
+        index_path = validation_paths.index_file
         _append_validation_index_entries(index_path, index_entries)
         manifest.upsert_validation_packs_dir(
             validation_paths.base,
-            account_dir=last_account.base,
-            results_dir=last_account.results_dir,
+            packs_dir=validation_paths.packs_dir,
+            results_dir=validation_paths.results_dir,
             index_file=index_path,
+            log_file=log_path,
         )
     else:
-        manifest.upsert_validation_packs_dir(validation_paths.base)
+        manifest.upsert_validation_packs_dir(
+            validation_paths.base,
+            packs_dir=validation_paths.packs_dir,
+            results_dir=validation_paths.results_dir,
+            index_file=validation_paths.index_file,
+            log_file=log_path,
+        )
 
     log.info(
         "VALIDATION_AI_PACKS_INITIALIZED sid=%s base=%s accounts=%s",

--- a/tests/core/logic/test_validation_ai_packs.py
+++ b/tests/core/logic/test_validation_ai_packs.py
@@ -110,13 +110,14 @@ def test_builder_creates_validation_structure(
 
     packs_validation = manifest_data["ai"]["packs"]["validation"]
     assert packs_validation["base"] == str(base_dir.resolve())
-    packs_path = Path(packs_validation["packs"])
-    assert packs_path.parent == base_dir.resolve()
-    assert packs_path.name in created_indices
-    expected_results = (packs_path / "results").resolve()
-    assert packs_validation["results"] == str(expected_results)
-    expected_index = (base_dir / "index.json").resolve()
+    assert packs_validation["dir"] == str(base_dir.resolve())
+    assert packs_validation["packs"] == str(validation_paths.packs_dir)
+    assert packs_validation["packs_dir"] == str(validation_paths.packs_dir)
+    assert packs_validation["results"] == str(validation_paths.results_dir)
+    assert packs_validation["results_dir"] == str(validation_paths.results_dir)
+    expected_index = validation_paths.index_file.resolve()
     assert packs_validation["index"] == str(expected_index)
+    assert packs_validation["logs"] == str(validation_paths.log_file)
     assert isinstance(packs_validation["last_built_at"], str)
 
     index_entries = json.loads(expected_index.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- ensure validation path helpers expose the canonical validation pack, result, index, and log locations
- update the run manifest writer to populate ai.packs.validation metadata when validation packs are built
- adjust the validation pack builder and tests to use and assert the new manifest structure

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py


------
https://chatgpt.com/codex/tasks/task_b_68dc8849a37c8325b46851bdf6d13b1f