### PR TITLE
Harden conditional validation prompts

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -417,6 +417,18 @@ class ValidationPackWriter:
             field_name, bureaus_data, consistency
         )
 
+        guidance = (
+            "Return a JSON object with a decision of either 'strong' or 'no_case', "
+            "along with rationale and any supporting citations."
+        )
+        if conditional_gate:
+            guidance += (
+                " Treat this as conditional. Return 'strong' only if the content "
+                "shows a materially incorrect report: a contradiction across "
+                "bureaus corroborated by documentation or CRA logs. Otherwise "
+                "respond with 'no_case'."
+            )
+
         prompt_payload = {
             "system": _SYSTEM_PROMPT,
             "user": {
@@ -430,10 +442,7 @@ class ValidationPackWriter:
                 "bureaus": bureau_values,
                 "context": context,
             },
-            "guidance": (
-                "Return a JSON object with a decision of either 'strong' or 'no_case', "
-                "along with rationale and any supporting citations."
-            ),
+            "guidance": guidance,
         }
 
         payload: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- add conditional guidance to validation prompts so gated fields only escalate on corroborated contradictions
- update validation pack tests to exercise creditor remarks and assert conditional guidance is present

## Testing
- pytest tests/test_validation_packs.py tests/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68dfe2d7275c832585467e0b34c84be8