### PR TITLE
Align validation AI result contracts and storage

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -24,6 +24,7 @@ from backend.core.ai.paths import (
     validation_index_path,
     validation_pack_filename_for_account,
     validation_packs_dir,
+    validation_result_jsonl_filename_for_account,
     validation_result_filename_for_account,
     validation_results_dir,
     validation_logs_path,
@@ -202,8 +203,13 @@ class ValidationPackWriter:
         *,
         summary: Mapping[str, Any] | None = None,
     ) -> None:
-        result_path = self._results_dir / validation_result_filename_for_account(
-            account_id
+        result_summary_path = (
+            self._results_dir
+            / validation_result_filename_for_account(account_id)
+        )
+        result_jsonl_path = (
+            self._results_dir
+            / validation_result_jsonl_filename_for_account(account_id)
         )
         weak_fields: list[str] = []
         for line in lines:
@@ -227,7 +233,8 @@ class ValidationPackWriter:
         entry = ValidationIndexEntry(
             account_id=account_id,
             pack_path=pack_path.resolve(),
-            result_path=result_path.resolve(),
+            result_jsonl_path=result_jsonl_path.resolve(),
+            result_summary_path=result_summary_path.resolve(),
             weak_fields=tuple(weak_fields),
             line_count=len(lines),
             status="built",

--- a/backend/ai/validation_index.py
+++ b/backend/ai/validation_index.py
@@ -28,7 +28,8 @@ class ValidationIndexEntry:
 
     account_id: int
     pack_path: Path
-    result_path: Path
+    result_jsonl_path: Path
+    result_summary_path: Path
     weak_fields: Sequence[str]
     line_count: int
     status: str
@@ -45,7 +46,9 @@ class ValidationIndexEntry:
         payload: dict[str, object] = {
             "account_id": int(self.account_id),
             "pack_path": str(self.pack_path.resolve()),
-            "result_path": str(self.result_path.resolve()),
+            "result_jsonl_path": str(self.result_jsonl_path.resolve()),
+            "result_summary_path": str(self.result_summary_path.resolve()),
+            "result_path": str(self.result_summary_path.resolve()),
             "weak_fields": weak_fields,
             "lines": int(self.line_count),
             "built_at": str(self.built_at or _utc_now()),

--- a/backend/ai/validation_results.py
+++ b/backend/ai/validation_results.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 from backend.ai.validation_index import ValidationPackIndexWriter
 from backend.core.ai.paths import (
     validation_index_path,
     validation_pack_filename_for_account,
     validation_packs_dir,
-    validation_result_filename_for_account,
+    validation_result_jsonl_filename_for_account,
+    validation_result_summary_filename_for_account,
     validation_results_dir,
 )
 
@@ -99,6 +101,136 @@ def _normalize_result_payload(
     return normalized
 
 
+def _coerce_account_int(account_id: int | str) -> int | None:
+    try:
+        return int(account_id)
+    except (TypeError, ValueError):
+        try:
+            return int(str(account_id).strip())
+        except (TypeError, ValueError):
+            return None
+
+
+def _load_pack_lookup(pack_path: Path) -> dict[str, Mapping[str, Any]]:
+    lookup: dict[str, Mapping[str, Any]] = {}
+    try:
+        raw_lines = pack_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return lookup
+    except OSError:
+        return lookup
+
+    for line in raw_lines:
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, Mapping):
+            continue
+
+        for key_name in ("id", "field_key", "field"):
+            key_value = payload.get(key_name)
+            if isinstance(key_value, str) and key_value.strip():
+                lookup.setdefault(key_value.strip(), payload)
+
+    return lookup
+
+
+def _normalize_decision(decision: Any) -> str:
+    value = str(decision or "").strip().lower()
+    if value == "strong":
+        return "strong"
+    if value in {"no_case", "no_claim", "no_claims"}:
+        return "no_case"
+    if value in {"", "unknown"}:
+        return "no_case"
+    return "no_case"
+
+
+def _normalize_citations(raw: Any) -> list[str]:
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return []
+    citations: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            citations.append(item.strip())
+    return citations
+
+
+def _fallback_result_id(account_int: int | None, field_name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", field_name.lower()).strip("_")
+    if not slug:
+        slug = "field"
+    if account_int is None:
+        return f"acc__{slug}"
+    return f"acc_{account_int:03d}__{slug}"
+
+
+def _collect_result_entries(payload: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    for key in ("results", "decision_per_field"):
+        raw = payload.get(key)
+        if isinstance(raw, Sequence):
+            for entry in raw:
+                if isinstance(entry, Mapping):
+                    yield entry
+
+
+def _build_result_lines(
+    account_id: int | str,
+    payload: Mapping[str, Any],
+    pack_lookup: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    account_int = _coerce_account_int(account_id)
+    result_lines: list[dict[str, Any]] = []
+
+    for entry in _collect_result_entries(payload):
+        candidate_keys: list[str] = []
+        for key_name in ("id", "field_key", "field"):
+            value = entry.get(key_name)
+            if isinstance(value, str) and value.strip():
+                candidate_keys.append(value.strip())
+
+        pack_payload: Mapping[str, Any] | None = None
+        for key in candidate_keys:
+            pack_payload = pack_lookup.get(key)
+            if pack_payload:
+                break
+
+        if pack_payload is not None:
+            field_name = (
+                str(pack_payload.get("field") or "").strip() or candidate_keys[-1]
+            )
+            line_id = str(pack_payload.get("id") or "").strip()
+        else:
+            field_name = candidate_keys[-1] if candidate_keys else ""
+            line_id = ""
+
+        if not field_name:
+            continue
+
+        if not line_id:
+            line_id = _fallback_result_id(account_int, field_name)
+
+        rationale = entry.get("rationale")
+        if not isinstance(rationale, str):
+            rationale = ""
+
+        result_line = {
+            "id": line_id,
+            "account_id": account_int if account_int is not None else account_id,
+            "field": field_name,
+            "decision": _normalize_decision(entry.get("decision")),
+            "rationale": rationale,
+            "citations": _normalize_citations(entry.get("citations")),
+        }
+
+        result_lines.append(result_line)
+
+    return result_lines
+
+
 def store_validation_result(
     sid: str,
     account_id: int | str,
@@ -119,8 +251,17 @@ def store_validation_result(
 
     runs_root_path = _resolve_runs_root(runs_root)
     results_dir = validation_results_dir(sid, runs_root=runs_root_path, create=True)
-    result_filename = validation_result_filename_for_account(account_id)
-    result_path = results_dir / result_filename
+    summary_filename = validation_result_summary_filename_for_account(account_id)
+    jsonl_filename = validation_result_jsonl_filename_for_account(account_id)
+    summary_path = results_dir / summary_filename
+    jsonl_path = results_dir / jsonl_filename
+
+    packs_dir = validation_packs_dir(sid, runs_root=runs_root_path, create=True)
+    pack_filename = validation_pack_filename_for_account(account_id)
+    pack_path = packs_dir / pack_filename
+    pack_lookup = _load_pack_lookup(pack_path)
+
+    result_lines = _build_result_lines(account_id, response_payload, pack_lookup)
 
     normalized_payload = _normalize_result_payload(
         sid,
@@ -133,13 +274,23 @@ def store_validation_result(
         completed_at=completed_at,
     )
 
-    serialized = json.dumps(normalized_payload, ensure_ascii=False, sort_keys=True)
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text(serialized + "\n", encoding="utf-8")
+    normalized_payload["results"] = result_lines
 
-    packs_dir = validation_packs_dir(sid, runs_root=runs_root_path, create=True)
-    pack_filename = validation_pack_filename_for_account(account_id)
-    pack_path = packs_dir / pack_filename
+    serialized_summary = json.dumps(
+        normalized_payload, ensure_ascii=False, sort_keys=True
+    )
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(serialized_summary + "\n", encoding="utf-8")
+
+    jsonl_lines = [
+        json.dumps(line, ensure_ascii=False, sort_keys=True) for line in result_lines
+    ]
+    jsonl_contents = "\n".join(jsonl_lines)
+    if jsonl_contents:
+        jsonl_contents += "\n"
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path.write_text(jsonl_contents, encoding="utf-8")
+
     writer = _index_writer(sid, runs_root_path)
     writer.record_result(
         pack_path,
@@ -150,7 +301,7 @@ def store_validation_result(
         completed_at=normalized_payload.get("completed_at"),
     )
 
-    return result_path
+    return summary_path
 
 
 __all__ = ["mark_validation_pack_sent", "store_validation_result"]

--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -17,7 +17,8 @@ class ValidationAccountPaths:
     account_id: int
     pack_file: Path
     prompt_file: Path
-    model_results_file: Path
+    result_jsonl_file: Path
+    result_summary_file: Path
 
 
 @dataclass(frozen=True)
@@ -69,20 +70,25 @@ def ensure_validation_account_paths(
     pack_filename = validation_pack_filename_for_account(normalized_idx)
     pack_file = paths.packs_dir / pack_filename
     prompt_file = paths.packs_dir / f"{pack_filename}.prompt.txt"
-    model_results_file = (
+    result_jsonl_file = (
+        paths.results_dir / validation_result_jsonl_filename_for_account(normalized_idx)
+    )
+    result_summary_file = (
         paths.results_dir / validation_result_filename_for_account(normalized_idx)
     )
 
     if create:
         pack_file.parent.mkdir(parents=True, exist_ok=True)
         prompt_file.parent.mkdir(parents=True, exist_ok=True)
-        model_results_file.parent.mkdir(parents=True, exist_ok=True)
+        result_jsonl_file.parent.mkdir(parents=True, exist_ok=True)
+        result_summary_file.parent.mkdir(parents=True, exist_ok=True)
 
     return ValidationAccountPaths(
         account_id=normalized_idx,
         pack_file=pack_file,
         prompt_file=prompt_file,
-        model_results_file=model_results_file,
+        result_jsonl_file=result_jsonl_file,
+        result_summary_file=result_summary_file,
     )
 
 
@@ -274,9 +280,22 @@ def validation_pack_filename_for_account(account_id: int | str) -> str:
     return f"val_acc_{normalized:03d}.jsonl"
 
 
-def validation_result_filename_for_account(account_id: int | str) -> str:
-    """Return the canonical validation result filename for ``account_id``."""
+def validation_result_jsonl_filename_for_account(account_id: int | str) -> str:
+    """Return the canonical validation result JSONL filename for ``account_id``."""
 
     normalized = _normalize_account_id(account_id)
-    return f"val_acc_{normalized:03d}.result.json"
+    return f"acc_{normalized:03d}.result.jsonl"
+
+
+def validation_result_summary_filename_for_account(account_id: int | str) -> str:
+    """Return the canonical validation result summary filename for ``account_id``."""
+
+    normalized = _normalize_account_id(account_id)
+    return f"acc_{normalized:03d}.result.json"
+
+
+def validation_result_filename_for_account(account_id: int | str) -> str:
+    """Backward-compatible alias for the summary filename."""
+
+    return validation_result_summary_filename_for_account(account_id)
 

--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -312,7 +312,7 @@ def build_validation_ai_packs_for_accounts(
         )
 
         pack_exists = account_paths.pack_file.exists()
-        result_exists = account_paths.model_results_file.exists()
+        result_exists = account_paths.result_summary_file.exists()
         prompt_exists = account_paths.prompt_file.exists()
 
         skip_build = (
@@ -329,7 +329,7 @@ def build_validation_ai_packs_for_accounts(
             statuses = ["up_to_date"]
             if line_count == 0:
                 statuses.append("no_weak_items")
-            result_payload = _load_model_results(account_paths.model_results_file)
+            result_payload = _load_model_results(account_paths.result_summary_file)
             if result_payload is None:
                 result_payload = {
                     "status": str(existing_entry.get("status") or "unknown"),
@@ -368,7 +368,7 @@ def build_validation_ai_packs_for_accounts(
                 has_weak_items=bool(weak_items),
                 config=packs_config,
             )
-            _write_model_results(account_paths.model_results_file, result_payload)
+            _write_model_results(account_paths.result_summary_file, result_payload)
 
             inference_status = str(result_payload.get("status") or "unknown")
             if inference_status == "ok":
@@ -402,7 +402,8 @@ def build_validation_ai_packs_for_accounts(
             ValidationIndexEntry(
                 account_id=int(idx),
                 pack_path=account_paths.pack_file,
-                result_path=account_paths.model_results_file,
+                result_jsonl_path=account_paths.result_jsonl_file,
+                result_summary_path=account_paths.result_summary_file,
                 weak_fields=weak_fields,
                 line_count=line_count,
                 status=inference_status,
@@ -442,7 +443,7 @@ def _ensure_placeholder_files(paths: ValidationAccountPaths) -> None:
 
     _ensure_file(paths.pack_file)
     _ensure_file(paths.prompt_file)
-    _ensure_file(paths.model_results_file, "{}\n")
+    _ensure_file(paths.result_summary_file, "{}\n")
 
 
 def _ensure_file(path: Path, default_contents: str = "") -> None:

--- a/docs/ai_packs/validation/README.md
+++ b/docs/ai_packs/validation/README.md
@@ -41,8 +41,8 @@ schema embedded in the pack line:
   absence.
 
 Additional metadata (e.g., `model`, `request_lines`, timestamps) is attached by
-our ingestion helpers when writing the `.result.json` files to
-`runs/<SID>/ai_packs/validation/results/`.
+our ingestion helpers when writing the `.result.jsonl` and `.result.json` files
+to `runs/<SID>/ai_packs/validation/results/`.
 
 ## Decision labels quick reference
 

--- a/tests/devtools/test_show_validation_index.py
+++ b/tests/devtools/test_show_validation_index.py
@@ -6,6 +6,7 @@ from backend.ai.validation_index import ValidationIndexEntry, ValidationPackInde
 from backend.core.ai.paths import (
     ensure_validation_paths,
     validation_pack_filename_for_account,
+    validation_result_jsonl_filename_for_account,
     validation_result_filename_for_account,
 )
 
@@ -25,18 +26,22 @@ def _create_index_entry(
     results_dir = validation_root / "results"
 
     pack_path = packs_dir / validation_pack_filename_for_account(account_id)
-    result_path = results_dir / validation_result_filename_for_account(account_id)
+    summary_path = results_dir / validation_result_filename_for_account(account_id)
+    jsonl_path = results_dir / validation_result_jsonl_filename_for_account(account_id)
 
     pack_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
 
     pack_path.write_text("", encoding="utf-8")
-    result_path.write_text("{}\n", encoding="utf-8")
+    summary_path.write_text("{}\n", encoding="utf-8")
+    jsonl_path.write_text("", encoding="utf-8")
 
     return ValidationIndexEntry(
         account_id=account_id,
         pack_path=pack_path,
-        result_path=result_path,
+        result_jsonl_path=jsonl_path,
+        result_summary_path=summary_path,
         weak_fields=weak_fields or [],
         line_count=lines or len(weak_fields or ()),
         status=status,

--- a/tests/test_validation_packs.py
+++ b/tests/test_validation_packs.py
@@ -14,6 +14,7 @@ from backend.core.ai.paths import (
     validation_index_path,
     validation_pack_filename_for_account,
     validation_packs_dir,
+    validation_result_jsonl_filename_for_account,
     validation_result_filename_for_account,
     validation_results_dir,
 )
@@ -53,7 +54,7 @@ def test_validation_pack_path_generation(tmp_path: Path) -> None:
 
     assert validation_pack_filename_for_account(3) == "val_acc_003.jsonl"
     assert validation_pack_filename_for_account("12") == "val_acc_012.jsonl"
-    assert validation_result_filename_for_account(7) == "val_acc_007.result.json"
+    assert validation_result_filename_for_account(7) == "acc_007.result.json"
 
 
 def test_builds_pack_with_two_weak_fields(tmp_path: Path) -> None:
@@ -159,18 +160,26 @@ def test_validation_index_round_trip(tmp_path: Path) -> None:
     index_path = validation_index_path(sid, runs_root=runs_root)
     writer = ValidationPackIndexWriter(sid=sid, index_path=index_path)
 
+    pack_path1 = packs_dir / validation_pack_filename_for_account(1)
+    summary_path1 = results_dir / validation_result_filename_for_account(1)
+    jsonl_path1 = results_dir / validation_result_jsonl_filename_for_account(1)
     entry1 = ValidationIndexEntry(
         account_id=1,
-        pack_path=packs_dir / validation_pack_filename_for_account(1),
-        result_path=results_dir / validation_result_filename_for_account(1),
+        pack_path=pack_path1,
+        result_jsonl_path=jsonl_path1,
+        result_summary_path=summary_path1,
         weak_fields=("balance_owed",),
         line_count=1,
         status="built",
     )
+    pack_path2 = packs_dir / validation_pack_filename_for_account(2)
+    summary_path2 = results_dir / validation_result_filename_for_account(2)
+    jsonl_path2 = results_dir / validation_result_jsonl_filename_for_account(2)
     entry2 = ValidationIndexEntry(
         account_id=2,
-        pack_path=packs_dir / validation_pack_filename_for_account(2),
-        result_path=results_dir / validation_result_filename_for_account(2),
+        pack_path=pack_path2,
+        result_jsonl_path=jsonl_path2,
+        result_summary_path=summary_path2,
         weak_fields=("payment_history", "balance_owed"),
         line_count=2,
         status="built",


### PR DESCRIPTION
## Summary
- update validation pack documentation and tooling to use the new acc_<ACCID> result artifacts and document the JSON contracts
- extend validation result ingestion to emit both JSONL and summary files while enriching the index with explicit result paths
- refresh helpers, migration utilities, and tests to work with the new filenames and stored payloads

## Testing
- pytest tests/ai/test_validation_pack_writer.py tests/test_validation_packs.py tests/core/logic/test_validation_ai_packs.py tests/devtools/test_show_validation_index.py -q

------
https://chatgpt.com/codex/tasks/task_b_68dd5abc5be48325bc93305217288f03