### PR TITLE
Add last verified validation rule and improve date normalization

### DIFF
--- a/backend/core/logic/validation_config.yml
+++ b/backend/core/logic/validation_config.yml
@@ -166,6 +166,14 @@ fields:
     min_corroboration: 2
     conditional_gate: true
 
+  last_verified:
+    category: status
+    min_days: 6
+    points: 4
+    documents: [cra_report, cra_reporting_log, monthly_statement]
+    strength: strong
+    ai_needed: false
+
   date_reported:
     category: status
     min_days: 3


### PR DESCRIPTION
## Summary
- add last_verified to the status validation rules so missing data generates findings per policy
- extend date normalization to cover ISO formats, two-digit years, and normalize last_verified as a date field

## Testing
- pytest tests/report_analysis/test_report_parsing.py::test_normalize_date_formats -q

------
https://chatgpt.com/codex/tasks/task_b_68e2cf0b6110832587cdbab1797f3c67