### PR TITLE
Refine validation findings payload schema

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -811,12 +811,7 @@ class ValidationPackWriter:
                 entry for entry in raw_findings if isinstance(entry, Mapping)
             ]
         else:
-            legacy_requirements = block.get("requirements")
-            if not isinstance(legacy_requirements, Sequence):
-                return None
-            findings_list = [
-                entry for entry in legacy_requirements if isinstance(entry, Mapping)
-            ]
+            return None
 
         consistency = block.get("field_consistency")
         consistency_map = (
@@ -926,10 +921,6 @@ class ValidationPackWriter:
             raw_findings: Sequence[Any] | None = validation_block.get("findings")
             if not isinstance(raw_findings, Sequence):
                 raw_findings = None
-            if raw_findings is None:
-                legacy_requirements = validation_block.get("requirements")
-                if isinstance(legacy_requirements, Sequence):
-                    raw_findings = list(legacy_requirements)
             send_to_ai_map = validation_block.get("send_to_ai", {})
             if isinstance(raw_findings, Sequence):
                 for entry in raw_findings:

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -244,10 +244,10 @@ def build_problem_cases_task(self, prev: dict | None = None, sid: str | None = N
             if isinstance(summary, dict):
                 summary["validation_requirements"] = stats
             log.info(
-                "VALIDATION_REQUIREMENTS_PIPELINE_DONE sid=%s processed=%s requirements=%s",
+                "VALIDATION_REQUIREMENTS_PIPELINE_DONE sid=%s processed=%s findings=%s",
                 sid,
                 stats.get("processed_accounts", 0),
-                stats.get("requirements", 0),
+                stats.get("findings", 0),
             )
 
     if os.environ.get("ENABLE_AUTO_AI_PIPELINE", "1") in ("1", "true", "True"):

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -2921,8 +2921,6 @@ def persist_merge_tags(
 
         findings_entries = validation_block.get("findings")
         if not isinstance(findings_entries, Sequence):
-            findings_entries = validation_block.get("requirements")
-        if not isinstance(findings_entries, Sequence):
             continue
 
         if any(

--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -510,11 +510,7 @@ def _collect_weak_items(summary: Mapping[str, Any] | None) -> list[dict[str, Any
 
     findings = validation.get("findings")
     if not isinstance(findings, Sequence):
-        legacy_requirements = validation.get("requirements")
-        if isinstance(legacy_requirements, Sequence):
-            findings = list(legacy_requirements)
-        else:
-            return []
+        return []
 
     field_consistency = validation.get("field_consistency")
     if isinstance(field_consistency, Mapping):
@@ -700,8 +696,6 @@ def _extract_weak_source_segment(
         validation = summary.get("validation_requirements")
         if isinstance(validation, Mapping):
             raw_findings = validation.get("findings")
-            if not isinstance(raw_findings, Sequence):
-                raw_findings = validation.get("requirements")
             if isinstance(raw_findings, Sequence):
                 for entry in raw_findings:
                     if not isinstance(entry, Mapping):

--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -68,7 +68,7 @@ def run_validation_requirements_for_all_accounts(
         "sid": sid,
         "total_accounts": 0,
         "processed_accounts": 0,
-        "requirements": 0,
+        "findings": 0,
         "missing_bureaus": 0,
         "errors": 0,
     }
@@ -99,14 +99,14 @@ def run_validation_requirements_for_all_accounts(
             continue
 
         stats["processed_accounts"] += 1
-        stats["requirements"] += int(result.get("count") or 0)
+        stats["findings"] += int(result.get("count") or 0)
 
     logger.info(
-        "VALIDATION_REQUIREMENTS_SUMMARY sid=%s accounts=%d processed=%d requirements=%d missing=%d errors=%d",
+        "VALIDATION_REQUIREMENTS_SUMMARY sid=%s accounts=%d processed=%d findings=%d missing=%d errors=%d",
         sid,
         stats["total_accounts"],
         stats["processed_accounts"],
-        stats["requirements"],
+        stats["findings"],
         stats["missing_bureaus"],
         stats["errors"],
     )

--- a/backend/pipeline/auto_ai_tasks.py
+++ b/backend/pipeline/auto_ai_tasks.py
@@ -545,10 +545,10 @@ def ai_validation_requirements_step(
     payload["validation_requirements"] = stats
 
     logger.info(
-        "AI_VALIDATION_REQUIREMENTS_END sid=%s processed=%d requirements=%d",
+        "AI_VALIDATION_REQUIREMENTS_END sid=%s processed=%d findings=%d",
         sid,
         stats.get("processed_accounts", 0),
-        stats.get("requirements", 0),
+        stats.get("findings", 0),
     )
 
     return payload

--- a/backend/pipeline/steps/validation_requirements_step.py
+++ b/backend/pipeline/steps/validation_requirements_step.py
@@ -35,4 +35,7 @@ def run(account_dir: str) -> dict:
     except Exception as exc:  # pragma: no cover - defensive logging path
         return {"skipped": True, "reason": f"write_error:{exc}"}
 
-    return {"skipped": False, "requirements_count": req.get("count")}
+    return {
+        "skipped": False,
+        "findings_count": int(req.get("count") or 0),
+    }

--- a/backend/validation/build_packs.py
+++ b/backend/validation/build_packs.py
@@ -123,18 +123,14 @@ class ValidationPackBuilder:
 
         findings = validation_block.get("findings")
         if not isinstance(findings, Sequence):
-            legacy_requirements = validation_block.get("requirements")
-            if isinstance(legacy_requirements, Sequence):
-                findings = list(legacy_requirements)
-            else:
-                return [], {"skip_reason": "missing_findings"}
+            return [], {"skip_reason": "missing_findings"}
 
         field_consistency = validation_block.get("field_consistency")
         if not isinstance(field_consistency, Mapping):
             field_consistency = {}
 
         send_to_ai_map = self._build_send_to_ai_map(
-            validation_block.get("findings")
+            findings
         )
         has_enriched_findings = bool(send_to_ai_map)
 

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -88,6 +88,7 @@ def test_build_summary_payload_includes_field_consistency():
         requirements, field_consistency=field_consistency
     )
 
+    assert payload["schema_version"] == 3
     assert payload["count"] == 1
     expected_consistency = {
         "balance_owed": {
@@ -138,6 +139,7 @@ def test_build_summary_payload_can_disable_reason_enrichment(monkeypatch):
         requirements, field_consistency=field_consistency
     )
 
+    assert payload["schema_version"] == 3
     assert payload["count"] == 1
     assert len(payload["findings"]) == 1
     assert payload["findings"][0]["field"] == "balance_owed"
@@ -441,6 +443,7 @@ def test_build_validation_requirements_for_account_respects_summary_consensus(
 
     summary_after = json.loads(summary_path.read_text(encoding="utf-8"))
     validation_block = summary_after["validation_requirements"]
+    assert validation_block["schema_version"] == 3
     assert validation_block["count"] == 0
     assert validation_block["findings"] == []
     assert "requirements" not in validation_block
@@ -543,6 +546,7 @@ def test_apply_validation_summary_and_sync_validation_tag(tmp_path):
     apply_validation_summary(summary_path, payload)
     summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
     validation_block = summary_data["validation_requirements"]
+    assert validation_block["schema_version"] == 3
     assert validation_block["count"] == 1
     assert summary_data["existing"] is True
     assert "requirements" not in validation_block
@@ -601,6 +605,7 @@ def test_build_validation_requirements_for_account_writes_summary_and_tags(
     assert result["count"] == 2
     assert set(result["fields"]) == {"balance_owed", "payment_status"}
     validation_payload = result["validation_requirements"]
+    assert validation_payload["schema_version"] == 3
     assert validation_payload["count"] == 2
     assert "requirements" not in validation_payload
     assert {entry["field"] for entry in validation_payload["findings"]} == {
@@ -614,6 +619,7 @@ def test_build_validation_requirements_for_account_writes_summary_and_tags(
     summary = json.loads((account_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["existing"] is True
     validation_block = summary["validation_requirements"]
+    assert validation_block["schema_version"] == 3
     assert validation_block["count"] == 2
     assert "requirements" not in validation_block
     assert {entry["field"] for entry in validation_block["findings"]} == {
@@ -683,6 +689,7 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
     assert result["count"] == 0
     assert result["fields"] == []
     validation_payload = result["validation_requirements"]
+    assert validation_payload["schema_version"] == 3
     assert validation_payload["count"] == 0
     assert "requirements" not in validation_payload
     assert validation_payload["findings"] == []
@@ -693,6 +700,7 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
 
     summary = json.loads((account_dir / "summary.json").read_text(encoding="utf-8"))
     validation_block = summary["validation_requirements"]
+    assert validation_block["schema_version"] == 3
     assert validation_block["count"] == 0
     assert "requirements" not in validation_block
     assert validation_block["findings"] == []


### PR DESCRIPTION
## Summary
- drop the legacy `requirements` array from the validation summary payload, add schema version 3, and ensure counts come from findings
- update validation pack builders, AI helpers, and pipeline stats to consume the findings list exclusively and rename requirement counters to findings
- expand validation requirement tests to cover the new schema version and findings-only structure

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py
- pytest tests/test_validation_packs.py
- pytest tests/ai/test_validation_pack_writer.py
- pytest tests/pipeline/test_auto_ai.py -k validation --maxfail=1 *(fails: missing optional requests dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68e02bbf6b3c832594c7056a76c2d7d6