### PR TITLE
Add validation findings snapshots for deterministic fixtures

### DIFF
--- a/tests/backend/core/logic/snapshots/validation_findings/account-11.json
+++ b/tests/backend/core/logic/snapshots/validation_findings/account-11.json
@@ -1,0 +1,514 @@
+{
+  "findings": [
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": true,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "monthly_statement",
+        "collection_report"
+      ],
+      "field": "account_number_display",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 2,
+      "min_days": 2,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": true,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report",
+        "cra_audit_log"
+      ],
+      "field": "account_rating",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 2,
+      "min_days": 18,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "cra_report",
+        "cra_audit_log"
+      ],
+      "field": "account_status",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "monthly_statement"
+      ],
+      "field": "account_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 2,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "balance_report",
+        "collection_report"
+      ],
+      "field": "balance_owed",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "closure_letter",
+        "internal_closure_report"
+      ],
+      "field": "closed_date",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "credit_line_agreement",
+        "limit_change_record",
+        "monthly_statement"
+      ],
+      "field": "credit_limit",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "lender_agreement",
+        "cra_report"
+      ],
+      "field": "creditor_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statement",
+        "system_activity_log",
+        "internal_report"
+      ],
+      "field": "date_of_last_activity",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "system_audit_log"
+      ],
+      "field": "date_opened",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "cra_reporting_log",
+        "cra_report"
+      ],
+      "field": "date_reported",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "loan_agreement",
+        "monthly_statement",
+        "internal_balance_report"
+      ],
+      "field": "high_balance",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statement",
+        "payment_receipt",
+        "internal_payment_log"
+      ],
+      "field": "last_payment",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report",
+        "cra_reporting_log",
+        "monthly_statement"
+      ],
+      "field": "last_verified",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "collection_report",
+        "delinquency_notice"
+      ],
+      "field": "past_due_amount",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "loan_agreement",
+        "amortization_schedule",
+        "monthly_statement"
+      ],
+      "field": "payment_amount",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 5,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "collection_notes",
+        "chargeoff_statement",
+        "monthly_statement"
+      ],
+      "field": "payment_status",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report_7y",
+        "cra_audit_logs",
+        "collection_history"
+      ],
+      "field": "seven_year_history",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statements_2y",
+        "internal_payment_history"
+      ],
+      "field": "two_year_payment_history",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 18,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    }
+  ],
+  "ai_fields": []
+}

--- a/tests/backend/core/logic/snapshots/validation_findings/account-12.json
+++ b/tests/backend/core/logic/snapshots/validation_findings/account-12.json
@@ -1,0 +1,302 @@
+{
+  "findings": [
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "monthly_statement"
+      ],
+      "field": "account_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 2,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "closure_letter",
+        "internal_closure_report"
+      ],
+      "field": "closed_date",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "credit_line_agreement",
+        "limit_change_record",
+        "monthly_statement"
+      ],
+      "field": "credit_limit",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "account_opening_contract",
+        "lender_agreement",
+        "cra_report"
+      ],
+      "field": "creditor_type",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": true,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 3,
+      "documents": [
+        "monthly_statement",
+        "system_activity_log",
+        "internal_report"
+      ],
+      "field": "date_of_last_activity",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C5_ALL_DIFF",
+      "reason_label": "all bureaus reported different values",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "system_audit_log"
+      ],
+      "field": "date_opened",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 3,
+      "documents": [
+        "loan_agreement",
+        "monthly_statement",
+        "internal_balance_report"
+      ],
+      "field": "high_balance",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C5_ALL_DIFF",
+      "reason_label": "all bureaus reported different values",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statement",
+        "payment_receipt",
+        "internal_payment_log"
+      ],
+      "field": "last_payment",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report",
+        "cra_reporting_log",
+        "monthly_statement"
+      ],
+      "field": "last_verified",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "cra_report_7y",
+        "cra_audit_logs",
+        "collection_history"
+      ],
+      "field": "seven_year_history",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statements_2y",
+        "internal_payment_history"
+      ],
+      "field": "two_year_payment_history",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 18,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    }
+  ],
+  "ai_fields": [
+    "creditor_type"
+  ]
+}

