### PR TITLE
Allow validation AI helpers to accept manifest mappings

### DIFF
--- a/backend/validation/build_packs.py
+++ b/backend/validation/build_packs.py
@@ -442,12 +442,28 @@ class ValidationPackBuilder:
             return None
 
 
-def build_validation_packs(manifest_path: Path | str) -> list[dict[str, Any]]:
-    """Build Validation AI packs for every account defined by ``manifest_path``."""
+def load_manifest_from_source(
+    manifest: Mapping[str, Any] | Path | str,
+) -> Mapping[str, Any]:
+    """Return a manifest mapping from ``manifest`` regardless of input type."""
+    if isinstance(manifest, Mapping):
+        return manifest
 
-    manifest_text = Path(manifest_path).read_text(encoding="utf-8")
-    manifest = json.loads(manifest_text)
-    builder = ValidationPackBuilder(manifest)
+    manifest_path = Path(manifest)
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    data = json.loads(manifest_text)
+    if not isinstance(data, Mapping):
+        raise TypeError("Manifest root must be a mapping")
+    return data
+
+
+def build_validation_packs(
+    manifest: Mapping[str, Any] | Path | str,
+) -> list[dict[str, Any]]:
+    """Build Validation AI packs for every account defined by ``manifest``."""
+
+    manifest_data = load_manifest_from_source(manifest)
+    builder = ValidationPackBuilder(manifest_data)
     return builder.build()
 
 
@@ -459,6 +475,7 @@ def resolve_manifest_paths(manifest: Mapping[str, Any]) -> ManifestPaths:
 
 __all__ = [
     "build_validation_packs",
+    "load_manifest_from_source",
     "resolve_manifest_paths",
     "ValidationPackBuilder",
     "ManifestPaths",

--- a/backend/validation/run_case.py
+++ b/backend/validation/run_case.py
@@ -44,7 +44,7 @@ def run_case(manifest_path: Path | str) -> Mapping[str, Any]:
 
     _append_log(paths.log_path, "validation_ai_start", sid=paths.sid)
     try:
-        build_items = build_validation_packs(manifest_path)
+        build_items = build_validation_packs(manifest)
         _append_log(
             paths.log_path,
             "validation_ai_built",
@@ -52,7 +52,7 @@ def run_case(manifest_path: Path | str) -> Mapping[str, Any]:
             accounts=len(build_items),
         )
 
-        send_results = send_validation_packs(manifest_path)
+        send_results = send_validation_packs(manifest)
         _append_log(
             paths.log_path,
             "validation_ai_sent",

--- a/backend/validation/send_packs.py
+++ b/backend/validation/send_packs.py
@@ -17,7 +17,7 @@ from backend.core.ai.paths import (
     validation_result_summary_filename_for_account,
 )
 
-from .build_packs import resolve_manifest_paths
+from .build_packs import load_manifest_from_source, resolve_manifest_paths
 
 _DEFAULT_MODEL = "gpt-4o-mini"
 _DEFAULT_TIMEOUT = 30.0
@@ -480,12 +480,13 @@ class ValidationPackSender:
             handle.write(line + "\n")
 
 
-def send_validation_packs(manifest_path: Path | str) -> list[dict[str, Any]]:
-    """Read ``manifest_path`` and send all validation packs it references."""
+def send_validation_packs(
+    manifest: Mapping[str, Any] | Path | str,
+) -> list[dict[str, Any]]:
+    """Send all validation packs referenced by ``manifest``."""
 
-    manifest_text = Path(manifest_path).read_text(encoding="utf-8")
-    manifest = json.loads(manifest_text)
-    sender = ValidationPackSender(manifest)
+    manifest_data = load_manifest_from_source(manifest)
+    sender = ValidationPackSender(manifest_data)
     return sender.send()
 
 


### PR DESCRIPTION
## Summary
- add a shared helper for loading validation manifests from either a mapping or a path so builders can accept in-memory data
- reuse the already parsed manifest when building and sending validation packs within the validation case runner

## Testing
- python -m compileall backend/validation

------
https://chatgpt.com/codex/tasks/task_b_68dd64b832108325b3957db33c9f635b