### PR TITLE
Add deterministic reason flags for field escalation

### DIFF
--- a/backend/core/ai/report_compare.py
+++ b/backend/core/ai/report_compare.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from .eligibility_policy import ALWAYS_ELIGIBLE_FIELDS, CONDITIONAL_FIELDS
+
 from .eligibility_policy import canonicalize_history
 
 
@@ -42,3 +44,42 @@ def classify_reporting_pattern(values_by_bureau: Dict[str, Any]) -> str:
     if len(unique_values) <= 2:
         return "case_4"
     return "case_5"
+
+
+def compute_reason_flags(field: str, pattern: str, match_matrix: dict) -> Dict[str, bool]:
+    """Compute reason flags describing the escalation rationale for *field*.
+
+    Args:
+        field: The bureau field name being evaluated.
+        pattern: The reporting pattern classification (``case_1`` - ``case_6``).
+        match_matrix: Matrix describing pairwise bureau value matches. Included for
+            signature compatibility with upstream callers. Not used by the
+            deterministic eligibility logic yet, but retained for future
+            expansion.
+
+    Returns:
+        A dictionary containing boolean flags for ``missing``, ``mismatch``,
+        ``both`` (when the field is both missing and mismatched across bureaus),
+        and ``eligible`` (whether the field qualifies for escalation under the
+        policy).
+    """
+
+    del match_matrix  # Unused in current deterministic computation.
+
+    missing = pattern in {"case_1", "case_2", "case_3", "case_6"}
+    mismatch = pattern in {"case_3", "case_4", "case_5"}
+    both = missing and mismatch
+
+    if field in ALWAYS_ELIGIBLE_FIELDS:
+        eligible = missing or mismatch
+    elif field in CONDITIONAL_FIELDS:
+        eligible = mismatch
+    else:
+        eligible = False
+
+    return {
+        "missing": missing,
+        "mismatch": mismatch,
+        "both": both,
+        "eligible": eligible,
+    }


### PR DESCRIPTION
## Summary
- add compute_reason_flags helper to generate reason metadata for deterministic escalation
- cover all reporting patterns for always-eligible and conditional policy fields in unit tests

## Testing
- pytest tests/backend/core/ai/test_report_compare.py

------
https://chatgpt.com/codex/tasks/task_b_68e00471378c8325a9ad1cbcbb862d5e