### PR TITLE
Implement conditional gating for validation AI packs

### DIFF
--- a/backend/validation/build_packs.py
+++ b/backend/validation/build_packs.py
@@ -215,6 +215,10 @@ class ValidationPackBuilder:
         documents = self._normalize_string_list(requirement.get("documents"))
         category = self._coerce_optional_str(requirement.get("category"))
         min_days = self._coerce_optional_int(requirement.get("min_days"))
+        min_corroboration = self._coerce_optional_int(
+            requirement.get("min_corroboration")
+        )
+        conditional_gate = self._coerce_bool(requirement.get("conditional_gate"))
 
         context = self._build_context(consistency)
         extra_context = requirement.get("notes") or requirement.get("reason")
@@ -255,6 +259,11 @@ class ValidationPackBuilder:
                 "user": prompt_user,
             },
         }
+
+        if min_corroboration is not None:
+            payload["min_corroboration"] = min_corroboration
+        if conditional_gate:
+            payload["conditional_gate"] = True
 
         return payload
 

--- a/tests/test_validation_send_packs.py
+++ b/tests/test_validation_send_packs.py
@@ -1,0 +1,121 @@
+import sys
+from types import SimpleNamespace
+from typing import Optional
+
+if "requests" not in sys.modules:
+    sys.modules["requests"] = SimpleNamespace(post=lambda *args, **kwargs: None)
+
+from backend.validation.send_packs import _enforce_conditional_gate
+
+
+def _account_number_pack_line(last4_a: str, last4_b: Optional[str]) -> dict:
+    bureaus = {
+        "transunion": {
+            "raw": f"****{last4_a}",
+            "normalized": {"display": f"****{last4_a}", "last4": last4_a},
+        },
+        "experian": {
+            "raw": f"{last4_b}" if last4_b else None,
+            "normalized": (
+                {"display": f"{last4_b}", "last4": last4_b}
+                if last4_b
+                else {"display": "", "last4": None}
+            ),
+        },
+        "equifax": {"raw": None, "normalized": {"display": "", "last4": None}},
+    }
+
+    return {
+        "field": "account_number_display",
+        "conditional_gate": True,
+        "min_corroboration": 2,
+        "bureaus": bureaus,
+    }
+
+
+def test_account_number_gate_rejects_masking_only() -> None:
+    decision, rationale = _enforce_conditional_gate(
+        "account_number_display",
+        "strong",
+        "Masking only",
+        _account_number_pack_line("1234", "1234"),
+    )
+
+    assert decision == "no_case"
+    assert "conditional_gate" in rationale
+
+
+def test_account_number_gate_allows_true_conflict() -> None:
+    decision, rationale = _enforce_conditional_gate(
+        "account_number_display",
+        "strong",
+        "Digits conflict",
+        _account_number_pack_line("1234", "5678"),
+    )
+
+    assert decision == "strong"
+    assert rationale == "Digits conflict"
+
+
+def _creditor_remarks_pack_line(remarks_a: str, remarks_b: str) -> dict:
+    return {
+        "field": "creditor_remarks",
+        "conditional_gate": True,
+        "min_corroboration": 2,
+        "bureaus": {
+            "transunion": {
+                "raw": remarks_a,
+                "normalized": remarks_a.lower(),
+            },
+            "experian": {
+                "raw": remarks_b,
+                "normalized": remarks_b.lower(),
+            },
+        },
+    }
+
+
+def test_creditor_remarks_gate_requires_high_signal() -> None:
+    decision, rationale = _enforce_conditional_gate(
+        "creditor_remarks",
+        "strong",
+        "Low signal",
+        _creditor_remarks_pack_line("account closed by consumer", "account closed by lender"),
+    )
+
+    assert decision == "no_case"
+    assert "conditional_gate" in rationale
+
+
+def test_creditor_remarks_gate_allows_keyword_conflict() -> None:
+    decision, rationale = _enforce_conditional_gate(
+        "creditor_remarks",
+        "strong",
+        "Conflicting remarks",
+        _creditor_remarks_pack_line(
+            "account closed by consumer",
+            "consumer disputes balance as fraud",
+        ),
+    )
+
+    assert decision == "strong"
+    assert rationale == "Conflicting remarks"
+
+
+def test_account_rating_gate_needs_multiple_values() -> None:
+    pack_line = {
+        "field": "account_rating",
+        "conditional_gate": True,
+        "min_corroboration": 2,
+        "bureaus": {
+            "transunion": {"raw": "A", "normalized": "a"},
+            "experian": {"raw": None, "normalized": None},
+        },
+    }
+
+    decision, rationale = _enforce_conditional_gate(
+        "account_rating", "strong", "Single bureau", pack_line
+    )
+
+    assert decision == "no_case"
+    assert "conditional_gate" in rationale


### PR DESCRIPTION
## Summary
- propagate the validation config min_corroboration and conditional_gate flags into generated pack payloads
- enforce conditional gating for soft validation fields so "strong" decisions require substantive mismatches with sufficient corroboration and high-signal remarks
- add unit tests covering gating behaviour for account numbers, creditor remarks, and account ratings

## Testing
- pytest tests/test_validation_send_packs.py tests/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dfde21c56483258e9ace44fc657398