### PR TITLE
Handle missing packs without blocking summaries

### DIFF
--- a/backend/validation/pipeline.py
+++ b/backend/validation/pipeline.py
@@ -136,12 +136,20 @@ def build_and_queue_packs(
         return []
 
     builder = config.pack_builder or _default_pack_builder
-    pack_lines = builder(
-        acc_ctx.sid,
-        acc_ctx.index,
-        acc_ctx.summary_path,
-        acc_ctx.bureaus_path,
-    )
+    try:
+        pack_lines = builder(
+            acc_ctx.sid,
+            acc_ctx.index,
+            acc_ctx.summary_path,
+            acc_ctx.bureaus_path,
+        )
+    except Exception:  # pragma: no cover - defensive pack builder guard
+        log.exception(
+            "VALIDATION_PACK_BUILD_FAILED sid=%s account_id=%s",
+            acc_ctx.sid,
+            acc_ctx.account_id,
+        )
+        return []
 
     callback = config.send_callback
     if callback is not None:

--- a/backend/validation/send_packs.py
+++ b/backend/validation/send_packs.py
@@ -711,6 +711,44 @@ class ValidationPackSender:
                 if normalized_account is not None
                 else str(account_id)
             )
+
+            if account.pack_missing:
+                missing_display = pack_relative or self._display_path(
+                    resolved_pack, base=index.index_dir
+                )
+                error_message = f"Pack file missing: {missing_display}"
+                log.warning(
+                    "VALIDATION_PACK_MISSING sid=%s account_id=%s pack=%s",
+                    self.sid,
+                    account_label,
+                    missing_display,
+                )
+                if normalized_account is None:
+                    self._log(
+                        "send_account_failed",
+                        account_id=str(account_id),
+                        error=error_message,
+                    )
+                    continue
+
+                self._log(
+                    "send_account_failed",
+                    account_id=f"{normalized_account:03d}",
+                    error=error_message,
+                )
+                account_summary = self._record_account_failure(
+                    normalized_account,
+                    resolved_pack,
+                    pack_relative,
+                    result_jsonl_path,
+                    result_jsonl_relative,
+                    result_json_path,
+                    result_json_relative,
+                    error_message,
+                )
+                results.append(account_summary)
+                continue
+
             log.info(
                 "PROCESSING account_id=%s pack=%s result_json=%s",
                 account_label,


### PR DESCRIPTION
## Summary
- guard pack building so failures are logged and do not abort the summary pipeline
- skip validation pack sending when the pack file is missing while recording a failure result

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0526135b083259f62b12d47fd2b27