### PR TITLE
feat(validation): support single result file storage

### DIFF
--- a/tests/backend/ai/test_validation_manifest_writer.py
+++ b/tests/backend/ai/test_validation_manifest_writer.py
@@ -25,13 +25,12 @@ def test_write_validation_manifest_v2_uses_relative_posix_paths(tmp_path: Path) 
     index_path = base_dir / "index.json"
 
     pack_path = packs_dir / "nested" / "pack.jsonl"
-    result_jsonl_path = results_dir / "nested" / "account_001.result.jsonl"
     result_json_path = results_dir / "nested" / "account_001.result.json"
 
     entry = ValidationIndexEntry(
         account_id=1,
         pack_path=pack_path,
-        result_jsonl_path=result_jsonl_path,
+        result_jsonl_path=result_json_path,
         result_json_path=result_json_path,
         weak_fields=("Account Name",),
         line_count=7,
@@ -61,10 +60,8 @@ def test_write_validation_manifest_v2_uses_relative_posix_paths(tmp_path: Path) 
 
     assert record["account_id"] == 1
     assert record["pack"] == "packs/nested/pack.jsonl"
-    assert record["result_jsonl"] == "results/nested/account_001.result.jsonl"
     assert record["result_json"] == "results/nested/account_001.result.json"
     assert "\\" not in record["pack"]
-    assert "\\" not in record["result_jsonl"]
     assert "\\" not in record["result_json"]
 
     assert record["weak_fields"] == ["Account Name"]
@@ -76,7 +73,6 @@ def test_write_validation_manifest_v2_uses_relative_posix_paths(tmp_path: Path) 
     expected_keys = {
         "account_id",
         "pack",
-        "result_jsonl",
         "result_json",
         "weak_fields",
         "lines",

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -25,6 +25,11 @@ from backend.validation.send_packs import ValidationPackSender
 from backend.validation.index_schema import load_validation_index
 
 
+@pytest.fixture(autouse=True)
+def _legacy_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALIDATION_SINGLE_RESULT_FILE", "0")
+
+
 class _StubClient:
     def create(self, *, model: str, messages, response_format):  # type: ignore[override]
         payload = {

--- a/tests/backend/validation/test_send_smoke.py
+++ b/tests/backend/validation/test_send_smoke.py
@@ -88,6 +88,7 @@ def test_validation_sender_smoke_writes_results(
 ) -> None:
     sid, index_path, results_dir = _seed_manifest(tmp_path, [1, 2])
     monkeypatch.setenv("AI_MODEL", "stub-model")
+    monkeypatch.setenv("VALIDATION_SINGLE_RESULT_FILE", "0")
 
     payload = {
         "decision": "strong",
@@ -133,6 +134,7 @@ def test_validation_sender_invalid_response_guardrail(
     _, index_path, results_dir = _seed_manifest(tmp_path, [1], sid="GUARD001")
     monkeypatch.setenv("AI_MODEL", "stub-model")
     monkeypatch.setenv("ENABLE_OBSERVABILITY_H", "1")
+    monkeypatch.setenv("VALIDATION_SINGLE_RESULT_FILE", "0")
 
     from backend.analytics import analytics_tracker
 
@@ -168,6 +170,7 @@ def test_validation_sender_low_confidence_guardrail(
     _, index_path, results_dir = _seed_manifest(tmp_path, [1], sid="GUARD002")
     monkeypatch.setenv("AI_MODEL", "stub-model")
     monkeypatch.setenv("ENABLE_OBSERVABILITY_H", "1")
+    monkeypatch.setenv("VALIDATION_SINGLE_RESULT_FILE", "0")
 
     from backend.analytics import analytics_tracker
 

--- a/tests/devtools/test_show_validation_index.py
+++ b/tests/devtools/test_show_validation_index.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from backend.ai.validation_index import ValidationIndexEntry, ValidationPackIndexWriter
 from backend.core.ai.paths import (
     ensure_validation_paths,
@@ -11,6 +13,11 @@ from backend.core.ai.paths import (
 )
 
 from devtools import show_validation_index
+
+
+@pytest.fixture(autouse=True)
+def _legacy_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALIDATION_SINGLE_RESULT_FILE", "0")
 
 
 def _create_index_entry(


### PR DESCRIPTION
## Summary
- add VALIDATION_SINGLE_RESULT_FILE flag (default on) to store validation outputs as a single JSON file with per-field answers and remove the parallel `.jsonl`
- update validation index and manifest helpers to skip recording `.result.jsonl` entries when single-file mode is enabled while keeping legacy behaviour available behind the flag
- refresh validation pack tests and tooling to assert on the new answer format and gate legacy expectations behind the opt-out flag

## Testing
- pytest tests/ai/test_validation_pack_writer.py -q
- pytest tests/backend/ai/test_validation_manifest_writer.py -q
- pytest tests/backend/validation/test_send_smoke.py -q
- pytest tests/backend/validation/test_manifest_schema.py -q
- pytest tests/devtools/test_show_validation_index.py -q
- pytest tests/backend/validation/test_send_manifest_loader.py -q
- pytest tests/test_validation_packs.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e3cc9c890c8325bc1665ba9c23419a