### PR TITLE
Stop emitting legacy validation requirements array

### DIFF
--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -2919,13 +2919,15 @@ def persist_merge_tags(
         if not isinstance(validation_block, Mapping):
             continue
 
-        req_entries = validation_block.get("requirements")
-        if not isinstance(req_entries, Sequence):
+        findings_entries = validation_block.get("findings")
+        if not isinstance(findings_entries, Sequence):
+            findings_entries = validation_block.get("requirements")
+        if not isinstance(findings_entries, Sequence):
             continue
 
         if any(
             isinstance(entry, Mapping) and bool(entry.get("ai_needed"))
-            for entry in req_entries
+            for entry in findings_entries
         ):
             validation_ai_indices.append(int(idx))
 

--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -842,9 +842,15 @@ def build_summary_payload(
     normalized_requirements = [dict(entry) for entry in requirements]
     reasons_enabled = _is_validation_reason_enabled()
 
-    payload: Dict[str, Any] = {
-        "requirements": normalized_requirements,
-        "count": len(normalized_requirements),
+    include_requirements = os.getenv(
+        "VALIDATION_SUMMARY_INCLUDE_REQUIREMENTS", "0"
+    )
+    include_requirements_flag = str(include_requirements).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
     }
 
     if reasons_enabled:
@@ -852,8 +858,16 @@ def build_summary_payload(
             _build_finding(entry, field_consistency)
             for entry in normalized_requirements
         ]
-        payload["findings"] = findings
-        payload["count"] = len(findings)
+    else:
+        findings = [dict(entry) for entry in normalized_requirements]
+
+    payload: Dict[str, Any] = {
+        "findings": findings,
+        "count": len(findings),
+    }
+
+    if include_requirements_flag:
+        payload["requirements"] = normalized_requirements
 
     if field_consistency:
         if reasons_enabled:

--- a/devtools/run_validation_once.py
+++ b/devtools/run_validation_once.py
@@ -20,10 +20,13 @@ def main(sid: str):
         if not os.path.isfile(os.path.join(acc_dir, "bureaus.json")):
             continue
         res = build_validation_requirements_for_account(acc_dir) or {}
+        findings = res.get("findings") or []
+        if not isinstance(findings, list):
+            findings = []
         out.append({
             "account": idx,
             "count": res.get("count"),
-            "fields": [r.get("field") for r in res.get("requirements", [])]
+            "fields": [r.get("field") for r in findings if isinstance(r, dict)]
         })
     print(json.dumps(out, ensure_ascii=False, indent=2))
 

--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -59,7 +59,7 @@ def test_writer_builds_pack_lines(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
@@ -67,16 +67,14 @@ def test_writer_builds_pack_lines(tmp_path: Path) -> None:
                     "documents": ["statement", "   "],
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "account_status",
                     "category": "status",
                     "ai_needed": False,
+                    "send_to_ai": False,
                 },
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True},
-                {"field": "account_status", "send_to_ai": False},
             ],
             "field_consistency": {
                 "balance_owed": {
@@ -155,17 +153,15 @@ def test_writer_uses_bureau_fallback(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "account_status",
                     "category": "status",
                     "strength": "soft",
                     "ai_needed": True,
                     "notes": "status mismatch",
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "account_status", "send_to_ai": True}
             ],
             "field_consistency": {},
         }
@@ -198,16 +194,14 @@ def test_writer_skips_strong_fields(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "payment_status",
                     "category": "status",
                     "strength": "strong",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "payment_status", "send_to_ai": True}
             ],
             "field_consistency": {},
         }
@@ -232,23 +226,21 @@ def test_writer_updates_index(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "account_status",
                     "category": "status",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True},
