### PR TITLE
Align AI routing with semantic field trio

### DIFF
--- a/backend/core/logic/reason_classifier.py
+++ b/backend/core/logic/reason_classifier.py
@@ -117,7 +117,7 @@ def classify_reason(bureau_values: Mapping[str, Any]) -> Mapping[str, Any]:
     }
 
 
-_AI_FIELDS = {"account_type", "account_rating", "creditor_remarks"}
+_AI_FIELDS = {"account_type", "account_rating", "creditor_type"}
 _AI_ALLOWED_REASONS = {"C3", "C4", "C5"}
 
 

--- a/tests/backend/core/logic/test_reason_classifier.py
+++ b/tests/backend/core/logic/test_reason_classifier.py
@@ -113,8 +113,9 @@ def test_normalizes_whitespace_and_missing_markers():
     [
         ("account_type", "C3_TWO_PRESENT_CONFLICT", True),
         ("account_rating", {"reason_code": "C4_TWO_MATCH_ONE_DIFF"}, True),
-        ("creditor_remarks", "C5_ALL_DIFF", True),
+        ("creditor_type", "C5_ALL_DIFF", True),
         ("account_type", "C1_TWO_PRESENT_ONE_MISSING", False),
+        ("creditor_type", "C2_ONE_MISSING", False),
         ("balance", "C3_TWO_PRESENT_CONFLICT", False),
         ("account_rating", {}, False),
     ],


### PR DESCRIPTION
## Summary
- restrict AI escalation eligibility to account_type, creditor_type, and account_rating
- ensure creditor_type participates in AI routing tests and block creditor_remarks

## Testing
- pytest tests/backend/core/logic/test_reason_classifier.py

------
https://chatgpt.com/codex/tasks/task_b_68e2c4d5155c8325a5c119711ad72be4