### PR TITLE
Add findings payload to validation requirements summary

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -814,9 +814,16 @@ def build_summary_payload(
 ) -> Dict[str, Any]:
     """Build the summary.json payload for validation requirements."""
 
-    findings = [_build_finding(entry, field_consistency) for entry in requirements]
+    normalized_requirements = [dict(entry) for entry in requirements]
+    findings = [
+        _build_finding(entry, field_consistency) for entry in normalized_requirements
+    ]
 
-    payload = {"requirements": findings, "count": len(findings)}
+    payload = {
+        "requirements": normalized_requirements,
+        "findings": findings,
+        "count": len(findings),
+    }
     if field_consistency:
         payload["field_consistency"] = dict(field_consistency)
     return payload


### PR DESCRIPTION
## Summary
- keep the legacy `requirements` list intact while emitting a new `findings` array with enriched metadata for each field
- extend validation requirements tests to assert both arrays are written to the summary and pack builder inputs

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68e01a749bcc8325ae3a36b4468f8170