--- a/tests/backend/core/logic/snapshots/validation_findings/account-16.json
+++ b/tests/backend/core/logic/snapshots/validation_findings/account-16.json
@@ -1,0 +1,434 @@
+{
+  "findings": [
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": true,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report",
+        "cra_audit_log"
+      ],
+      "field": "account_rating",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 2,
+      "min_days": 18,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "cra_report",
+        "cra_audit_log"
+      ],
+      "field": "account_status",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "monthly_statement"
+      ],
+      "field": "account_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 2,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "balance_report",
+        "collection_report"
+      ],
+      "field": "balance_owed",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "credit_line_agreement",
+        "limit_change_record",
+        "monthly_statement"
+      ],
+      "field": "credit_limit",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "lender_agreement",
+        "cra_report"
+      ],
+      "field": "creditor_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "system_activity_log",
+        "internal_report"
+      ],
+      "field": "date_of_last_activity",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "system_audit_log"
+      ],
+      "field": "date_opened",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_reporting_log",
+        "cra_report"
+      ],
+      "field": "date_reported",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "loan_agreement",
+        "monthly_statement",
+        "internal_balance_report"
+      ],
+      "field": "high_balance",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "payment_receipt",
+        "internal_payment_log"
+      ],
+      "field": "last_payment",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statement",
+        "collection_report",
+        "delinquency_notice"
+      ],
+      "field": "past_due_amount",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "loan_agreement",
+        "amortization_schedule",
+        "monthly_statement"
+      ],
+      "field": "payment_amount",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 5,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "collection_notes",
+        "chargeoff_statement",
+        "monthly_statement"
+      ],
+      "field": "payment_status",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report_7y",
+        "cra_audit_logs",
+        "collection_history"
+      ],
+      "field": "seven_year_history",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "monthly_statements_2y",
+        "internal_payment_history"
+      ],
+      "field": "two_year_payment_history",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 18,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    }
+  ],
+  "ai_fields": []
+}

--- a/tests/backend/core/logic/snapshots/validation_findings/account-8.json
+++ b/tests/backend/core/logic/snapshots/validation_findings/account-8.json
@@ -1,0 +1,326 @@
+{
+  "findings": [
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": true,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "monthly_statement",
+        "collection_report"
+      ],
+      "field": "account_number_display",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 2,
+      "min_days": 2,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "monthly_statement"
+      ],
+      "field": "account_type",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 2,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C1_TWO_PRESENT_ONE_MISSING",
+      "reason_label": "two present, one missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "closure_letter",
+        "internal_closure_report"
+      ],
+      "field": "closed_date",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "credit_line_agreement",
+        "limit_change_record",
+        "monthly_statement"
+      ],
+      "field": "credit_limit",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 3,
+      "documents": [
+        "monthly_statement",
+        "system_activity_log",
+        "internal_report"
+      ],
+      "field": "date_of_last_activity",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 12,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C5_ALL_DIFF",
+      "reason_label": "all bureaus reported different values",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "open_ident",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "account_opening_contract",
+        "application_form",
+        "system_audit_log"
+      ],
+      "field": "date_opened",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 3,
+      "documents": [
+        "cra_reporting_log",
+        "cra_report"
+      ],
+      "field": "date_reported",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C5_ALL_DIFF",
+      "reason_label": "all bureaus reported different values",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "terms",
+      "conditional_gate": false,
+      "distinct_values": 3,
+      "documents": [
+        "loan_agreement",
+        "monthly_statement",
+        "internal_balance_report"
+      ],
+      "field": "high_balance",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 8,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C5_ALL_DIFF",
+      "reason_label": "all bureaus reported different values",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "activity",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statement",
+        "payment_receipt",
+        "internal_payment_log"
+      ],
+      "field": "last_payment",
+      "is_mismatch": true,
+      "is_missing": false,
+      "min_corroboration": 1,
+      "min_days": 3,
+      "missing_count": 0,
+      "present_count": 3,
+      "reason_code": "C4_TWO_MATCH_ONE_DIFF",
+      "reason_label": "two bureaus agree, one differs",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": false,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "status",
+      "conditional_gate": false,
+      "distinct_values": 1,
+      "documents": [
+        "cra_report",
+        "cra_reporting_log",
+        "monthly_statement"
+      ],
+      "field": "last_verified",
+      "is_mismatch": false,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 6,
+      "missing_count": 2,
+      "present_count": 1,
+      "reason_code": "C2_ONE_MISSING",
+      "reason_label": "only one bureau reported a value",
+      "send_to_ai": false,
+      "strength": "strong"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "cra_report_7y",
+        "cra_audit_logs",
+        "collection_history"
+      ],
+      "field": "seven_year_history",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 25,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    },
+    {
+      "ai_needed": true,
+      "bureaus": [
+        "equifax",
+        "experian",
+        "transunion"
+      ],
+      "category": "history",
+      "conditional_gate": false,
+      "distinct_values": 2,
+      "documents": [
+        "monthly_statements_2y",
+        "internal_payment_history"
+      ],
+      "field": "two_year_payment_history",
+      "is_mismatch": true,
+      "is_missing": true,
+      "min_corroboration": 1,
+      "min_days": 18,
+      "missing_count": 1,
+      "present_count": 2,
+      "reason_code": "C3_TWO_PRESENT_CONFLICT",
+      "reason_label": "conflict with one bureau missing",
+      "send_to_ai": false,
+      "strength": "soft"
+    }
+  ],
+  "ai_fields": []
+}

