### PR TITLE
Ensure validation summaries always include findings block

### DIFF
--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -89,7 +89,6 @@ def test_build_summary_payload_includes_field_consistency():
     )
 
     assert payload["schema_version"] == 3
-    assert payload["count"] == 1
     expected_consistency = {
         "balance_owed": {
             "consensus": "split",
@@ -139,7 +138,6 @@ def test_build_summary_payload_can_optionally_include_legacy_requirements(monkey
     payload = build_summary_payload(requirements)
 
     assert payload["schema_version"] == 3
-    assert payload["count"] == 2
     assert payload["findings"]
     assert payload["requirements"] == [
         {
@@ -191,7 +189,6 @@ def test_build_summary_payload_can_disable_reason_enrichment(monkeypatch):
     )
 
     assert payload["schema_version"] == 3
-    assert payload["count"] == 1
     assert len(payload["findings"]) == 1
     assert payload["findings"][0]["field"] == "balance_owed"
     assert "reason_code" not in payload["findings"][0]
@@ -269,7 +266,7 @@ def test_build_summary_payload_reason_codes_send_to_ai(
     )
 
     assert "findings" in payload
-    assert payload["count"] == 1
+    assert len(payload["findings"]) == 1
 
     finding = payload["findings"][0]
     assert finding["field"] == field
@@ -495,7 +492,6 @@ def test_build_validation_requirements_for_account_respects_summary_consensus(
     summary_after = json.loads(summary_path.read_text(encoding="utf-8"))
     validation_block = summary_after["validation_requirements"]
     assert validation_block["schema_version"] == 3
-    assert validation_block["count"] == 0
     assert validation_block["findings"] == []
     assert "requirements" not in validation_block
     assert (
@@ -598,7 +594,6 @@ def test_apply_validation_summary_and_sync_validation_tag(tmp_path):
     summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
     validation_block = summary_data["validation_requirements"]
     assert validation_block["schema_version"] == 3
-    assert validation_block["count"] == 1
     assert summary_data["existing"] is True
     assert "requirements" not in validation_block
     assert len(validation_block["findings"]) == 1
@@ -618,7 +613,6 @@ def test_apply_validation_summary_and_sync_validation_tag(tmp_path):
     summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
     validation_block = summary_data["validation_requirements"]
     assert validation_block["schema_version"] == 3
-    assert validation_block["count"] == 0
     assert validation_block["findings"] == []
 
     sync_validation_tag(tag_path, [], emit=True)
@@ -660,7 +654,6 @@ def test_build_validation_requirements_for_account_writes_summary_and_tags(
     assert set(result["fields"]) == {"balance_owed", "payment_status"}
     validation_payload = result["validation_requirements"]
     assert validation_payload["schema_version"] == 3
-    assert validation_payload["count"] == 2
     assert "requirements" not in validation_payload
     assert {entry["field"] for entry in validation_payload["findings"]} == {
         "balance_owed",
@@ -674,7 +667,6 @@ def test_build_validation_requirements_for_account_writes_summary_and_tags(
     assert summary["existing"] is True
     validation_block = summary["validation_requirements"]
     assert validation_block["schema_version"] == 3
-    assert validation_block["count"] == 2
     assert "requirements" not in validation_block
     assert {entry["field"] for entry in validation_block["findings"]} == {
         "balance_owed",
@@ -708,7 +700,6 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
     seed_summary = {
         "field_consistency": compute_field_consistency(consistent),
         "validation_requirements": {
-            "count": 1,
             "findings": [
                 {
                     "field": "balance_owed",
@@ -744,7 +735,6 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
     assert result["fields"] == []
     validation_payload = result["validation_requirements"]
     assert validation_payload["schema_version"] == 3
-    assert validation_payload["count"] == 0
     assert "requirements" not in validation_payload
     assert validation_payload["findings"] == []
     assert "field_consistency" in validation_payload
@@ -755,7 +745,6 @@ def test_build_validation_requirements_for_account_clears_when_empty(tmp_path, m
     summary = json.loads((account_dir / "summary.json").read_text(encoding="utf-8"))
     validation_block = summary["validation_requirements"]
     assert validation_block["schema_version"] == 3
-    assert validation_block["count"] == 0
     assert "requirements" not in validation_block
     assert validation_block["findings"] == []
     assert "balance_owed" in validation_block["field_consistency"]
@@ -811,7 +800,6 @@ def test_build_validation_requirements_writes_summary_when_missing(tmp_path, mon
     assert pointers["bureaus"] == "bureaus.json"
 
     validation_block = summary["validation_requirements"]
-    assert validation_block["count"] == 0
     assert validation_block["findings"] == []
 
 


### PR DESCRIPTION
## Summary
- add a dedicated `build_findings` helper and respect the new REQUIREMENTS_WRITE_EMPTY flag when writing validation summaries
- drop the legacy `count` field from the validation_requirements block while keeping schema_version/findings only and update the pipeline writer accordingly
- refresh validation requirement tests to cover the new summary layout and error-handling expectations

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68e04c37a174832596bf358eef37e307