### PR TITLE
Add env toggle for 2Y history validation packs

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -179,10 +179,10 @@ def _is_mismatch(requirement: Mapping[str, Any]) -> bool:
     return _normalize_flag(requirement.get("is_mismatch")) is True
 
 
-def _history_2y_allowed(requirement: Mapping[str, Any]) -> bool:
-    """Placeholder hook for enabling two-year history fallback logic."""
+def _history_2y_allowed() -> bool:
+    """Return ``True`` if two-year history fallback packs are enabled."""
 
-    return True
+    return os.getenv("VALIDATION_ALLOW_HISTORY_2Y_AI", "1") == "1"
 
 
 def _reasons_enabled() -> bool:
@@ -1026,7 +1026,7 @@ class ValidationPackWriter:
             return False
 
         if canonical_field in FALLBACK_FIELDS:
-            return _is_mismatch(requirement) and _history_2y_allowed(requirement)
+            return _is_mismatch(requirement) and _history_2y_allowed()
 
         if canonical_field not in AI_FIELDS:
             return False


### PR DESCRIPTION
## Summary
- add a helper that checks VALIDATION_ALLOW_HISTORY_2Y_AI to control history pack fallback
- respect the toggle when evaluating two_year_payment_history fallback eligibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3de15a0948325b5e9874296d3297c