### PR TITLE
Add reporting pattern classifier for deterministic escalation

### DIFF
--- a/backend/core/ai/report_compare.py
+++ b/backend/core/ai/report_compare.py
@@ -1,0 +1,44 @@
+"""Reporting comparison utilities for deterministic escalation."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .eligibility_policy import canonicalize_history
+
+
+def classify_reporting_pattern(values_by_bureau: Dict[str, Any]) -> str:
+    """Classify the reporting pattern among bureau values.
+
+    Args:
+        values_by_bureau: Mapping of bureau name to the raw reported value.
+
+    Returns:
+        One of ``case_1`` through ``case_6`` describing the combination of
+        missing and present values along with their equality relationships.
+    """
+
+    canonicalized: Dict[str, str | None] = {
+        bureau: canonicalize_history(value)
+        for bureau, value in values_by_bureau.items()
+    }
+
+    present_values = [value for value in canonicalized.values() if value is not None]
+    missing_count = len(values_by_bureau) - len(present_values)
+
+    if not present_values:
+        return "case_6"
+
+    if len(present_values) == 1:
+        return "case_1"
+
+    if missing_count == 1:
+        first, second = present_values
+        if first == second:
+            return "case_2"
+        return "case_3"
+
+    # At this point all bureaus have a value (missing_count == 0).
+    unique_values = set(present_values)
+    if len(unique_values) <= 2:
+        return "case_4"
+    return "case_5"

--- a/tests/backend/core/ai/test_report_compare.py
+++ b/tests/backend/core/ai/test_report_compare.py
@@ -1,0 +1,42 @@
+from backend.core.ai import eligibility_policy as policy
+from backend.core.ai.report_compare import classify_reporting_pattern
+
+
+def test_case_1_single_present():
+    values = {"equifax": "value", "experian": None, "transunion": ""}
+    assert classify_reporting_pattern(values) == "case_1"
+
+
+def test_case_2_one_missing_two_match():
+    values = {"equifax": "VALUE", "experian": " value ", "transunion": None}
+    assert classify_reporting_pattern(values) == "case_2"
+
+
+def test_case_3_one_missing_two_different():
+    values = {"equifax": "foo", "experian": "bar", "transunion": "--"}
+    assert classify_reporting_pattern(values) == "case_3"
+
+
+def test_case_4_all_present_two_match():
+    values = {"equifax": "foo", "experian": "foo", "transunion": "bar"}
+    assert classify_reporting_pattern(values) == "case_4"
+
+
+def test_case_5_all_present_all_different():
+    values = {"equifax": "foo", "experian": "bar", "transunion": "baz"}
+    assert classify_reporting_pattern(values) == "case_5"
+
+
+def test_case_6_all_missing():
+    values = {"equifax": None, "experian": "--", "transunion": "!!!"}
+    assert classify_reporting_pattern(values) == "case_6"
+
+
+def test_canonicalization_with_history():
+    values = {
+        "equifax": [" OK ", "LATE"],
+        "experian": ["ok", "late"],
+        "transunion": None,
+    }
+    assert policy.canonicalize_history(values["equifax"]) == "ok|late"
+    assert classify_reporting_pattern(values) == "case_2"


### PR DESCRIPTION
## Summary
- add a deterministic reporting pattern classifier for bureau value comparisons
- normalize inputs using existing canonicalization helpers to handle missing values
- cover all six classification cases and edge inputs with unit tests

## Testing
- pytest tests/backend/core/ai/test_report_compare.py

------
https://chatgpt.com/codex/tasks/task_b_68e003ef98408325977f78de022ab976