### PR TITLE
Remove raw bureau values from validation summary output

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -304,6 +304,20 @@ def _clone_field_consistency(
     return {str(field): _clone(details) for field, details in field_consistency.items()}
 
 
+def _strip_raw_from_field_consistency(
+    field_consistency: Mapping[str, Any]
+) -> Dict[str, Any]:
+    """Return a deep copy of ``field_consistency`` without bureau raw values."""
+
+    cloned = _clone_field_consistency(field_consistency)
+
+    for field, details in list(cloned.items()):
+        if isinstance(details, dict):
+            details.pop("raw", None)
+
+    return cloned
+
+
 def _filter_inconsistent_fields(
     field_consistency: Mapping[str, Any]
 ) -> Dict[str, Dict[str, Any]]:
@@ -825,7 +839,9 @@ def build_summary_payload(
         "count": len(findings),
     }
     if field_consistency:
-        payload["field_consistency"] = dict(field_consistency)
+        sanitized_consistency = _strip_raw_from_field_consistency(field_consistency)
+        if sanitized_consistency:
+            payload["field_consistency"] = sanitized_consistency
     return payload
 
 

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -81,7 +81,14 @@ def test_build_summary_payload_includes_field_consistency():
     )
 
     assert payload["count"] == 1
-    assert payload["field_consistency"] == field_consistency
+    expected_consistency = {
+        "balance_owed": {
+            "consensus": "split",
+            "normalized": {"transunion": 100.0, "experian": 150.0},
+            "disagreeing_bureaus": ["experian"],
+        }
+    }
+    assert payload["field_consistency"] == expected_consistency
     assert len(payload["requirements"]) == 1
     requirement = payload["requirements"][0]
     assert requirement["field"] == "balance_owed"


### PR DESCRIPTION
## Summary
- strip raw bureau values before writing the validation summary payload
- update the validation summary test expectations to reflect the sanitized field consistency map

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py::test_build_summary_payload_includes_field_consistency *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68e01b9463ec832582eff7fffb452c0f