-                {"field": "account_status", "send_to_ai": True},
             ],
             "field_consistency": {
                 "balance_owed": {
@@ -289,8 +281,8 @@ def test_writer_updates_index(tmp_path: Path) -> None:
     assert isinstance(entry.get("source_hash"), str) and len(entry["source_hash"]) == 64
 
     # Update summary to remove one requirement and rebuild.
-    summary_payload["validation_requirements"]["requirements"] = [
-        summary_payload["validation_requirements"]["requirements"][0]
+    summary_payload["validation_requirements"]["findings"] = [
+        summary_payload["validation_requirements"]["findings"][0]
     ]
     _write_json(account_dir / "summary.json", summary_payload)
 
@@ -315,16 +307,14 @@ def _seed_validation_account(
     account_dir = runs_root / sid / "cases" / "accounts" / str(account_id)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": field,
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": field, "send_to_ai": True}
             ],
             "field_consistency": {
                 field: {"raw": {"transunion": "$100"}},
@@ -563,16 +553,14 @@ def test_build_validation_pack_respects_env_toggle(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {
                 "balance_owed": {"raw": {"transunion": "$100"}}
@@ -608,16 +596,14 @@ def test_build_validation_packs_for_run_auto_send(
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {
                 "balance_owed": {"raw": {"transunion": "$100"}}
@@ -663,16 +649,14 @@ def test_rewrite_index_to_canonical_layout(tmp_path: Path) -> None:
     account_dir = runs_root / sid / "cases" / "accounts" / "1"
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {
                 "balance_owed": {

--- a/tests/ai/test_validation_packs.py
+++ b/tests/ai/test_validation_packs.py
@@ -95,10 +95,9 @@ def test_pack_writer_emits_all_21_fields(tmp_path: Path, account_id: int) -> Non
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": requirements,
             "findings": [
-                {"field": field, "send_to_ai": True}
-                for field in ALL_VALIDATION_FIELDS
+                dict(requirement, send_to_ai=True)
+                for requirement in requirements
             ],
             "field_consistency": {},
         }
@@ -257,10 +256,9 @@ def reason_pack_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": requirements,
             "findings": [
-                {"field": field, "send_to_ai": True}
-                for field in field_patterns
+                dict(requirement, send_to_ai=True)
+                for requirement in requirements
             ],
             "field_consistency": field_consistency,
         }

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -47,17 +47,15 @@ def _build_manifest(tmp_path: Path, sid: str = "S001") -> tuple[dict[str, object
 
     summary = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "Account Status",
                     "strength": "weak",
                     "ai_needed": False,
                     "documents": ["statement"],
                     "category": "identity",
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "Account Status", "send_to_ai": True}
             ],
             "field_consistency": {},
         }
@@ -115,21 +113,19 @@ def test_builder_respects_summary_findings(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "account_type",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": False,
                 },
                 {
                     "field": "creditor_remarks",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
-            ],
-            "findings": [
-                {"field": "account_type", "send_to_ai": False},
-                {"field": "creditor_remarks", "send_to_ai": True},
             ],
             "field_consistency": {},
         }

--- a/tests/core/logic/test_validation_ai_packs.py
+++ b/tests/core/logic/test_validation_ai_packs.py
@@ -189,13 +189,14 @@ def test_builder_populates_pack_and_preserves_prompt_and_results(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "min_days": 30,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "payment_status",
@@ -203,6 +204,7 @@ def test_builder_populates_pack_and_preserves_prompt_and_results(
                     "min_days": 10,
                     "documents": [],
                     "ai_needed": False,
+                    "send_to_ai": False,
                 },
             ],
             "field_consistency": {
@@ -337,13 +339,14 @@ def test_builder_skips_when_source_unchanged(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "min_days": 30,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
             ],
             "field_consistency": {
@@ -430,13 +433,14 @@ def test_builder_uses_configured_model(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "account_status",
                     "category": "status",
                     "min_days": 10,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
             ],
             "field_consistency": {},
@@ -490,13 +494,14 @@ def test_builder_skips_when_write_disabled(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "account_status",
                     "category": "status",
                     "min_days": 3,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
             ],
             "field_consistency": {},
@@ -542,13 +547,14 @@ def test_builder_skips_inference_when_disabled(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "account_status",
                     "category": "status",
                     "min_days": 3,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
             ],
             "field_consistency": {},
@@ -596,13 +602,14 @@ def test_builder_honors_weak_limit(
     account_dir.mkdir(parents=True, exist_ok=True)
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "min_days": 30,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "account_status",
@@ -610,6 +617,7 @@ def test_builder_honors_weak_limit(
                     "min_days": 10,
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
             ],
             "field_consistency": {},

--- a/tests/test_validation_packs.py
+++ b/tests/test_validation_packs.py
@@ -71,13 +71,14 @@ def test_builds_pack_with_two_weak_fields(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "documents": ["statement"],
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "creditor_remarks",
@@ -86,11 +87,8 @@ def test_builds_pack_with_two_weak_fields(tmp_path: Path) -> None:
                     "ai_needed": True,
                     "notes": "recent remark change",
                     "conditional_gate": True,
+                    "send_to_ai": True,
                 },
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True},
-                {"field": "creditor_remarks", "send_to_ai": True},
             ],
             "field_consistency": {
                 "balance_owed": {
@@ -179,37 +177,35 @@ def test_removed_fields_are_never_emitted(tmp_path: Path) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "category": "activity",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "account_description",
                     "category": "status",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "dispute_status",
                     "category": "status",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "last_verified",
                     "category": "status",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True},
-                {"field": "account_description", "send_to_ai": True},
-                {"field": "dispute_status", "send_to_ai": True},
-                {"field": "last_verified", "send_to_ai": True},
             ],
             "field_consistency": {},
         }
@@ -300,15 +296,13 @@ def test_manifest_updated_after_first_pack(tmp_path: Path, monkeypatch) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 }
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True}
             ],
             "field_consistency": {},
         }
@@ -349,21 +343,19 @@ def test_build_validation_pack_idempotent(tmp_path: Path, monkeypatch) -> None:
 
     summary_payload = {
         "validation_requirements": {
-            "requirements": [
+            "findings": [
                 {
                     "field": "balance_owed",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
                 {
                     "field": "account_status",
                     "strength": "weak",
                     "ai_needed": True,
+                    "send_to_ai": True,
                 },
-            ],
-            "findings": [
-                {"field": "balance_owed", "send_to_ai": True},
-                {"field": "account_status", "send_to_ai": True},
             ],
             "field_consistency": {},
         }


### PR DESCRIPTION
## Summary
- default the validation summary to omit the legacy `requirements` array while keeping a backwards-compatibility toggle
- update validation pack builders and AI helpers to consume `findings` as the canonical requirement entries
- refresh validation-related tests and fixtures to align with the new summary payload shape

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py
- pytest tests/ai/test_validation_pack_writer.py
- pytest tests/ai/test_validation_packs.py
- pytest tests/backend/validation/test_manifest_schema.py
- pytest tests/core/logic/test_validation_ai_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68e02868484c83258bf0ee8db475f4c7