### PR TITLE
Ensure validation pipelines process all accounts

### DIFF
--- a/backend/core/logic/tags/compact.py
+++ b/backend/core/logic/tags/compact.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from itertools import islice
 from os import PathLike
 from pathlib import Path
 from typing import Any, Iterable, Mapping, MutableMapping, Sequence, Union
@@ -42,13 +41,11 @@ log = logging.getLogger(__name__)
 
 
 def _maybe_slice(iterable: Iterable[Path]) -> Iterable[Path]:
-    """Optionally limit iteration via the ``DEBUG_FIRST_N`` env toggle."""
+    """Return ``iterable`` unchanged so tag compaction covers all accounts."""
 
     debug_first_n = os.getenv("DEBUG_FIRST_N", "").strip()
-    if debug_first_n and debug_first_n.isdigit():
-        limit = int(debug_first_n)
-        if limit > 0:
-            return islice(iterable, limit)
+    if debug_first_n:
+        log.debug("DEBUG_FIRST_N=%s ignored for tag compaction", debug_first_n)
     return iterable
 
 

--- a/backend/core/logic/validation_ai_packs.py
+++ b/backend/core/logic/validation_ai_packs.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
-from itertools import islice
 from pathlib import Path
 import textwrap
 from typing import Any, Iterable, Mapping, Sequence
@@ -38,13 +37,13 @@ _DEFAULT_RETRY_BACKOFF = (1.0, 3.0, 10.0)
 
 
 def _maybe_slice(iterable: Iterable[int]) -> Iterable[int]:
-    """Optionally truncate ``iterable`` based on ``DEBUG_FIRST_N``."""
+    """Return ``iterable`` unchanged so every account index is handled."""
 
     debug_first_n = os.getenv("DEBUG_FIRST_N", "").strip()
-    if debug_first_n and debug_first_n.isdigit():
-        limit = int(debug_first_n)
-        if limit > 0:
-            return islice(iterable, limit)
+    if debug_first_n:
+        log.debug(
+            "DEBUG_FIRST_N=%s ignored for validation AI packs", debug_first_n
+        )
     return iterable
 
 

--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import time
-from itertools import islice
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,13 +42,13 @@ DEFAULT_INFLIGHT_TTL_SECONDS = 30 * 60
 
 
 def _maybe_slice(iterable: Iterable[object]) -> Iterable[object]:
-    """Optionally limit ``iterable`` to the first ``DEBUG_FIRST_N`` items."""
+    """Return ``iterable`` unchanged to ensure all accounts are processed."""
 
     debug_first_n = os.getenv("DEBUG_FIRST_N", "").strip()
-    if debug_first_n and debug_first_n.isdigit():
-        limit = int(debug_first_n)
-        if limit > 0:
-            return islice(iterable, limit)
+    if debug_first_n:
+        logger.debug(
+            "DEBUG_FIRST_N=%s ignored; processing all items", debug_first_n
+        )
     return iterable
 
 


### PR DESCRIPTION
## Summary
- ignore DEBUG_FIRST_N slicing in the auto AI validation pass so every account is processed while logging when the env toggle is set
- remove debug slicing from validation AI pack generation to cover the full account index and note when DEBUG_FIRST_N is ignored
- ensure tag compaction iterates all accounts regardless of DEBUG_FIRST_N, logging when the toggle is present

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68e03b8f578c8325ad4b4623a9ba7ce5