### PR TITLE
Refine validation result summary structure

### DIFF
--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -536,17 +536,17 @@ def test_store_validation_result_updates_index_and_writes_file(
     stored_payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert stored_payload["sid"] == sid
     assert stored_payload["account_id"] == account_id
-    assert stored_payload["status"] == "ok"
+    assert stored_payload["status"] == "done"
     assert stored_payload["model"] == "gpt-infer"
     assert stored_payload["request_lines"] == len(lines)
     assert stored_payload["raw_response"] == {"id": "resp_123"}
     assert isinstance(stored_payload["completed_at"], str)
-    assert stored_payload["answers"] == [
-        {
-            "field": "account_rating",
-            "decision": "strong",
-        }
-    ]
+    assert stored_payload["decisions"]
+    decision_entry = stored_payload["decisions"][0]
+    assert decision_entry["field_id"]
+    assert decision_entry["decision"] == "strong"
+    assert decision_entry["rationale"] == "values diverge"
+    assert decision_entry["citations"] == []
 
     results_dir = validation_results_dir(sid, runs_root=runs_root)
     jsonl_path = (
@@ -597,7 +597,7 @@ def test_store_validation_result_error(tmp_path: Path) -> None:
     stored_payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert stored_payload["status"] == "error"
     assert stored_payload["error"] == "api_timeout"
-    assert stored_payload["answers"] == []
+    assert stored_payload["decisions"] == []
 
     index_path = validation_index_path(sid, runs_root=runs_root)
     entry = _index_entry_for_account(_read_index(index_path), account_id)


### PR DESCRIPTION
## Summary
- update validation result storage to emit a single JSON document with per-field decision details and metadata
- adjust validation pack tests to validate the new decisions schema in stored results

## Testing
- pytest tests/backend/ai/test_validation_packs.py::test_single_result_file -q
- pytest tests/ai/test_validation_pack_writer.py::test_store_validation_result_updates_index_and_writes_file -q

------
https://chatgpt.com/codex/tasks/task_b_68e3dfdd3b388325b999f1b51829c0a3