### PR TITLE
Restrict validation packs to semantic mismatch fields

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -84,7 +84,6 @@ _FIELD_CATEGORY_MAP: dict[str, str] = {
     "closed_date": "open_ident",
     "account_type": "open_ident",
     "creditor_type": "open_ident",
-    "account_number_display": "open_ident",
     # Terms
     "high_balance": "terms",
     "credit_limit": "terms",
@@ -103,7 +102,6 @@ _FIELD_CATEGORY_MAP: dict[str, str] = {
     "account_rating": "status",
     # Histories
     "two_year_payment_history": "history",
-    "seven_year_history": "history",
 }
 
 _missing_fields = ALL_VALIDATION_FIELD_SET - set(_FIELD_CATEGORY_MAP)
@@ -131,6 +129,15 @@ _ALLOWED_FIELD_CATEGORIES: dict[str, str] = {
 _ALLOWED_FIELDS: frozenset[str] = frozenset(ALL_VALIDATION_FIELDS)
 _ALLOWED_CATEGORIES: frozenset[str] = frozenset(
     _ALLOWED_FIELD_CATEGORIES.values()
+)
+
+_PACK_ELIGIBLE_FIELDS: frozenset[str] = frozenset(
+    {
+        "account_type",
+        "creditor_type",
+        "account_rating",
+        "two_year_payment_history",
+    }
 )
 
 
@@ -361,6 +368,9 @@ class ValidationPackWriter:
 
             canonical_field = self._canonical_field_name(requirement.get("field"))
             if canonical_field is None:
+                continue
+
+            if canonical_field not in _PACK_ELIGIBLE_FIELDS:
                 continue
 
             if requirement.get("is_missing") is True:
@@ -638,6 +648,8 @@ class ValidationPackWriter:
             canonical_field = self._canonical_field_name(requirement.get("field"))
             if canonical_field is None:
                 continue
+            if canonical_field not in _PACK_ELIGIBLE_FIELDS:
+                continue
             if not self._should_send_to_ai(
                 requirement,
                 canonical_field,
@@ -679,6 +691,9 @@ class ValidationPackWriter:
 
         field_name = canonical_field or self._canonical_field_name(field)
         if field_name is None:
+            return None
+
+        if field_name not in _PACK_ELIGIBLE_FIELDS:
             return None
 
         field_key = self._field_key(field_name)
@@ -1168,6 +1183,8 @@ class ValidationPackWriter:
                         continue
                     canonical_field = self._canonical_field_name(entry.get("field"))
                     if canonical_field is None:
+                        continue
+                    if canonical_field not in _PACK_ELIGIBLE_FIELDS:
                         continue
                     if not self._should_send_to_ai(
                         entry,

--- a/backend/core/logic/validation_field_sets.py
+++ b/backend/core/logic/validation_field_sets.py
@@ -26,12 +26,10 @@ ALWAYS_INVESTIGATABLE_FIELDS: tuple[str, ...] = (
     "date_reported",
     # Histories
     "two_year_payment_history",
-    "seven_year_history",
 )
 
 # Fields that require corroboration before escalating to a strong dispute.
 CONDITIONAL_FIELDS: tuple[str, ...] = (
-    "account_number_display",
     "account_rating",
 )
 

--- a/tests/test_validation_send_packs.py
+++ b/tests/test_validation_send_packs.py
@@ -48,6 +48,8 @@ def _account_number_pack_line(last4_a: str, last4_b: Optional[str]) -> dict:
 
 
 def test_account_number_gate_rejects_masking_only() -> None:
+    assert "account_number_display" not in _CONDITIONAL_FIELDS
+
     decision, rationale, info = _enforce_conditional_gate(
         "account_number_display",
         "strong",
@@ -55,10 +57,9 @@ def test_account_number_gate_rejects_masking_only() -> None:
         _account_number_pack_line("1234", "1234"),
     )
 
-    assert decision == "no_case"
-    assert "conditional_gate" in rationale
-    assert info is not None
-    assert info["reason"] == "insufficient_evidence"
+    assert decision == "strong"
+    assert rationale == "Masking only"
+    assert info is None
 
 
 def test_validation_field_sets_match_spec() -> None:
@@ -75,9 +76,17 @@ def test_validation_field_sets_match_spec() -> None:
     )
     assert set(validation_builder._CONDITIONAL_FIELDS) == set(expected_conditional)
     assert validation_builder._ALLOWED_FIELDS == expected_all
+    assert validation_builder._PACK_ELIGIBLE_FIELDS == {
+        "account_type",
+        "creditor_type",
+        "account_rating",
+        "two_year_payment_history",
+    }
 
 
 def test_account_number_gate_allows_true_conflict() -> None:
+    assert "account_number_display" not in _CONDITIONAL_FIELDS
+
     decision, rationale, info = _enforce_conditional_gate(
         "account_number_display",
         "strong",


### PR DESCRIPTION
## Summary
- update validation field sets to remove account_number_display and seven_year_history while keeping two_year_payment_history eligible
- ensure the validation pack builder only emits lines for account_type, creditor_type, account_rating, and two_year_payment_history
- refresh validation pack tests to reflect the narrowed eligibility and new gating behavior

## Testing
- pytest tests/ai/test_validation_packs.py tests/test_validation_send_packs.py

------
https://chatgpt.com/codex/tasks/task_b_68e30f81aca4832597b9cce23e3861cf