### PR TITLE
Add validation pack build stats and guard per-account iteration

### DIFF
--- a/devtools/run_build_validation_packs.py
+++ b/devtools/run_build_validation_packs.py
@@ -175,7 +175,7 @@ def main() -> None:
     account_indices = _iter_account_indices(accounts_root)
 
     with _InferenceOverride(args.no_infer):
-        validation_ai_packs.build_validation_ai_packs_for_accounts(
+        pack_stats = validation_ai_packs.build_validation_ai_packs_for_accounts(
             sid,
             account_indices=account_indices,
             runs_root=runs_root,
@@ -210,6 +210,7 @@ def main() -> None:
             "backoff_seconds": list(effective_config.backoff_seconds),
         },
         "accounts_processed": len(account_indices),
+        "pack_stats": pack_stats,
         "status_counts": status_counts,
         "weak_accounts": weak_accounts,
         "weak_item_total": weak_total,


### PR DESCRIPTION
## Summary
- add per-account statistics reporting and defensive logging to validation AI pack generation to ensure loops continue on errors or skipped accounts
- log build summaries for legacy validation pack writer to highlight totals, written, skipped, and error counts
- expose build statistics to devtools runner and extend tests to cover new iteration safeguards

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py


------
https://chatgpt.com/codex/tasks/task_b_68e044b20c948325a603da9a586dde67