### PR TITLE
Add weak field reason badges to upload account detail view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -59,3 +59,70 @@ nav a:hover {
   font-family: monospace;
   white-space: pre-wrap;
 }
+
+.weak-fields-card {
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  background: #fafafa;
+  border: 1px solid #e2e2e2;
+  border-radius: 6px;
+}
+
+.weak-fields-heading {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.weak-fields-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.weak-fields-table th,
+.weak-fields-table td {
+  border-bottom: 1px solid #e5e5e5;
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.weak-fields-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.weak-field-badges {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.weak-field-badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: #eef2ff;
+  color: #1d3a8a;
+}
+
+.weak-field-badge--missing {
+  background: #fff4e5;
+  color: #8a4600;
+  border-color: #ffd9a6;
+}
+
+.weak-field-badge--mismatch {
+  background: #ffe5ec;
+  color: #921b3a;
+  border-color: #ffb6c9;
+}
+
+.weak-field-badge--both {
+  background: #e7f5ff;
+  color: #004a77;
+  border-color: #a8d8ff;
+}


### PR DESCRIPTION
## Summary
- render weak-field escalation badges with tooltips in the upload detail drawer
- surface extracted weak-field entries with a concise table next to the raw JSON
- add styling for the weak-field table and badges for missing, mismatch, and both cases

## Testing
- npm test -- --runTestsByPath src/pages/UploadPage.test.jsx

------
https://chatgpt.com/codex/tasks/task_b_68e00caf045483258c906605f287d7c7