### PR TITLE
Write validation manifest v2 with relative paths

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -121,6 +121,8 @@ class ValidationPackWriter:
         self._index_writer = ValidationPackIndexWriter(
             sid=self.sid,
             index_path=index_path,
+            packs_dir=self._packs_dir,
+            results_dir=self._results_dir,
         )
         self._per_field = per_field
 
@@ -203,7 +205,7 @@ class ValidationPackWriter:
         *,
         summary: Mapping[str, Any] | None = None,
     ) -> None:
-        result_summary_path = (
+        result_json_path = (
             self._results_dir
             / validation_result_filename_for_account(account_id)
         )
@@ -234,7 +236,7 @@ class ValidationPackWriter:
             account_id=account_id,
             pack_path=pack_path.resolve(),
             result_jsonl_path=result_jsonl_path.resolve(),
-            result_summary_path=result_summary_path.resolve(),
+            result_json_path=result_json_path.resolve(),
             weak_fields=tuple(weak_fields),
             line_count=len(lines),
             status="built",

--- a/backend/ai/validation_index.py
+++ b/backend/ai/validation_index.py
@@ -6,14 +6,16 @@ import json
 import logging
 import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Mapping, Sequence
+
+from backend.validation.index_schema import ValidationIndex, ValidationPackRecord, load_validation_index
 
 log = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 
 
 def _utc_now() -> str:
@@ -29,7 +31,7 @@ class ValidationIndexEntry:
     account_id: int
     pack_path: Path
     result_jsonl_path: Path
-    result_summary_path: Path
+    result_json_path: Path
     weak_fields: Sequence[str]
     line_count: int
     status: str
@@ -40,102 +42,193 @@ class ValidationIndexEntry:
     completed_at: str | None = None
     error: str | None = None
     source_hash: str | None = None
+    extra: Mapping[str, object] = field(default_factory=dict)
 
-    def to_json_payload(self) -> dict[str, object]:
+    def to_json_payload(self, index_dir: Path) -> dict[str, object]:
         weak_fields = [str(field) for field in self.weak_fields if str(field).strip()]
         payload: dict[str, object] = {
             "account_id": int(self.account_id),
-            "pack_path": str(self.pack_path.resolve()),
-            "result_jsonl_path": str(self.result_jsonl_path.resolve()),
-            "result_summary_path": str(self.result_summary_path.resolve()),
-            "result_path": str(self.result_summary_path.resolve()),
+            "pack": _relativize_path(self.pack_path, index_dir),
+            "result_jsonl": _relativize_path(self.result_jsonl_path, index_dir),
+            "result_json": _relativize_path(self.result_json_path, index_dir),
             "weak_fields": weak_fields,
             "lines": int(self.line_count),
             "built_at": str(self.built_at or _utc_now()),
             "status": str(self.status or "built"),
         }
+
         if self.request_lines is not None:
-            try:
-                payload["request_lines"] = int(self.request_lines)
-            except (TypeError, ValueError):
-                payload.pop("request_lines", None)
+            normalized_request = _normalize_optional_int(self.request_lines)
+            if normalized_request is not None:
+                payload["request_lines"] = normalized_request
         if self.model is not None:
-            payload["model"] = str(self.model)
+            normalized_model = _normalize_optional_str(self.model)
+            if normalized_model is not None:
+                payload["model"] = normalized_model
         if self.sent_at:
-            payload["sent_at"] = str(self.sent_at)
+            normalized_sent = _normalize_optional_str(self.sent_at)
+            if normalized_sent is not None:
+                payload["sent_at"] = normalized_sent
         if self.completed_at:
-            payload["completed_at"] = str(self.completed_at)
+            normalized_completed = _normalize_optional_str(self.completed_at)
+            if normalized_completed is not None:
+                payload["completed_at"] = normalized_completed
         if self.error:
-            payload["error"] = str(self.error)
+            normalized_error = _normalize_optional_str(self.error)
+            if normalized_error is not None:
+                payload["error"] = normalized_error
         if self.source_hash:
             payload["source_hash"] = str(self.source_hash)
+
+        for key, value in (self.extra or {}).items():
+            if key in payload:
+                continue
+            payload[key] = value
+
         return payload
+
+
+def _atomic_write_json(path: Path, document: Mapping[str, object]) -> None:
+    try:
+        serialized = json.dumps(document, ensure_ascii=False, indent=2)
+    except TypeError:
+        log.exception("VALIDATION_INDEX_SERIALIZE_FAILED path=%s", path)
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except OSError:
+        log.warning("VALIDATION_INDEX_WRITE_FAILED path=%s", path, exc_info=True)
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+    else:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _ensure_posix(relative: Path | PurePosixPath | str) -> str:
+    return str(PurePosixPath(str(relative)))
+
+
+def _relativize_path(path: Path, base_dir: Path) -> str:
+    resolved_path = Path(path).resolve()
+    resolved_base = Path(base_dir).resolve()
+    try:
+        relative = resolved_path.relative_to(resolved_base)
+    except ValueError:
+        relative = Path(os.path.relpath(resolved_path, resolved_base))
+    return _ensure_posix(relative)
+
+
+def _normalize_optional_str(value: object) -> str | None:
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if value is None:
+        return None
+    return str(value)
+
+
+def _normalize_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def write_validation_manifest_v2(
+    sid: str,
+    packs_dir: Path,
+    results_dir: Path,
+    entries: Iterable[ValidationIndexEntry],
+    *,
+    index_path: Path,
+) -> None:
+    index_dir = index_path.parent.resolve()
+    normalized_entries = [
+        entry.to_json_payload(index_dir) for entry in entries
+    ]
+
+    normalized_entries.sort(
+        key=lambda item: (
+            _safe_int(item.get("account_id")),
+            str(item.get("pack") or ""),
+        )
+    )
+
+    document = {
+        "schema_version": _SCHEMA_VERSION,
+        "sid": sid,
+        "root": ".",
+        "packs_dir": _relativize_path(packs_dir, index_dir),
+        "results_dir": _relativize_path(results_dir, index_dir),
+        "packs": normalized_entries,
+    }
+
+    _atomic_write_json(index_path, document)
 
 
 class ValidationPackIndexWriter:
     """Maintain the consolidated validation pack index file."""
 
-    def __init__(self, *, sid: str, index_path: Path) -> None:
+    def __init__(
+        self,
+        *,
+        sid: str,
+        index_path: Path,
+        packs_dir: Path,
+        results_dir: Path,
+    ) -> None:
         self.sid = str(sid)
         self._index_path = Path(index_path)
+        self._packs_dir = Path(packs_dir)
+        self._results_dir = Path(results_dir)
         self._index_path.parent.mkdir(parents=True, exist_ok=True)
-
-    def load_accounts(self) -> dict[int, dict[str, object]]:
-        """Return a mapping of account id to existing index entries."""
-
-        document = self._load_index()
-        packs = document.get("packs")
-        if not isinstance(packs, Sequence):
-            return {}
-
-        entries: dict[int, dict[str, object]] = {}
-        for pack in packs:
-            if not isinstance(pack, Mapping):
-                continue
-            account_id = pack.get("account_id")
-            try:
-                normalized_id = int(account_id)  # type: ignore[arg-type]
-            except (TypeError, ValueError):
-                continue
-            entries[normalized_id] = dict(pack)
-        return entries
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    def load_accounts(self) -> dict[int, dict[str, object]]:
+        """Return a mapping of account id to existing index entries."""
+
+        entries = self._load_entries()
+        index_dir = self._index_path.parent.resolve()
+        result: dict[int, dict[str, object]] = {}
+        for entry in entries.values():
+            payload = entry.to_json_payload(index_dir)
+            result[int(entry.account_id)] = payload
+        return result
+
     def upsert(self, entry: ValidationIndexEntry) -> None:
         self.bulk_upsert([entry])
 
     def bulk_upsert(self, entries: Iterable[ValidationIndexEntry]) -> None:
-        payloads = [entry.to_json_payload() for entry in entries]
-        if not payloads:
+        new_entries = [entry for entry in entries]
+        if not new_entries:
             return
 
-        document = self._load_index()
-        existing: dict[str, dict[str, object]] = {}
+        existing = self._load_entries()
+        for entry in new_entries:
+            existing[self._entry_key(entry)] = entry
 
-        for pack in document.get("packs", []):
-            if not isinstance(pack, Mapping):
-                continue
-            pack_path = str(pack.get("pack_path") or "").strip()
-            if not pack_path:
-                continue
-            existing[pack_path] = dict(pack)
-
-        for payload in payloads:
-            pack_path = payload.get("pack_path")
-            if isinstance(pack_path, str) and pack_path:
-                existing[pack_path] = dict(payload)
-
-        ordered = self._sort_entries(existing.values())
-
-        document = {
-            "schema_version": _SCHEMA_VERSION,
-            "sid": self.sid,
-            "packs": ordered,
-        }
-
-        self._write_index(document)
+        write_validation_manifest_v2(
+            self.sid,
+            self._packs_dir,
+            self._results_dir,
+            existing.values(),
+            index_path=self._index_path,
+        )
 
     def mark_sent(
         self,
@@ -151,12 +244,13 @@ class ValidationPackIndexWriter:
             "sent_at": _utc_now(),
         }
         if request_lines is not None:
-            try:
-                set_values["request_lines"] = int(request_lines)
-            except (TypeError, ValueError):
-                pass
+            normalized_request = _normalize_optional_int(request_lines)
+            if normalized_request is not None:
+                set_values["request_lines"] = normalized_request
         if model is not None:
-            set_values["model"] = str(model)
+            normalized_model = _normalize_optional_str(model)
+            if normalized_model is not None:
+                set_values["model"] = normalized_model
 
         return self._update_entry_fields(
             Path(pack_path),
@@ -186,21 +280,19 @@ class ValidationPackIndexWriter:
         }
 
         if request_lines is not None:
-            try:
-                set_values["request_lines"] = int(request_lines)
-            except (TypeError, ValueError):
-                pass
+            normalized_request = _normalize_optional_int(request_lines)
+            if normalized_request is not None:
+                set_values["request_lines"] = normalized_request
 
         if model is not None:
-            set_values["model"] = str(model)
+            normalized_model = _normalize_optional_str(model)
+            if normalized_model is not None:
+                set_values["model"] = normalized_model
 
-        remove_keys: tuple[str, ...]
         if normalized_status == "error":
-            if error:
-                set_values["error"] = str(error)
-            else:
-                set_values.setdefault("error", "unknown")
-            remove_keys = ()
+            normalized_error = _normalize_optional_str(error) or "unknown"
+            set_values["error"] = normalized_error
+            remove_keys: tuple[str, ...] = ()
         else:
             remove_keys = ("error",)
 
@@ -213,77 +305,105 @@ class ValidationPackIndexWriter:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _load_index(self) -> dict[str, object]:
+    def _entry_key(self, entry: ValidationIndexEntry) -> str:
+        return _relativize_path(entry.pack_path, self._index_path.parent)
+
+    def _load_entries(self) -> dict[str, ValidationIndexEntry]:
         try:
-            raw_text = self._index_path.read_text(encoding="utf-8")
+            index = load_validation_index(self._index_path)
         except FileNotFoundError:
-            return {"schema_version": _SCHEMA_VERSION, "sid": self.sid, "packs": []}
-        except OSError:
-            log.warning("VALIDATION_INDEX_READ_FAILED path=%s", self._index_path, exc_info=True)
-            return {"schema_version": _SCHEMA_VERSION, "sid": self.sid, "packs": []}
-
-        try:
-            payload = json.loads(raw_text)
-        except json.JSONDecodeError:
+            return {}
+        except Exception:  # pragma: no cover - defensive logging
             log.warning(
-                "VALIDATION_INDEX_INVALID_JSON path=%s", self._index_path, exc_info=True
+                "VALIDATION_INDEX_READ_FAILED path=%s", self._index_path, exc_info=True
             )
-            return {"schema_version": _SCHEMA_VERSION, "sid": self.sid, "packs": []}
+            return {}
 
-        if not isinstance(payload, Mapping):
-            log.warning(
-                "VALIDATION_INDEX_INVALID_TYPE path=%s type=%s",
-                self._index_path,
-                type(payload).__name__,
-            )
-            return {"schema_version": _SCHEMA_VERSION, "sid": self.sid, "packs": []}
+        entries: dict[str, ValidationIndexEntry] = {}
+        for record in index.packs:
+            entry = self._entry_from_record(index, record)
+            entries[self._entry_key(entry)] = entry
+        return entries
 
-        return dict(payload)
+    def _entry_from_record(
+        self, index: ValidationIndex, record: ValidationPackRecord
+    ) -> ValidationIndexEntry:
+        pack_path = index.resolve_pack_path(record)
+        result_jsonl_path = index.resolve_result_jsonl_path(record)
+        result_json_path = index.resolve_result_json_path(record)
 
-    def _write_index(self, document: Mapping[str, object]) -> None:
-        try:
-            serialized = json.dumps(document, ensure_ascii=False, indent=2)
-        except TypeError:
-            log.exception("VALIDATION_INDEX_SERIALIZE_FAILED path=%s", self._index_path)
-            return
+        extra: dict[str, object] = dict(record.extra)
+        request_lines = _normalize_optional_int(extra.pop("request_lines", None))
+        model = _normalize_optional_str(extra.pop("model", None))
+        sent_at = _normalize_optional_str(extra.pop("sent_at", None))
+        completed_at = _normalize_optional_str(extra.pop("completed_at", None))
+        error = _normalize_optional_str(extra.pop("error", None))
 
-        tmp_fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{self._index_path.name}.", dir=str(self._index_path.parent)
+        status = _normalize_optional_str(record.status) or "built"
+        built_at = _normalize_optional_str(record.built_at) or _utc_now()
+        source_hash = _normalize_optional_str(record.source_hash)
+        weak_fields = tuple(
+            str(field).strip()
+            for field in record.weak_fields
+            if str(field).strip()
         )
-        try:
-            with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
-                handle.write(serialized)
-                handle.write("\n")
-            os.replace(tmp_name, self._index_path)
-        except OSError:
-            log.warning(
-                "VALIDATION_INDEX_WRITE_FAILED path=%s", self._index_path, exc_info=True
-            )
-            try:
-                os.unlink(tmp_name)
-            except FileNotFoundError:
-                pass
-        else:
-            try:
-                os.unlink(tmp_name)
-            except FileNotFoundError:
-                pass
 
-    def _sort_entries(
-        self, entries: Iterable[Mapping[str, object]]
-    ) -> list[dict[str, object]]:
-        normalized: list[dict[str, object]] = []
-        for entry in entries:
-            if isinstance(entry, Mapping):
-                normalized.append(dict(entry))
-
-        normalized.sort(
-            key=lambda item: (
-                _safe_int(item.get("account_id")),
-                str(item.get("pack_path") or ""),
-            )
+        return ValidationIndexEntry(
+            account_id=record.account_id,
+            pack_path=pack_path,
+            result_jsonl_path=result_jsonl_path,
+            result_json_path=result_json_path,
+            weak_fields=weak_fields,
+            line_count=record.lines,
+            status=status,
+            built_at=built_at,
+            request_lines=request_lines,
+            model=model,
+            sent_at=sent_at,
+            completed_at=completed_at,
+            error=error,
+            source_hash=source_hash,
+            extra=extra,
         )
-        return normalized
+
+    def _mutate_entry(
+        self,
+        entry: ValidationIndexEntry,
+        *,
+        set_values: Mapping[str, object],
+        remove_keys: Iterable[str] = (),
+    ) -> ValidationIndexEntry:
+        extra = dict(entry.extra)
+        updates: dict[str, object] = {}
+
+        for key in remove_keys:
+            normalized_key = str(key)
+            if normalized_key in {"request_lines", "model", "sent_at", "completed_at", "error"}:
+                updates[normalized_key] = None
+            else:
+                extra.pop(normalized_key, None)
+
+        for key, value in set_values.items():
+            normalized_key = str(key)
+            if normalized_key == "status":
+                updates["status"] = _normalize_optional_str(value) or entry.status
+            elif normalized_key == "built_at":
+                updates["built_at"] = _normalize_optional_str(value) or entry.built_at or _utc_now()
+            elif normalized_key == "request_lines":
+                updates["request_lines"] = _normalize_optional_int(value)
+            elif normalized_key == "model":
+                updates["model"] = _normalize_optional_str(value)
+            elif normalized_key == "sent_at":
+                updates["sent_at"] = _normalize_optional_str(value)
+            elif normalized_key == "completed_at":
+                updates["completed_at"] = _normalize_optional_str(value)
+            elif normalized_key == "error":
+                updates["error"] = _normalize_optional_str(value)
+            else:
+                extra[normalized_key] = value
+
+        updates["extra"] = extra
+        return replace(entry, **updates)
 
     def _update_entry_fields(
         self,
@@ -292,41 +412,28 @@ class ValidationPackIndexWriter:
         set_values: Mapping[str, object],
         remove_keys: Iterable[str] = (),
     ) -> dict[str, object] | None:
-        document = self._load_index()
-        packs_raw = document.get("packs")
-        if not isinstance(packs_raw, Sequence):
-            packs_raw = []
-
-        target_path = str(pack_path.resolve())
-        updated_entry: dict[str, object] | None = None
-        next_entries: list[dict[str, object]] = []
-
-        for entry in packs_raw:
-            if not isinstance(entry, Mapping):
-                continue
-
-            entry_copy = dict(entry)
-            entry_path = str(entry_copy.get("pack_path") or "").strip()
-            if entry_path == target_path:
-                for key in remove_keys:
-                    entry_copy.pop(key, None)
-                for key, value in set_values.items():
-                    if value is None:
-                        entry_copy.pop(key, None)
-                    else:
-                        entry_copy[key] = value
-                updated_entry = dict(entry_copy)
-
-            next_entries.append(entry_copy)
-
-        if updated_entry is None:
+        entries = self._load_entries()
+        key = _relativize_path(Path(pack_path), self._index_path.parent)
+        entry = entries.get(key)
+        if entry is None:
             return None
 
-        document["schema_version"] = int(document.get("schema_version", _SCHEMA_VERSION))
-        document["sid"] = str(document.get("sid") or self.sid)
-        document["packs"] = self._sort_entries(next_entries)
-        self._write_index(document)
-        return updated_entry
+        updated_entry = self._mutate_entry(
+            entry,
+            set_values=set_values,
+            remove_keys=remove_keys,
+        )
+        entries[key] = updated_entry
+
+        write_validation_manifest_v2(
+            self.sid,
+            self._packs_dir,
+            self._results_dir,
+            entries.values(),
+            index_path=self._index_path,
+        )
+
+        return updated_entry.to_json_payload(self._index_path.parent.resolve())
 
 
 def _safe_int(value: object) -> int:
@@ -334,4 +441,3 @@ def _safe_int(value: object) -> int:
         return int(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return 0
-

--- a/backend/ai/validation_results.py
+++ b/backend/ai/validation_results.py
@@ -33,7 +33,14 @@ def _resolve_runs_root(runs_root: Path | str | None) -> Path:
 
 def _index_writer(sid: str, runs_root: Path) -> ValidationPackIndexWriter:
     index_path = validation_index_path(sid, runs_root=runs_root, create=True)
-    return ValidationPackIndexWriter(sid=sid, index_path=index_path)
+    packs_dir = validation_packs_dir(sid, runs_root=runs_root, create=True)
+    results_dir = validation_results_dir(sid, runs_root=runs_root, create=True)
+    return ValidationPackIndexWriter(
+        sid=sid,
+        index_path=index_path,
+        packs_dir=packs_dir,
+        results_dir=results_dir,
+    )
 
 
 def mark_validation_pack_sent(

--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -287,7 +287,12 @@ def build_validation_ai_packs_for_accounts(
     processed_accounts: list[int] = []
     index_entries: list[ValidationIndexEntry] = []
     accounts_root = runs_root_path / sid / "cases" / "accounts"
-    index_writer = ValidationPackIndexWriter(sid=sid, index_path=validation_paths.index_file)
+    index_writer = ValidationPackIndexWriter(
+        sid=sid,
+        index_path=validation_paths.index_file,
+        packs_dir=validation_paths.packs_dir,
+        results_dir=validation_paths.results_dir,
+    )
     existing_index = index_writer.load_accounts()
 
     for idx in normalized_indices:
@@ -403,7 +408,7 @@ def build_validation_ai_packs_for_accounts(
                 account_id=int(idx),
                 pack_path=account_paths.pack_file,
                 result_jsonl_path=account_paths.result_jsonl_file,
-                result_summary_path=account_paths.result_summary_file,
+                result_json_path=account_paths.result_summary_file,
                 weak_fields=weak_fields,
                 line_count=line_count,
                 status=inference_status,

--- a/devtools/show_validation_index.py
+++ b/devtools/show_validation_index.py
@@ -101,7 +101,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     runs_root = _resolve_runs_root(args.runs_root)
     validation_paths = ensure_validation_paths(runs_root, args.sid, create=False)
     index_path = validation_paths.index_file
-    writer = ValidationPackIndexWriter(sid=args.sid, index_path=index_path)
+    writer = ValidationPackIndexWriter(
+        sid=args.sid,
+        index_path=index_path,
+        packs_dir=validation_paths.packs_dir,
+        results_dir=validation_paths.results_dir,
+    )
     accounts = writer.load_accounts()
 
     print(f"SID: {args.sid}")

--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -241,27 +241,18 @@ def test_writer_updates_index(tmp_path: Path) -> None:
     index_path = validation_index_path(sid, runs_root=runs_root)
     index_payload = _read_index(index_path)
 
-    assert index_payload["schema_version"] == 1
+    assert index_payload["schema_version"] == 2
     assert index_payload["sid"] == sid
+    assert index_payload["root"] == "."
+    assert index_payload["packs_dir"] == "packs"
+    assert index_payload["results_dir"] == "results"
     assert len(index_payload["packs"]) == 1
 
     entry = index_payload["packs"][0]
-    expected_pack = (runs_root / sid / "ai_packs" / "validation" / "packs" / "val_acc_001.jsonl").resolve()
-    expected_result_dir = validation_results_dir(sid, runs_root=runs_root)
-    expected_summary = (
-        expected_result_dir
-        / validation_result_filename_for_account(1)
-    ).resolve()
-    expected_jsonl = (
-        expected_result_dir
-        / validation_result_jsonl_filename_for_account(1)
-    ).resolve()
-
     assert entry["account_id"] == 1
-    assert entry["pack_path"] == str(expected_pack)
-    assert entry["result_summary_path"] == str(expected_summary)
-    assert entry["result_jsonl_path"] == str(expected_jsonl)
-    assert entry["result_path"] == str(expected_summary)
+    assert entry["pack"] == "packs/val_acc_001.jsonl"
+    assert entry["result_json"] == "results/acc_001.result.json"
+    assert entry["result_jsonl"] == "results/acc_001.result.jsonl"
     assert entry["lines"] == 2
     assert entry["weak_fields"] == ["balance_owed", "account_status"]
     assert entry["status"] == "built"

--- a/tests/core/logic/test_validation_ai_packs.py
+++ b/tests/core/logic/test_validation_ai_packs.py
@@ -122,7 +122,7 @@ def test_builder_creates_validation_structure(
 
     index_payload = json.loads(expected_index.read_text(encoding="utf-8"))
     assert index_payload["sid"] == sid
-    assert index_payload["schema_version"] == 1
+    assert index_payload["schema_version"] == 2
     pack_accounts = {entry["account_id"] for entry in index_payload["packs"]}
     assert pack_accounts == {14, 15}
     for entry in index_payload["packs"]:
@@ -132,7 +132,11 @@ def test_builder_creates_validation_structure(
         assert "request_lines" not in entry
         assert isinstance(entry.get("source_hash"), str) and len(entry["source_hash"]) == 64
         assert isinstance(entry["built_at"], str)
-        assert Path(entry["pack_path"]) == (
+        pack_path = (
+            validation_paths.index_file.parent
+            / entry["pack"]
+        ).resolve()
+        assert pack_path == (
             validation_paths.packs_dir
             / validation_pack_filename_for_account(entry["account_id"])
         ).resolve()
@@ -278,7 +282,10 @@ def test_builder_populates_pack_and_preserves_prompt_and_results(
     account_entry = packs_map[42]
     assert account_entry["status"] == model_results["status"]
     assert isinstance(account_entry["built_at"], str)
-    assert Path(account_entry["pack_path"]).resolve() == account_paths.pack_file.resolve()
+    pack_path = (
+        validation_paths.index_file.parent / account_entry["pack"]
+    ).resolve()
+    assert pack_path == account_paths.pack_file.resolve()
     assert account_entry["weak_fields"] == ["balance_owed"]
     assert account_entry["lines"] == 1
     assert isinstance(account_entry.get("source_hash"), str)

--- a/tests/devtools/test_show_validation_index.py
+++ b/tests/devtools/test_show_validation_index.py
@@ -41,7 +41,7 @@ def _create_index_entry(
         account_id=account_id,
         pack_path=pack_path,
         result_jsonl_path=jsonl_path,
-        result_summary_path=summary_path,
+        result_json_path=summary_path,
         weak_fields=weak_fields or [],
         line_count=lines or len(weak_fields or ()),
         status=status,
@@ -70,7 +70,12 @@ def test_show_validation_index_outputs_table(tmp_path, capsys):
         weak_fields=["history_2y"],
     )
 
-    writer = ValidationPackIndexWriter(sid=sid, index_path=validation_paths.index_file)
+    writer = ValidationPackIndexWriter(
+        sid=sid,
+        index_path=validation_paths.index_file,
+        packs_dir=validation_paths.packs_dir,
+        results_dir=validation_paths.results_dir,
+    )
     writer.bulk_upsert([entry_ok, entry_error])
 
     exit_code = show_validation_index.main([sid, "--runs-root", str(runs_root)])

--- a/tests/test_validation_packs.py
+++ b/tests/test_validation_packs.py
@@ -158,7 +158,12 @@ def test_validation_index_round_trip(tmp_path: Path) -> None:
     packs_dir = validation_packs_dir(sid, runs_root=runs_root)
     results_dir = validation_results_dir(sid, runs_root=runs_root)
     index_path = validation_index_path(sid, runs_root=runs_root)
-    writer = ValidationPackIndexWriter(sid=sid, index_path=index_path)
+    writer = ValidationPackIndexWriter(
+        sid=sid,
+        index_path=index_path,
+        packs_dir=packs_dir,
+        results_dir=results_dir,
+    )
 
     pack_path1 = packs_dir / validation_pack_filename_for_account(1)
     summary_path1 = results_dir / validation_result_filename_for_account(1)
@@ -167,7 +172,7 @@ def test_validation_index_round_trip(tmp_path: Path) -> None:
         account_id=1,
         pack_path=pack_path1,
         result_jsonl_path=jsonl_path1,
-        result_summary_path=summary_path1,
+        result_json_path=summary_path1,
         weak_fields=("balance_owed",),
         line_count=1,
         status="built",
@@ -179,7 +184,7 @@ def test_validation_index_round_trip(tmp_path: Path) -> None:
         account_id=2,
         pack_path=pack_path2,
         result_jsonl_path=jsonl_path2,
-        result_summary_path=summary_path2,
+        result_json_path=summary_path2,
         weak_fields=("payment_history", "balance_owed"),
         line_count=2,
         status="built",


### PR DESCRIPTION
## Summary
- update the validation index writer to emit schema v2 manifests with relative paths and normalized metadata
- update the builder, result handlers, and tooling to use the new writer signature and path fields
- refresh validation pack tests to assert the v2 manifest layout

## Testing
- pytest tests/ai/test_validation_pack_writer.py tests/test_validation_packs.py tests/core/logic/test_validation_ai_packs.py tests/backend/validation/test_manifest_schema.py

------
https://chatgpt.com/codex/tasks/task_b_68dd848ef98c832597ddbf049f66da6d