### PR TITLE
Filter validation packs to send_to_ai fields

### DIFF
--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -74,6 +74,10 @@ def test_writer_builds_pack_lines(tmp_path: Path) -> None:
                     "ai_needed": False,
                 },
             ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True},
+                {"field": "account_status", "send_to_ai": False},
+            ],
             "field_consistency": {
                 "balance_owed": {
                     "consensus": "split",
@@ -160,6 +164,9 @@ def test_writer_uses_bureau_fallback(tmp_path: Path) -> None:
                     "notes": "status mismatch",
                 }
             ],
+            "findings": [
+                {"field": "account_status", "send_to_ai": True}
+            ],
             "field_consistency": {},
         }
     }
@@ -199,6 +206,9 @@ def test_writer_skips_strong_fields(tmp_path: Path) -> None:
                     "ai_needed": True,
                 }
             ],
+            "findings": [
+                {"field": "payment_status", "send_to_ai": True}
+            ],
             "field_consistency": {},
         }
     }
@@ -235,6 +245,10 @@ def test_writer_updates_index(tmp_path: Path) -> None:
                     "strength": "weak",
                     "ai_needed": True,
                 },
+            ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True},
+                {"field": "account_status", "send_to_ai": True},
             ],
             "field_consistency": {
                 "balance_owed": {
@@ -308,6 +322,9 @@ def _seed_validation_account(
                     "strength": "weak",
                     "ai_needed": True,
                 }
+            ],
+            "findings": [
+                {"field": field, "send_to_ai": True}
             ],
             "field_consistency": {
                 field: {"raw": {"transunion": "$100"}},
@@ -554,6 +571,9 @@ def test_build_validation_pack_respects_env_toggle(
                     "ai_needed": True,
                 }
             ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True}
+            ],
             "field_consistency": {
                 "balance_owed": {"raw": {"transunion": "$100"}}
             },
@@ -595,6 +615,9 @@ def test_build_validation_packs_for_run_auto_send(
                     "strength": "weak",
                     "ai_needed": True,
                 }
+            ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {
                 "balance_owed": {"raw": {"transunion": "$100"}}
@@ -647,6 +670,9 @@ def test_rewrite_index_to_canonical_layout(tmp_path: Path) -> None:
                     "strength": "weak",
                     "ai_needed": True,
                 }
+            ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {
                 "balance_owed": {

--- a/tests/ai/test_validation_packs.py
+++ b/tests/ai/test_validation_packs.py
@@ -96,6 +96,10 @@ def test_pack_writer_emits_all_21_fields(tmp_path: Path, account_id: int) -> Non
     summary_payload = {
         "validation_requirements": {
             "requirements": requirements,
+            "findings": [
+                {"field": field, "send_to_ai": True}
+                for field in ALL_VALIDATION_FIELDS
+            ],
             "field_consistency": {},
         }
     }
@@ -254,6 +258,10 @@ def reason_pack_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict
     summary_payload = {
         "validation_requirements": {
             "requirements": requirements,
+            "findings": [
+                {"field": field, "send_to_ai": True}
+                for field in field_patterns
+            ],
             "field_consistency": field_consistency,
         }
     }

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -56,6 +56,9 @@ def _build_manifest(tmp_path: Path, sid: str = "S001") -> tuple[dict[str, object
                     "category": "identity",
                 }
             ],
+            "findings": [
+                {"field": "Account Status", "send_to_ai": True}
+            ],
             "field_consistency": {},
         }
     }

--- a/tests/test_validation_packs.py
+++ b/tests/test_validation_packs.py
@@ -88,6 +88,10 @@ def test_builds_pack_with_two_weak_fields(tmp_path: Path) -> None:
                     "conditional_gate": True,
                 },
             ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True},
+                {"field": "creditor_remarks", "send_to_ai": True},
+            ],
             "field_consistency": {
                 "balance_owed": {
                     "consensus": "split",
@@ -201,6 +205,12 @@ def test_removed_fields_are_never_emitted(tmp_path: Path) -> None:
                     "ai_needed": True,
                 },
             ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True},
+                {"field": "account_description", "send_to_ai": True},
+                {"field": "dispute_status", "send_to_ai": True},
+                {"field": "last_verified", "send_to_ai": True},
+            ],
             "field_consistency": {},
         }
     }
@@ -297,6 +307,9 @@ def test_manifest_updated_after_first_pack(tmp_path: Path, monkeypatch) -> None:
                     "ai_needed": True,
                 }
             ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True}
+            ],
             "field_consistency": {},
         }
     }
@@ -347,6 +360,10 @@ def test_build_validation_pack_idempotent(tmp_path: Path, monkeypatch) -> None:
                     "strength": "weak",
                     "ai_needed": True,
                 },
+            ],
+            "findings": [
+                {"field": "balance_owed", "send_to_ai": True},
+                {"field": "account_status", "send_to_ai": True},
             ],
             "field_consistency": {},
         }


### PR DESCRIPTION
## Summary
- update the validation pack builder to honor `send_to_ai` metadata from summary findings when generating pack lines
- ensure pack status and source hash logic align with the new gating behaviour
- refresh validation pack tests with findings fixtures that exercise the new routing rules

## Testing
- pytest tests/ai/test_validation_pack_writer.py tests/test_validation_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68e01dcda98c83259db3af32f1684486