### PR TITLE
Add manifest CLI options and send helper for validation packs

### DIFF
--- a/backend/validation/__init__.py
+++ b/backend/validation/__init__.py
@@ -6,7 +6,7 @@ from .build_packs import (
     build_validation_packs,
     resolve_manifest_paths,
 )
-from .manifest import check_index, load_index_for_sid
+from .manifest import check_index, load_index_for_sid, rewrite_index_to_v2
 from .run_case import run_case
 from .send_packs import (
     ValidationPackError,
@@ -22,6 +22,7 @@ __all__ = [
     "build_validation_packs",
     "check_index",
     "load_index_for_sid",
+    "rewrite_index_to_v2",
     "resolve_manifest_paths",
     "run_case",
     "send_validation_packs",

--- a/backend/validation/manifest.py
+++ b/backend/validation/manifest.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
-from typing import Sequence, TextIO
+from itertools import count
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence, TextIO
 
 from backend.core.ai.paths import validation_index_path
 
@@ -20,6 +21,30 @@ def load_index_for_sid(sid: str, *, runs_root: Path | str | None = None) -> Vali
     return load_validation_index(index_path)
 
 
+def _display_relative(path: Path, base: Path) -> str:
+    """Return ``path`` relative to ``base`` using POSIX separators."""
+
+    path_resolved = path.resolve()
+    base_resolved = base.resolve()
+    try:
+        relative = path_resolved.relative_to(base_resolved)
+        return PurePosixPath(relative).as_posix() or "."
+    except ValueError:
+        try:
+            relpath = Path(os_path_relpath(path_resolved, base_resolved))
+        except (OSError, ValueError):  # pragma: no cover - defensive
+            return path_resolved.as_posix()
+        return PurePosixPath(relpath).as_posix() or "."
+
+
+def os_path_relpath(target: Path, base: Path) -> str:
+    """``os.path.relpath`` wrapper that accepts :class:`Path` arguments."""
+
+    from os import path as os_path
+
+    return os_path.relpath(str(target), str(base))
+
+
 def check_index(
     index: ValidationIndex,
     *,
@@ -27,23 +52,128 @@ def check_index(
 ) -> bool:
     """Verify that every pack referenced by ``index`` exists on disk."""
 
-    ok = True
+    total = len(index.packs)
+    rows: list[list[str]] = []
+    missing = 0
+
+    index_dir = index.index_dir
+
     for record in index.packs:
         pack_path = index.resolve_pack_path(record)
-        status = "OK" if pack_path.is_file() else "MISSING"
-        stream.write(
-            f"{status:>8}  account {record.account_id:03d}  {record.pack}\n"
-        )
-        if status == "MISSING":
-            ok = False
+        pack_exists = pack_path.is_file()
+        if not pack_exists:
+            missing += 1
 
-    if ok:
-        stream.write(
-            f"All {len(index.packs)} packs present for SID {index.sid}.\n"
+        pack_display = record.pack or _display_relative(pack_path, index_dir)
+        result_jsonl_display = record.result_jsonl or _display_relative(
+            index.resolve_result_jsonl_path(record), index_dir
         )
+        result_json_display = record.result_json or _display_relative(
+            index.resolve_result_json_path(record), index_dir
+        )
+
+        rows.append(
+            [
+                f"{record.account_id:03d}",
+                pack_display,
+                "OK" if pack_exists else "MISSING",
+                str(record.lines or 0),
+                result_jsonl_display,
+                result_json_display,
+            ]
+        )
+
+    headers = ["ACCOUNT", "PACK", "STATUS", "LINES", "RESULT_JSONL", "RESULT_JSON"]
+
+    def _column_width(idx: int) -> int:
+        column_values = [headers[idx], *[row[idx] for row in rows]]
+        return max(len(value) for value in column_values) if column_values else len(headers[idx])
+
+    widths = [_column_width(i) for i in range(len(headers))]
+    align_right = {0, 3}
+
+    def _format_row(cells: Sequence[str]) -> str:
+        formatted: list[str] = []
+        for idx, cell in enumerate(cells):
+            width = widths[idx]
+            if idx in align_right:
+                formatted.append(cell.rjust(width))
+            else:
+                formatted.append(cell.ljust(width))
+        return "  ".join(formatted)
+
+    stream.write(f"Validation packs for SID {index.sid}:\n")
+    stream.write(_format_row(headers) + "\n")
+    separator_width = sum(widths) + 2 * (len(headers) - 1) if widths else 0
+    if separator_width:
+        stream.write("-" * separator_width + "\n")
+
+    if rows:
+        for row in rows:
+            stream.write(_format_row(row) + "\n")
     else:
-        stream.write("Missing packs detected.\n")
-    return ok
+        stream.write("(no packs)\n")
+
+    stream.write("\n")
+    stream.write(
+        f"Manifest: {_display_relative(index.index_path, index_dir)}\n"
+    )
+    stream.write(
+        f"Packs dir: {_display_relative(index.packs_dir_path, index_dir)}\n"
+    )
+    stream.write(
+        f"Results dir: {_display_relative(index.results_dir_path, index_dir)}\n"
+    )
+
+    if missing:
+        stream.write(f"Missing packs detected: {missing} of {total}.\n")
+    else:
+        stream.write(f"All {total} packs present for SID {index.sid}.\n")
+
+    return missing == 0
+
+
+def _schema_version_from_document(document: Mapping[str, Any]) -> int:
+    value = document.get("schema_version")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 1
+
+
+def _resolve_backup_path(index_path: Path) -> Path:
+    base = index_path.with_name(f"{index_path.stem}.v1.json")
+    if not base.exists():
+        return base
+    for suffix in count(1):
+        candidate = index_path.with_name(f"{index_path.stem}.v1.{suffix}.json")
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError("Unable to determine backup path for manifest")
+
+
+def rewrite_index_to_v2(
+    index_path: Path,
+    *,
+    document: Mapping[str, Any],
+    original_text: str,
+    stream: TextIO = sys.stdout,
+) -> tuple[ValidationIndex, bool]:
+    """Convert a legacy schema v1 manifest to v2 and persist the result."""
+
+    original_version = _schema_version_from_document(document)
+    if original_version >= 2:
+        stream.write("Validation manifest already uses schema version 2.\n")
+        return load_validation_index(index_path), False
+
+    backup_path = _resolve_backup_path(index_path)
+    backup_path.write_text(original_text, encoding="utf-8")
+    stream.write(f"Backed up legacy manifest to {backup_path}.\n")
+
+    index = load_validation_index(index_path)
+    index.write()
+    stream.write(f"Rewrote validation manifest to schema v2 at {index_path}.\n")
+    return index, True
 
 
 def _parse_argv(argv: Sequence[str] | None) -> argparse.Namespace:
@@ -58,6 +188,11 @@ def _parse_argv(argv: Sequence[str] | None) -> argparse.Namespace:
         action="store_true",
         help="Verify that every pack referenced by the index exists",
     )
+    parser.add_argument(
+        "--rewrite-v2",
+        action="store_true",
+        help="Rewrite legacy schema v1 manifests to v2 (creates index.v1.json backup)",
+    )
     return parser.parse_args(argv)
 
 
@@ -65,8 +200,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_argv(argv)
     runs_root = Path(args.runs_root) if args.runs_root else None
 
+    index_path = validation_index_path(args.sid, runs_root=runs_root, create=False)
+
     try:
-        index = load_index_for_sid(args.sid, runs_root=runs_root)
+        original_text = index_path.read_text(encoding="utf-8")
+        document = json.loads(original_text)
+        if not isinstance(document, Mapping):
+            raise TypeError("Validation index root must be an object")
     except FileNotFoundError:
         print(
             f"Validation index not found for SID {args.sid!r}.",
@@ -79,6 +219,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    index: ValidationIndex
+    if args.rewrite_v2:
+        index, _ = rewrite_index_to_v2(
+            index_path,
+            document=document,
+            original_text=original_text,
+            stream=sys.stdout,
+        )
+    else:
+        index = load_validation_index(index_path)
 
     if args.check:
         ok = check_index(index)

--- a/backend/validation/send.py
+++ b/backend/validation/send.py
@@ -1,0 +1,49 @@
+"""CLI wrapper around :func:`backend.validation.send_packs.send_validation_packs`."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from backend.core.ai.paths import validation_index_path
+
+from .send_packs import ValidationPackError, send_validation_packs
+
+
+def _parse_argv(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Send validation packs referenced by the manifest index"
+    )
+    parser.add_argument("--sid", required=True, help="Run SID to send")
+    parser.add_argument(
+        "--runs-root",
+        help="Base runs/ directory (defaults to ./runs or RUNS_ROOT env)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_argv(argv)
+    runs_root = Path(args.runs_root) if args.runs_root else None
+
+    index_path = validation_index_path(args.sid, runs_root=runs_root, create=False)
+    if not index_path.is_file():
+        print(
+            f"Validation index not found for SID {args.sid!r} at {index_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        send_validation_packs(index_path)
+    except ValidationPackError as exc:
+        print(f"Validation send failed: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -121,7 +121,7 @@ def test_manifest_check_reports_missing_pack(tmp_path: Path) -> None:
     assert check_index(index, stream=buffer) is False
     output = buffer.getvalue()
     assert "MISSING" in output
-    assert "Missing packs detected." in output
+    assert "Missing packs detected: 1 of 1." in output
 
 
 def test_sender_uses_manifest_paths(


### PR DESCRIPTION
## Summary
- enhance the validation manifest CLI with summary-table checks and an option to rewrite schema v1 manifests to schema v2 with backups
- add a thin CLI wrapper for sending validation packs that resolves the manifest index from an SID
- update validation manifest tests to reflect the richer check output

## Testing
- pytest tests/backend/validation/test_manifest_schema.py

------
https://chatgpt.com/codex/tasks/task_b_68dd910d15e083258db4fcdf9ccd7d42