### PR TITLE
Remove dead dispute status normalization hooks

### DIFF
--- a/backend/core/logic/consistency.py
+++ b/backend/core/logic/consistency.py
@@ -126,18 +126,6 @@ _ENUM_DOMAINS: Dict[str, Dict[str, str]] = {
         "bankmortgageloans": "mortgage_lender",
         "savingsandloansmortgage": "mortgage_lender",
     },
-    "dispute_status": {
-        "disputed": "disputed",
-        "indispute": "disputed",
-        "dispute": "disputed",
-        "open_dispute": "disputed",
-        "notdisputed": "not_disputed",
-        "nodispute": "not_disputed",
-        "undisputed": "not_disputed",
-        "resolved": "resolved",
-        "closed": "resolved",
-        "previouslydisputed": "previously_disputed",
-    },
 }
 
 _HISTORY_FIELDS = {"two_year_payment_history", "seven_year_history"}

--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -642,13 +642,6 @@ def _determine_account_number_strength(normalized: Mapping[str, Any]) -> tuple[s
     return "soft", True
 
 
-def _determine_dispute_strength(normalized: Mapping[str, Any]) -> tuple[str, bool]:
-    seen = {str(value) for value in normalized.values() if value is not None}
-    if len(seen) > 1 or _has_missing_mismatch(normalized):
-        return "strong", False
-    return "strong", False
-
-
 def _apply_strength_policy(
     field: str, details: Mapping[str, Any], rule: ValidationRule
 ) -> ValidationRule:
@@ -669,8 +662,6 @@ def _apply_strength_policy(
         strength, ai_needed = "strong", False
     elif _is_numeric_field(field, normalized):
         strength, ai_needed = "strong", False
-    elif field == "dispute_status":
-        strength, ai_needed = _determine_dispute_strength(normalized)
     elif _has_missing_mismatch(normalized) and strength != "strong":
         strength = "medium"
 


### PR DESCRIPTION
## Summary
- drop the unused dispute_status enum mapping from the consistency normalizer
- remove the dead dispute_status strength handler from validation requirements

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68e2d45e789c8325a89f7dcbf14e56ee