### PR TITLE
Document validation env toggles and default tolerances

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -132,7 +132,16 @@ _ALLOWED_CATEGORIES: frozenset[str] = frozenset(
 
 
 def _reasons_enabled() -> bool:
-    return os.getenv("VALIDATION_REASON_ENABLED") == "1"
+    raw = os.getenv("VALIDATION_REASON_ENABLED", "1")
+    if raw is None:
+        return True
+
+    lowered = raw.strip().lower()
+    if lowered in {"1", "true", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "n", "off"}:
+        return False
+    return True
 
 
 @dataclass(frozen=True)

--- a/backend/ai/validation_results.py
+++ b/backend/ai/validation_results.py
@@ -32,7 +32,16 @@ _BUREAUS: tuple[str, ...] = ("transunion", "experian", "equifax")
 
 
 def _reasons_enabled() -> bool:
-    return os.getenv("VALIDATION_REASON_ENABLED") == "1"
+    raw = os.getenv("VALIDATION_REASON_ENABLED", "1")
+    if raw is None:
+        return True
+
+    lowered = raw.strip().lower()
+    if lowered in {"1", "true", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "n", "off"}:
+        return False
+    return True
 
 
 def _clone_jsonish(value: Any) -> Any:

--- a/backend/core/logic/report_analysis/account_merge.py
+++ b/backend/core/logic/report_analysis/account_merge.py
@@ -384,7 +384,7 @@ _TRIGGER_DEFAULTS: Dict[str, Union[int, str, bool]] = {
 _TOLERANCE_DEFAULTS: Dict[str, Union[int, float]] = {
     "AMOUNT_TOL_ABS": 50.0,
     "AMOUNT_TOL_RATIO": 0.01,
-    "LAST_PAYMENT_DAY_TOL": 7,
+    "LAST_PAYMENT_DAY_TOL": 5,
     "COUNT_ZERO_PAYMENT_MATCH": 0,
     "CA_DATE_MONTH_TOL": 6,
 }

--- a/backend/core/logic/report_analysis/ai_packs.py
+++ b/backend/core/logic/report_analysis/ai_packs.py
@@ -428,7 +428,7 @@ def _tolerance_hint() -> Mapping[str, float | int]:
     return {
         "amount_abs_usd": _get_float("AMOUNT_TOL_ABS", 50.0),
         "amount_ratio": _get_float("AMOUNT_TOL_RATIO", 0.01),
-        "last_payment_day_tol": _get_int("LAST_PAYMENT_DAY_TOL", 7),
+        "last_payment_day_tol": _get_int("LAST_PAYMENT_DAY_TOL", 5),
     }
 
 

--- a/docs/README_validation.md
+++ b/docs/README_validation.md
@@ -1,0 +1,62 @@
+# Validation Workflow Overview
+
+The validation pipeline evaluates bureau discrepancies in two passes: deterministic
+screening to detect "missing" reports versus "mismatched" values, followed by
+optional AI adjudication for semantic disagreements. All logic shares the same
+normalisation rules so that bureau data is compared on an even footing before
+any escalation decisions are made.
+
+## Findings without AI
+
+* **Missing** – Only the 18 deterministic fields participate. When at least one
+  bureau reports a value and another bureau omits it entirely we create a
+  *Missing* finding. Packs are never created for these cases and the AI path is
+  skipped entirely.
+* **Deterministic mismatches** – Amounts, dates, enumerations and history blocks
+  are reconciled with pure code. Normalisation includes tolerance windows (see
+  below) so that equivalent reporting formats do not escalate.
+
+## AI escalation
+
+Only three semantic fields may route to AI: `account_type`, `creditor_type` and
+`account_rating`. After normalisation, a mismatch on any of these fields sets
+`send_to_ai=true` and generates a validation pack when the validation packs
+feature flag is enabled. The associated reason codes are limited to the C3/C4/C5
+series and packs are never generated for missing data.
+
+## Environment configuration
+
+The behaviour of the validation pipeline can be tuned through the following
+environment variables. Each reader falls back to the documented default when no
+value is supplied.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AMOUNT_TOL_ABS` | `50` | Absolute USD tolerance for amount mismatches. |
+| `AMOUNT_TOL_RATIO` | `0.01` | Relative ratio tolerance for amount mismatches. |
+| `LAST_PAYMENT_DAY_TOL` | `5` | Day window applied when comparing payment dates. |
+| `VALIDATION_PACKS_ENABLED` | `1` | Toggle to build validation packs. |
+| `VALIDATION_REASON_ENABLED` | `1` | Enables reason capture and observability logging. |
+| `VALIDATION_INCLUDE_CREDITOR_REMARKS` | `0` | Optional toggle to include `creditor_remarks` validation (disabled by default). |
+
+Boolean toggles accept the standard set of truthy values (`1`, `true`, `yes`,
+`on`, `y`) and falsy values (`0`, `false`, `no`, `off`, `n`). Unrecognised inputs
+fall back to their defaults so a misconfigured deployment will not disable
+critical observability.
+
+These flags are consumed by both the deterministic merge layer and the AI pack
+builders. For example, tolerance defaults flow into the merge configuration used
+by `account_merge.get_merge_cfg`, while `_reasons_enabled()` and
+`_packs_enabled()` in the AI path read their respective toggles when deciding
+whether to attach packs, send them automatically, and emit reason codes.
+
+## History normalisation
+
+Payment history blocks are compared after removing empty dictionaries so that
+missing data is not incorrectly treated as a mismatch. This keeps the focus on
+substantive discrepancies and aligns with our policy to exclude `creditor_remarks`
+from the validation scope entirely.
+
+For deeper implementation details explore the modules under
+`backend/core/logic/report_analysis/` and `backend/ai/` which contain the
+configuration readers and pack builders.

--- a/scripts/_build_ai_packs_quick.py
+++ b/scripts/_build_ai_packs_quick.py
@@ -77,7 +77,7 @@ def build_prompt(pair_summary, context_a, context_b):
         "tolerances_hint": {
             "amount_abs_usd": int(os.environ.get("AMOUNT_TOL_ABS","50")),
             "amount_ratio": float(os.environ.get("AMOUNT_TOL_RATIO","0.01")),
-            "last_payment_day_tol": int(os.environ.get("LAST_PAYMENT_DAY_TOL","7"))
+            "last_payment_day_tol": int(os.environ.get("LAST_PAYMENT_DAY_TOL","5"))
         },
         "context": {
             "a": context_a,

--- a/tests/report_analysis/test_merge_cfg.py
+++ b/tests/report_analysis/test_merge_cfg.py
@@ -32,7 +32,7 @@ def test_get_merge_cfg_defaults(monkeypatch):
     assert cfg.triggers["MERGE_AI_ON_ALL_DATES"] is True
     assert cfg.tolerances["AMOUNT_TOL_ABS"] == 50.0
     assert cfg.tolerances["AMOUNT_TOL_RATIO"] == 0.01
-    assert cfg.tolerances["LAST_PAYMENT_DAY_TOL"] == 7
+    assert cfg.tolerances["LAST_PAYMENT_DAY_TOL"] == 5
     assert cfg.tolerances["COUNT_ZERO_PAYMENT_MATCH"] == 0
 
 


### PR DESCRIPTION
## Summary
- add documentation describing validation workflow, AI routing rules, and environment toggles
- align validation tolerance defaults with configuration (5 day last payment tolerance) and ensure env readers honour boolean defaults
- update helper scripts and tests to reflect the new defaults

## Testing
- pytest tests/report_analysis/test_merge_cfg.py

------
https://chatgpt.com/codex/tasks/task_b_68e2d1a6ef9883259a989c4ad54ddbba