### PR TITLE
Add tests for validation manifest loading and sending

### DIFF
--- a/tests/backend/ai/test_validation_manifest_writer.py
+++ b/tests/backend/ai/test_validation_manifest_writer.py
@@ -1,0 +1,87 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+
+_requests_stub = types.ModuleType("requests")
+
+
+def _post_stub(*args, **kwargs):  # pragma: no cover - safety net
+    raise AssertionError("requests.post should not be invoked in tests")
+
+
+_requests_stub.post = _post_stub
+sys.modules.setdefault("requests", _requests_stub)
+
+
+from backend.ai.validation_index import ValidationIndexEntry, write_validation_manifest_v2
+
+
+def test_write_validation_manifest_v2_uses_relative_posix_paths(tmp_path: Path) -> None:
+    base_dir = tmp_path / "runs" / "SID123" / "ai_packs" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    index_path = base_dir / "index.json"
+
+    pack_path = packs_dir / "nested" / "pack.jsonl"
+    result_jsonl_path = results_dir / "nested" / "account_001.result.jsonl"
+    result_json_path = results_dir / "nested" / "account_001.result.json"
+
+    entry = ValidationIndexEntry(
+        account_id=1,
+        pack_path=pack_path,
+        result_jsonl_path=result_jsonl_path,
+        result_json_path=result_json_path,
+        weak_fields=("Account Name",),
+        line_count=7,
+        status="built",
+        built_at="2024-01-01T00:00:00Z",
+        extra={"custom": "value"},
+    )
+
+    write_validation_manifest_v2(
+        "SID123",
+        packs_dir,
+        results_dir,
+        [entry],
+        index_path=index_path,
+    )
+
+    document = json.loads(index_path.read_text(encoding="utf-8"))
+
+    assert document["schema_version"] == 2
+    assert document["sid"] == "SID123"
+    assert document["root"] == "."
+    assert document["packs_dir"] == "packs"
+    assert document["results_dir"] == "results"
+
+    assert len(document["packs"]) == 1
+    record = document["packs"][0]
+
+    assert record["account_id"] == 1
+    assert record["pack"] == "packs/nested/pack.jsonl"
+    assert record["result_jsonl"] == "results/nested/account_001.result.jsonl"
+    assert record["result_json"] == "results/nested/account_001.result.json"
+    assert "\\" not in record["pack"]
+    assert "\\" not in record["result_jsonl"]
+    assert "\\" not in record["result_json"]
+
+    assert record["weak_fields"] == ["Account Name"]
+    assert record["lines"] == 7
+    assert record["status"] == "built"
+    assert record["built_at"] == "2024-01-01T00:00:00Z"
+    assert record["custom"] == "value"
+
+    expected_keys = {
+        "account_id",
+        "pack",
+        "result_jsonl",
+        "result_json",
+        "weak_fields",
+        "lines",
+        "status",
+        "built_at",
+        "custom",
+    }
+    assert set(record) == expected_keys

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -121,6 +121,7 @@ def test_manifest_check_reports_missing_pack(tmp_path: Path) -> None:
     assert check_index(index, stream=buffer) is False
     output = buffer.getvalue()
     assert "MISSING" in output