--- a/tests/backend/core/logic/test_validation_findings_snapshot.py
+++ b/tests/backend/core/logic/test_validation_findings_snapshot.py
@@ -1,0 +1,54 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from backend.core.logic.validation_requirements import (
+    build_validation_requirements_for_account,
+)
+
+
+_FIXTURE_ROOT = Path(
+    "runs/a09686e7-11b9-47a8-a5a0-0fdabc20e220/cases/accounts"
+)
+_SNAPSHOT_ROOT = Path(__file__).parent / "snapshots" / "validation_findings"
+
+
+def _normalize_findings(findings):
+    normalized = json.loads(json.dumps(findings, sort_keys=True))
+    normalized.sort(key=lambda entry: entry.get("field", ""))
+    return normalized
+
+
+@pytest.mark.parametrize(
+    "account_label, account_id",
+    [
+        ("account-8", "8"),
+        ("account-11", "11"),
+        ("account-12", "12"),
+        ("account-16", "16"),
+    ],
+)
+def test_validation_findings_match_snapshot(account_label, account_id, tmp_path):
+    fixture_dir = _FIXTURE_ROOT / account_id
+    if not fixture_dir.exists():
+        pytest.skip(f"fixture directory missing: {fixture_dir}")
+
+    working_dir = tmp_path / account_id
+    shutil.copytree(fixture_dir, working_dir)
+
+    result = build_validation_requirements_for_account(working_dir, build_pack=False)
+    findings = result["validation_requirements"]["findings"]
+
+    snapshot = {
+        "findings": _normalize_findings(findings),
+        "ai_fields": sorted(
+            entry["field"] for entry in findings if entry.get("send_to_ai")
+        ),
+    }
+
+    snapshot_path = _SNAPSHOT_ROOT / f"{account_label}.json"
+    expected = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+    assert snapshot == expected


### PR DESCRIPTION
## Summary
- add snapshot coverage for validation findings generated from deterministic bureau fixtures
- store golden JSON snapshots capturing reason codes and AI-routing fields to lock behavior

## Testing
- pytest tests/backend/core/logic/test_validation_findings_snapshot.py

------
https://chatgpt.com/codex/tasks/task_b_68e2d8edab648325ac4a927daa0cf9d9