### PR TITLE
Add devtools script for validation index overview

### DIFF
--- a/devtools/show_validation_index.py
+++ b/devtools/show_validation_index.py
@@ -1,0 +1,155 @@
+"""Display consolidated validation AI pack index information."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.ai.validation_index import ValidationPackIndexWriter
+from backend.core.ai.paths import ensure_validation_paths
+from backend.pipeline.runs import RUNS_ROOT_ENV
+
+__all__ = ["main"]
+
+
+def _resolve_runs_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit)
+    env_value = os.getenv(RUNS_ROOT_ENV)
+    if env_value:
+        return Path(env_value)
+    return Path("runs")
+
+
+def _coerce_int(value: object) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def _weak_field_count(entry: dict[str, object]) -> int:
+    weak_fields = entry.get("weak_fields")
+    if isinstance(weak_fields, (list, tuple, set)):
+        return sum(1 for field in weak_fields if str(field).strip())
+
+    lines = _coerce_int(entry.get("lines"))
+    if lines:
+        return lines
+
+    return _coerce_int(entry.get("request_lines"))
+
+
+def _line_count(entry: dict[str, object]) -> int:
+    lines = _coerce_int(entry.get("lines"))
+    if lines:
+        return lines
+    return _coerce_int(entry.get("request_lines"))
+
+
+def _format_table(rows: list[list[str]]) -> str:
+    if not rows:
+        return ""
+
+    headers = ["Account", "Weak", "Lines", "Status", "Model"]
+    align_right = {0, 1, 2}
+
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    header_line = "  ".join(
+        header.rjust(widths[idx]) if idx in align_right else header.ljust(widths[idx])
+        for idx, header in enumerate(headers)
+    )
+
+    separator = "  ".join("-" * width for width in widths)
+
+    body = [
+        "  ".join(
+            cell.rjust(widths[idx]) if idx in align_right else cell.ljust(widths[idx])
+            for idx, cell in enumerate(row)
+        )
+        for row in rows
+    ]
+
+    return "\n".join([header_line, separator, *body])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Show consolidated validation AI pack index details for a SID",
+    )
+    parser.add_argument("sid", help="Run identifier (SID)")
+    parser.add_argument(
+        "--runs-root",
+        dest="runs_root",
+        default=None,
+        help="Override runs root directory (defaults to $RUNS_ROOT or ./runs)",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    runs_root = _resolve_runs_root(args.runs_root)
+    validation_paths = ensure_validation_paths(runs_root, args.sid, create=False)
+    index_path = validation_paths.index_file
+    writer = ValidationPackIndexWriter(sid=args.sid, index_path=index_path)
+    accounts = writer.load_accounts()
+
+    print(f"SID: {args.sid}")
+    print(f"Index: {index_path}")
+
+    if not accounts:
+        print("No validation packs recorded in the index.")
+        return 0
+
+    rows: list[list[str]] = []
+    total_weak = 0
+    status_counts: dict[str, int] = {}
+
+    for account_id in sorted(accounts):
+        entry = accounts[account_id]
+        weak_count = _weak_field_count(entry)
+        total_weak += weak_count
+
+        line_count = _line_count(entry)
+
+        status = str(entry.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+        model = str(entry.get("model") or "-")
+
+        rows.append(
+            [
+                f"{account_id:03d}",
+                str(weak_count),
+                str(line_count),
+                status,
+                model,
+            ]
+        )
+
+    table = _format_table(rows)
+    if table:
+        print(table)
+
+    print()
+    print(f"Accounts: {len(rows)}  Weak fields: {total_weak}")
+    if status_counts:
+        print("Status counts:")
+        for status in sorted(status_counts):
+            print(f"  {status}: {status_counts[status]}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/devtools/test_show_validation_index.py
+++ b/tests/devtools/test_show_validation_index.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.ai.validation_index import ValidationIndexEntry, ValidationPackIndexWriter
+from backend.core.ai.paths import (
+    ensure_validation_paths,
+    validation_pack_filename_for_account,
+    validation_result_filename_for_account,
+)
+
+from devtools import show_validation_index
+
+
+def _create_index_entry(
+    validation_root: Path,
+    account_id: int,
+    *,
+    status: str,
+    weak_fields: list[str] | None = None,
+    model: str | None = None,
+    lines: int = 0,
+) -> ValidationIndexEntry:
+    packs_dir = validation_root / "packs"
+    results_dir = validation_root / "results"
+
+    pack_path = packs_dir / validation_pack_filename_for_account(account_id)
+    result_path = results_dir / validation_result_filename_for_account(account_id)
+
+    pack_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+
+    pack_path.write_text("", encoding="utf-8")
+    result_path.write_text("{}\n", encoding="utf-8")
+
+    return ValidationIndexEntry(
+        account_id=account_id,
+        pack_path=pack_path,
+        result_path=result_path,
+        weak_fields=weak_fields or [],
+        line_count=lines or len(weak_fields or ()),
+        status=status,
+        model=model,
+        request_lines=lines or len(weak_fields or ()),
+        source_hash="hash",
+    )
+
+
+def test_show_validation_index_outputs_table(tmp_path, capsys):
+    sid = "SID123"
+    runs_root = tmp_path
+    validation_paths = ensure_validation_paths(runs_root, sid, create=True)
+
+    entry_ok = _create_index_entry(
+        validation_paths.base,
+        14,
+        status="ok",
+        weak_fields=["field_a", "field_b"],
+        model="gpt-test",
+    )
+    entry_error = _create_index_entry(
+        validation_paths.base,
+        7,
+        status="error",
+        weak_fields=["history_2y"],
+    )
+
+    writer = ValidationPackIndexWriter(sid=sid, index_path=validation_paths.index_file)
+    writer.bulk_upsert([entry_ok, entry_error])
+
+    exit_code = show_validation_index.main([sid, "--runs-root", str(runs_root)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "SID: SID123" in captured.out
+    assert "Index:" in captured.out
+    # Table contents
+    assert "014" in captured.out
+    assert "007" in captured.out
+    assert "gpt-test" in captured.out
+    assert "ok" in captured.out
+    assert "error" in captured.out
+    assert "Status counts:" in captured.out
+    assert "Accounts: 2  Weak fields: 3" in captured.out
+
+
+def test_show_validation_index_handles_missing_index(tmp_path, capsys):
+    sid = "MISSING"
+    runs_root = tmp_path
+
+    exit_code = show_validation_index.main([sid, "--runs-root", str(runs_root)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "No validation packs recorded in the index." in captured.out


### PR DESCRIPTION
## Summary
- add a devtools CLI helper to print validation AI index status for a SID
- report weak-field counts, statuses, and model information in a compact table
- cover the new CLI with unit tests that exercise populated and empty indexes

## Testing
- pytest tests/devtools/test_show_validation_index.py

------
https://chatgpt.com/codex/tasks/task_b_68dd4f64575c8325b083b6c63a9f17b2