+    assert "Missing packs detected." in output
 
 
 def test_sender_uses_manifest_paths(

--- a/tests/backend/validation/test_send_manifest_loader.py
+++ b/tests/backend/validation/test_send_manifest_loader.py
@@ -1,0 +1,139 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from backend.validation.send_packs import ValidationPackSender
+
+
+_requests_stub = types.ModuleType("requests")
+
+
+def _post_stub(*args, **kwargs):  # pragma: no cover - safety net
+    raise AssertionError("requests.post should not be invoked in tests")
+
+
+_requests_stub.post = _post_stub
+sys.modules.setdefault("requests", _requests_stub)
+
+
+class _LoaderStubClient:
+    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+        payload = {
+            "decision": "strong",
+            "rationale": "stub",
+            "citations": [],
+        }
+        return {"choices": [{"message": {"content": json.dumps(payload)}}]}
+
+
+@pytest.fixture()
+def loader_client() -> _LoaderStubClient:
+    return _LoaderStubClient()
+
+
+def test_sender_loader_accepts_v2_manifest_mapping(
+    tmp_path: Path, loader_client: _LoaderStubClient
+) -> None:
+    base_dir = tmp_path / "runs" / "SID555" / "ai_packs" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    index_path = base_dir / "index.json"
+
+    pack_file = packs_dir / "account_001.pack.jsonl"
+    pack_file.parent.mkdir(parents=True, exist_ok=True)
+    pack_file.write_text(
+        json.dumps({"prompt": {"system": "s", "user": {"sample": True}}}) + "\n",
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "__index_path__": str(index_path),
+        "schema_version": 2,
+        "sid": "SID555",
+        "root": ".",
+        "packs_dir": "packs",
+        "results_dir": "results",
+        "packs": [
+            {
+                "account_id": 1,
+                "pack": "packs/account_001.pack.jsonl",
+                "result_jsonl": "results/account_001.result.jsonl",
+                "result_json": "results/account_001.result.json",
+                "lines": 1,
+                "status": "built",
+                "built_at": "2024-01-01T00:00:00Z",
+            }
+        ],
+    }
+
+    sender = ValidationPackSender(manifest, http_client=loader_client)
+
+    index = sender._index  # type: ignore[attr-defined]
+    assert index.schema_version == 2
+    assert index.sid == "SID555"
+    assert index.packs_dir == "packs"
+    assert index.results_dir == "results"
+    assert index.index_path == index_path.resolve()
+
+    record = index.packs[0]
+    assert record.pack == "packs/account_001.pack.jsonl"
+    assert index.resolve_pack_path(record) == pack_file.resolve()
+
+
+def test_sender_loader_converts_v1_manifest_in_memory(
+    tmp_path: Path, loader_client: _LoaderStubClient
+) -> None:
+    base_dir = tmp_path / "runs" / "SID556" / "ai_packs" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    index_path = base_dir / "index.json"
+
+    pack_file = packs_dir / "account_002.pack.jsonl"
+    pack_file.parent.mkdir(parents=True, exist_ok=True)
+    pack_file.write_text(
+        json.dumps({"prompt": {"system": "s", "user": {"sample": False}}}) + "\n",
+        encoding="utf-8",
+    )
+
+    jsonl_path = results_dir / "account_002.result.jsonl"
+    summary_path = results_dir / "account_002.result.json"
+
+    manifest_v1 = {
+        "__index_path__": str(index_path),
+        "schema_version": 1,
+        "sid": "SID556",
+        "packs_dir": str(packs_dir),
+        "results_dir": str(results_dir),
+        "items": [
+            {
+                "account_id": 2,
+                "pack": str(pack_file),
+                "result_jsonl_path": str(jsonl_path),
+                "result_path": str(summary_path),
+                "lines": 1,
+                "status": "built",
+                "built_at": "2024-01-02T00:00:00Z",
+            }
+        ],
+    }
+
+    assert not index_path.exists()
+
+    sender = ValidationPackSender(manifest_v1, http_client=loader_client)
+
+    index = sender._index  # type: ignore[attr-defined]
+    assert index.schema_version == 2
+    assert index.sid == "SID556"
+    assert index.packs_dir == "packs"
+    assert index.results_dir == "results"
+    assert index.index_path == index_path.resolve()
+
+    record = index.packs[0]
+    assert record.pack == "packs/account_002.pack.jsonl"
+    assert record.result_jsonl == "results/account_002.result.jsonl"
+    assert record.result_json == "results/account_002.result.json"
+    assert index.resolve_pack_path(record) == pack_file.resolve()
+    assert not index_path.exists(), "conversion should not persist the manifest"

--- a/tests/backend/validation/test_send_smoke.py
+++ b/tests/backend/validation/test_send_smoke.py
@@ -1,0 +1,113 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from backend.validation.send_packs import ValidationPackSender
+
+
+_requests_stub = types.ModuleType("requests")
+
+
+def _post_stub(*args, **kwargs):  # pragma: no cover - safety net
+    raise AssertionError("requests.post should not be invoked in tests")
+
+
+_requests_stub.post = _post_stub
+sys.modules.setdefault("requests", _requests_stub)
+
+
+class _SmokeStubClient:
+    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+        payload = {
+            "decision": "strong",
+            "rationale": "auto",
+            "citations": [],
+            "confidence": 0.75,
+        }
+        return {"choices": [{"message": {"content": json.dumps(payload)}}]}
+
+
+def _pack_line(field: str) -> str:
+    payload = {
+        "id": field,
+        "field": field,
+        "prompt": {
+            "system": "system",
+            "user": {"field": field, "context": "value"},
+        },
+    }
+    return json.dumps(payload)
+
+
+def test_validation_sender_smoke_writes_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sid = "SMOKE001"
+    base_dir = tmp_path / "runs" / sid / "ai_packs" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    index_path = base_dir / "index.json"
+
+    packs_dir.mkdir(parents=True, exist_ok=True)
+
+    pack1 = packs_dir / "account_001.pack.jsonl"
+    pack1.write_text("\n".join((_pack_line("Account Name"), "")), encoding="utf-8")
+
+    pack2 = packs_dir / "account_002.pack.jsonl"
+    pack2.write_text("\n".join((_pack_line("Balance"), "")), encoding="utf-8")
+
+    manifest = {
+        "schema_version": 2,
+        "sid": sid,
+        "root": ".",
+        "packs_dir": "packs",
+        "results_dir": "results",
+        "packs": [
+            {
+                "account_id": 1,
+                "pack": "packs/account_001.pack.jsonl",
+                "result_jsonl": "results/account_001.result.jsonl",
+                "result_json": "results/account_001.result.json",
+                "lines": 1,
+                "status": "built",
+                "built_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "account_id": 2,
+                "pack": "packs/account_002.pack.jsonl",
+                "result_jsonl": "results/account_002.result.jsonl",
+                "result_json": "results/account_002.result.json",
+                "lines": 1,
+                "status": "built",
+                "built_at": "2024-01-01T00:00:00Z",
+            },
+        ],
+    }
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    monkeypatch.setenv("AI_MODEL", "stub-model")
+
+    sender = ValidationPackSender(index_path, http_client=_SmokeStubClient())
+    results = sender.send()
+
+    assert {item["account_id"] for item in results} == {1, 2}
+
+    for account_id in (1, 2):
+        jsonl_file = results_dir / f"account_{account_id:03d}.result.jsonl"
+        summary_file = results_dir / f"account_{account_id:03d}.result.json"
+
+        assert jsonl_file.is_file()
+        assert summary_file.is_file()
+
+        lines = [line for line in jsonl_file.read_text(encoding="utf-8").splitlines() if line]
+        assert lines, f"expected result lines for account {account_id}"
+
+        summary = json.loads(summary_file.read_text(encoding="utf-8"))
+        assert summary["status"] == "done"
+        assert summary["account_id"] == account_id
+        assert summary["results"], "summary should include results"


### PR DESCRIPTION
## Summary
- add coverage for write_validation_manifest_v2 to ensure stable relative manifest paths
- exercise the sender manifest loader for both v2 manifests and legacy v1 conversions
- add a smoke test that drives two packs through the sender and verifies result files plus tighten existence checks

## Testing
- pytest tests/backend/ai/test_validation_manifest_writer.py tests/backend/validation -q

------
https://chatgpt.com/codex/tasks/task_b_68dd8f94c9708325b285680cf3c3da18