### PR TITLE
Add guardrails for validation AI responses

### DIFF
--- a/backend/validation/build_packs.py
+++ b/backend/validation/build_packs.py
@@ -31,15 +31,32 @@ _SYSTEM_PROMPT = (
 )
 _GUIDANCE_TEXT = (
     "Return a JSON object with a decision of either 'strong' or 'no_case', "
-    "along with rationale and any supporting citations."
+    "a justification explaining the call, at least one supporting label, "
+    "and any citations that back up the judgment. Include a confidence value "
+    "between 0 and 1."
 )
 _EXPECTED_OUTPUT_SCHEMA = {
     "type": "object",
-    "required": ["decision", "rationale", "citations"],
+    "required": ["decision", "justification", "labels", "confidence"],
+    "additionalProperties": False,
     "properties": {
         "decision": {"type": "string", "enum": ["strong", "no_case"]},
-        "rationale": {"type": "string"},
-        "citations": {"type": "array", "items": {"type": "string"}},
+        "justification": {"type": "string", "minLength": 1},
+        "labels": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1},
+        },
+        "citations": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "default": [],
+        },
+        "confidence": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+        },
     },
 }
 _BUREAUS = ("transunion", "experian", "equifax")

--- a/docs/ai_packs/validation/README.md
+++ b/docs/ai_packs/validation/README.md
@@ -34,11 +34,12 @@ schema embedded in the pack line:
 
 * `decision`: either `strong` (consumer has a usable validation argument) or
   `no_case` (insufficient basis).
-* `rationale`: free-form explanation that justifies the decision.
+* `justification`: free-form explanation that justifies the decision.
+* `labels`: non-empty array of strings tagging the drivers behind the call.
 * `citations`: array of strings referencing the bureau facts relied upon.
-* `confidence` *(optional)*: float between `0` and `1` indicating the model's
-  self-assessed certainty. The builder and result ingesters gracefully handle its
-  absence.
+* `confidence`: float between `0` and `1` indicating the model's self-assessed
+  certainty. Low-confidence (`< AI_MIN_CONFIDENCE`) responses are downgraded to
+  `no_case` by the sender guardrails.
 
 Additional metadata (e.g., `model`, `request_lines`, timestamps) is attached by
 our ingestion helpers when writing the `.result.jsonl` and `.result.json` files
@@ -53,7 +54,7 @@ to `runs/<SID>/ai_packs/validation/results/`.
 
 ## Rationale and confidence expectations
 
-Responses should always provide a concise rationale describing the deciding
-facts. When available, include the optional `confidence` value so analysts can
-triage borderline calls quickly. Lack of confidence simply means the model was
-unable or unwilling to provide an estimate.
+Responses must include justification text, at least one supporting label, and a
+confidence score. The sender rejects malformed outputs (missing required keys)
+and downgrades `strong` decisions when the reported confidence falls below the
+configured guardrail threshold.

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -29,8 +29,10 @@ class _StubClient:
     def create(self, *, model: str, messages, response_format):  # type: ignore[override]
         payload = {
             "decision": "strong",
-            "rationale": "auto",
-            "citations": [],
+            "justification": "auto",
+            "labels": ["semantic_review"],
+            "citations": ["experian.raw"],
+            "confidence": 0.82,
         }
         return {"choices": [{"message": {"content": json.dumps(payload)}}]}
 


### PR DESCRIPTION
## Summary
- require validation AI responses to include decisions, justification labels, and confidence, rejecting schema violations and downgrading low-confidence calls while logging guardrail telemetry
- align validation pack prompts, expected output schema, and documentation with the stricter response contract
- propagate labels/confidence through result ingestion and expand tests to cover guardrail behaviour

## Testing
- pytest tests/backend/validation

------
https://chatgpt.com/codex/tasks/task_b_68e2e73b102483259adf546b490a5ec3