### PR TITLE
Restrict validation to targeted fields and add conditional gating

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -332,6 +332,12 @@ class ValidationPackWriter:
         documents = self._normalize_string_list(requirement.get("documents"))
         category = self._coerce_optional_str(requirement.get("category"))
         min_days = self._coerce_optional_int(requirement.get("min_days"))
+        min_corroboration = self._coerce_optional_int(
+            requirement.get("min_corroboration")
+        )
+        conditional_gate = self._coerce_optional_bool(
+            requirement.get("conditional_gate")
+        )
 
         context = self._build_context(consistency)
         bureau_values = self._build_bureau_values(
@@ -367,7 +373,9 @@ class ValidationPackWriter:
             "category": category,
             "documents": documents,
             "min_days": min_days,
+            "min_corroboration": min_corroboration,
             "strength": strength,
+            "conditional_gate": conditional_gate,
             "bureaus": bureau_values,
             "context": context,
             "prompt": prompt_payload,
@@ -602,6 +610,22 @@ class ValidationPackWriter:
             text = value.strip()
             return text or None
         return str(value)
+
+    @staticmethod
+    def _coerce_optional_bool(value: Any) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"1", "true", "yes", "y", "on"}:
+                return True
+            if lowered in {"0", "false", "no", "n", "off"}:
+                return False
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return bool(value)
+        return None
 
     @staticmethod
     def _normalize_string_list(value: Any) -> list[str]:

--- a/backend/core/logic/validation_config.yml
+++ b/backend/core/logic/validation_config.yml
@@ -18,6 +18,8 @@ defaults:
   documents: []
   strength: "soft"
   ai_needed: false
+  min_corroboration: 1
+  conditional_gate: false
 
 fields:
   # ---- Open/Identification ----
@@ -28,6 +30,8 @@ fields:
     documents: [account_opening_contract, monthly_statement, collection_report]
     strength: soft
     ai_needed: true         # masking vs true mismatch
+    min_corroboration: 2
+    conditional_gate: true
 
   date_opened:
     category: open_ident
@@ -58,14 +62,6 @@ fields:
     min_days: 6
     points: 6
     documents: [account_opening_contract, lender_agreement, cra_report]
-    strength: soft
-    ai_needed: true
-
-  account_description:
-    category: open_ident
-    min_days: 6
-    points: 6
-    documents: [application_form, account_opening_contract]
     strength: soft
     ai_needed: true
 
@@ -167,6 +163,8 @@ fields:
     documents: [cra_report, cra_audit_log]
     strength: soft     # semantics differ across bureaus
     ai_needed: true
+    min_corroboration: 2
+    conditional_gate: true
 
   creditor_remarks:
     category: status
@@ -175,28 +173,14 @@ fields:
     documents: [collection_notes, customer_letters, cra_log]
     strength: soft
     ai_needed: true     # free text needs LLM to judge usefulness
-
-  dispute_status:
-    category: status
-    min_days: 6
-    points: 6
-    documents: [cra_audit_log, eoscar_system]
-    strength: strong
-    ai_needed: false
+    min_corroboration: 2
+    conditional_gate: true
 
   date_reported:
     category: status
     min_days: 3
     points: 3
     documents: [cra_reporting_log, cra_report]
-    strength: strong
-    ai_needed: false
-
-  last_verified:
-    category: status
-    min_days: 6
-    points: 6
-    documents: [internal_audit_log, verification_report]
     strength: strong
     ai_needed: false
 


### PR DESCRIPTION
## Summary
- limit validation configuration to the 21 approved fields and add conditional gating metadata for conditional items
- extend validation rule handling to carry new gating attributes, skip out-of-scope fields, and surface the metadata to AI pack generation
- update validation requirement tests to reflect the new field list, data layout, and strengthened gating expectations

## Testing
- pytest tests/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dfd9f844dc8325965d6b6341c80ce4