### PR TITLE
Limit validation summary to findings by default

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -866,6 +866,9 @@ def build_summary_payload(
         "count": len(findings),
     }
 
+    if _include_legacy_requirements():
+        payload["requirements"] = normalized_requirements
+
     if field_consistency:
         if reasons_enabled:
             sanitized_consistency = _strip_raw_from_field_consistency(field_consistency)

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -112,6 +112,57 @@ def test_build_summary_payload_includes_field_consistency():
     assert finding["send_to_ai"] is False
 
 
+def test_build_summary_payload_can_optionally_include_legacy_requirements(monkeypatch):
+    monkeypatch.setenv("VALIDATION_SUMMARY_INCLUDE_REQUIREMENTS", "1")
+
+    requirements = [
+        {
+            "field": "balance_owed",
+            "category": "activity",
+            "min_days": 8,
+            "documents": ["monthly_statement"],
+            "strength": "strong",
+            "ai_needed": False,
+            "bureaus": ["experian", "transunion"],
+        },
+        {
+            "field": "account_status",
+            "category": "status",
+            "min_days": 10,
+            "documents": ["account_statement"],
+            "strength": "soft",
+            "ai_needed": True,
+            "bureaus": ["experian", "equifax"],
+        },
+    ]
+
+    payload = build_summary_payload(requirements)
+
+    assert payload["schema_version"] == 3
+    assert payload["count"] == 2
+    assert payload["findings"]
+    assert payload["requirements"] == [
+        {
+            "field": "balance_owed",
+            "category": "activity",
+            "min_days": 8,
+            "documents": ["monthly_statement"],
+            "strength": "strong",
+            "ai_needed": False,
+            "bureaus": ["experian", "transunion"],
+        },
+        {
+            "field": "account_status",
+            "category": "status",
+            "min_days": 10,
+            "documents": ["account_statement"],
+            "strength": "soft",
+            "ai_needed": True,
+            "bureaus": ["experian", "equifax"],
+        },
+    ]
+
+
 def test_build_summary_payload_can_disable_reason_enrichment(monkeypatch):
     monkeypatch.setenv("VALIDATION_REASON_ENABLED", "0")
 


### PR DESCRIPTION
## Summary
- gate the legacy validation requirements list behind VALIDATION_SUMMARY_INCLUDE_REQUIREMENTS so findings remain the single default source
- exercise the new flag in unit tests to ensure the optional list is emitted only when requested

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py::test_build_summary_payload_includes_field_consistency tests/backend/core/logic/test_validation_requirements.py::test_build_summary_payload_can_optionally_include_legacy_requirements

------
https://chatgpt.com/codex/tasks/task_b_68e030e471ac8325ab5191b4b148bada