### PR TITLE
Use shared prompt template for validation packs

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -62,10 +62,21 @@ _AUTO_SEND_ENV_VARS: tuple[str, ...] = (
 _BUREAUS = ("transunion", "experian", "equifax")
 _SYSTEM_PROMPT = (
     "You are an adjudication assistant reviewing credit report discrepancies. "
-    "Evaluate the provided bureau data and decide if the consumer has a strong claim. "
+    "Evaluate the provided bureau data and decide if the consumer has a strong claim."
+)
+_USER_PROMPT = (
+    "Review the validation finding JSON for the disputed field. "
+    "Base your assessment solely on the provided information to determine whether "
+    "the consumer has a strong validation argument."
+)
+_GUIDANCE_PROMPT = (
     "Respond with a JSON object that matches the expected output schema."
 )
-_SHARED_PROMPT = " ".join(part.strip() for part in _SYSTEM_PROMPT if part)
+_SHARED_PROMPT = {
+    "system": _SYSTEM_PROMPT,
+    "user": _USER_PROMPT,
+    "guidance": _GUIDANCE_PROMPT,
+}
 _EXPECTED_OUTPUT_SCHEMA = {
     "type": "object",
     "required": ["decision", "rationale", "citations"],
@@ -1230,7 +1241,7 @@ def build_line(
         "account_id": account_id,
         "field": field_name,
         "finding": finding_payload,
-        "prompt": _SHARED_PROMPT,
+        "prompt": _json_clone(_SHARED_PROMPT),
         "expected_output": _json_clone(_EXPECTED_OUTPUT_SCHEMA),
     }
 

--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -136,8 +136,10 @@ def test_writer_builds_pack_lines(tmp_path: Path) -> None:
     assert finding.get("bureau_values", {}).get("transunion", {}).get("raw") == "1"
 
     prompt = payload["prompt"]
-    assert isinstance(prompt, str)
-    assert prompt.strip()
+    assert isinstance(prompt, dict)
+    assert prompt["system"].startswith("You are an adjudication assistant")
+    assert prompt["user"].startswith("Review the validation finding JSON")
+    assert prompt["guidance"].startswith("Respond with a JSON object")
 
     expected_output = payload["expected_output"]
     assert expected_output["properties"]["decision"]["enum"] == ["strong", "no_case"]


### PR DESCRIPTION
## Summary
- replace the per-field prompt string with a shared system/user/guidance template for validation pack lines
- ensure each line receives a cloned copy of the shared prompt payload
- update validation pack writer tests to assert the new prompt structure

## Testing
- pytest tests/ai/test_validation_pack_writer.py

------
https://chatgpt.com/codex/tasks/task_b_68e3cfd67edc8325981a0238c141bca7