### PR TITLE
Normalize bureau values in reason classifier

### DIFF
--- a/backend/core/logic/reason_classifier.py
+++ b/backend/core/logic/reason_classifier.py
@@ -59,11 +59,23 @@ def classify_reason(bureau_values: Mapping[str, Any]) -> Mapping[str, Any]:
         mismatch counts, and helper booleans that downstream callers can use.
     """
 
-    total_bureaus = len(bureau_values)
+    normalized_values: Dict[str, Any] = {}
+
+    for bureau, value in bureau_values.items():
+        if isinstance(value, str):
+            value = value.strip()
+            if value in {"", "--"}:
+                value = None
+        elif value in {"", "--"}:  # pragma: no cover - defensive, non-str inputs unlikely
+            value = None
+
+        normalized_values[bureau] = value
+
+    total_bureaus = len(normalized_values)
     missing_count = 0
     present_values: list[Any] = []
 
-    for value in bureau_values.values():
+    for value in normalized_values.values():
         if _is_missing(value):
             missing_count += 1
         else:

--- a/tests/backend/core/logic/test_reason_classifier.py
+++ b/tests/backend/core/logic/test_reason_classifier.py
@@ -90,3 +90,18 @@ def test_classify_all_diff():
     assert result["is_missing"] is False
     assert result["is_mismatch"] is True
 
+
+def test_normalizes_whitespace_and_missing_markers():
+    result = classify_reason({
+        "experian": "  open  ",
+        "equifax": " -- ",
+        "transunion": " ",
+    })
+
+    assert result["reason_code"] == "C2_ONE_MISSING"
+    assert result["missing_count"] == 2
+    assert result["present_count"] == 1
+    assert result["distinct_values"] == 1
+    assert result["is_missing"] is True
+    assert result["is_mismatch"] is False
+


### PR DESCRIPTION
## Summary
- normalize bureau values within classify_reason by trimming whitespace and collapsing missing markers to None
- update reason classifier tests to cover normalization scenarios

## Testing
- pytest tests/backend/core/logic/test_reason_classifier.py

------
https://chatgpt.com/codex/tasks/task_b_68e018115cdc8325a93a4e4cdee76922