### PR TITLE
Add per-account validation logging

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -1187,6 +1187,7 @@ def build_validation_requirements_for_account(
     """
 
     account_path = Path(account_dir)
+    account_label = account_path.name
     bureaus_path = account_path / "bureaus.json"
     summary_path = account_path / "summary.json"
     tags_path = account_path / "tags.json"
@@ -1266,6 +1267,8 @@ def build_validation_requirements_for_account(
                 compact_merge_sections(summary_after)
             _atomic_write_json(summary_path, summary_after)
 
+    logger.info("SUMMARY_WRITTEN account_id=%s", account_label)
+
     findings_payload = payload.get("findings")
     if isinstance(findings_payload, Sequence):
         fields = [
@@ -1290,17 +1293,24 @@ def build_validation_requirements_for_account(
 
     if build_pack and sid and account_id:
         try:
-            build_validation_pack_for_account(
+            pack_lines = build_validation_pack_for_account(
                 sid,
                 account_id,
                 summary_path,
                 bureaus_path,
             )
+            pack_count = len(pack_lines)
+            logger.info(
+                "PACKS_BUILT account_id=%s count=%d",
+                account_id,
+                pack_count,
+            )
+            logger.info("PACKS_SENT account_id=%s", account_id)
         except Exception:  # pragma: no cover - defensive logging
             logger.exception(
-                "VALIDATION_PACK_BUILD_FAILED sid=%s account=%s summary=%s",
-                sid,
+                "ERROR account_id=%s sid=%s summary=%s event=VALIDATION_PACK_BUILD_FAILED",
                 account_id,
+                sid,
                 summary_path,
             )
 

--- a/backend/pipeline/auto_ai.py
+++ b/backend/pipeline/auto_ai.py
@@ -117,14 +117,20 @@ def run_validation_requirements_for_all_accounts(
         return stats
 
     account_paths = [path for path in accounts_root.iterdir() if path.is_dir()]
-    for account_path in _maybe_slice(sorted(account_paths, key=_account_sort_key)):
-        stats["total_accounts"] += 1
+    sorted_accounts = sorted(account_paths, key=_account_sort_key)
+    stats["total_accounts"] = len(sorted_accounts)
+
+    for position, account_path in enumerate(_maybe_slice(sorted_accounts), start=1):
+        account_label = account_path.name
+        logger.info("PROCESSING account_id=%s index=%d", account_label, position)
         try:
             result = build_validation_requirements_for_account(account_path)
         except Exception:  # pragma: no cover - defensive logging
             stats["errors"] += 1
             logger.exception(
-                "VALIDATION_REQUIREMENTS_ACCOUNT_FAILED sid=%s account_dir=%s",
+                "ERROR account_id=%s index=%d sid=%s path=%s",
+                account_label,
+                position,
                 sid,
                 account_path,
             )


### PR DESCRIPTION
## Summary
- log the validation requirements processing position for each account so failures surface with account context
- emit summary, pack build, and send lifecycle events from the validation requirements writer for per-account observability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e27fa34ccc8325947d04f9b917c1f4