### PR TITLE
Respect finding gating in validation AI routing

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -1034,13 +1034,19 @@ class ValidationPackWriter:
         if canonical_field in EXCLUDED_FIELDS:
             return False
 
-        if canonical_field in FALLBACK_FIELDS:
-            return _is_mismatch(requirement) and _history_2y_allowed()
+        if canonical_field not in _PACK_ELIGIBLE_FIELDS:
+            return False
 
-        if canonical_field not in AI_FIELDS:
+        if _normalize_flag(requirement.get("is_missing")) is True:
             return False
 
         if not _is_mismatch(requirement):
+            return False
+
+        if canonical_field in FALLBACK_FIELDS:
+            return _history_2y_allowed()
+
+        if canonical_field not in AI_FIELDS:
             return False
 
         lookup_keys: list[str] = [canonical_field]

--- a/tests/ai/test_validation_packs.py
+++ b/tests/ai/test_validation_packs.py
@@ -92,6 +92,47 @@ def test_two_year_history_mismatch_routes_without_send_flag(tmp_path: Path) -> N
     )
 
 
+def test_missing_findings_are_never_sent_to_ai(tmp_path: Path) -> None:
+    sid = "SID002-missing"
+    writer = ValidationPackWriter(sid, runs_root=tmp_path / "runs")
+
+    requirement = {
+        "field": "account_type",
+        "is_mismatch": True,
+        "is_missing": True,
+        "send_to_ai": True,
+    }
+
+    assert (
+        writer._should_send_to_ai(
+            requirement,
+            "account_type",
+            send_to_ai_map={"account_type": True},
+        )
+        is False
+    )
+
+
+def test_mismatch_gate_required_for_ai_fields(tmp_path: Path) -> None:
+    sid = "SID002-no-mismatch"
+    writer = ValidationPackWriter(sid, runs_root=tmp_path / "runs")
+
+    requirement = {
+        "field": "account_type",
+        "is_mismatch": False,
+        "send_to_ai": True,
+    }
+
+    assert (
+        writer._should_send_to_ai(
+            requirement,
+            "account_type",
+            send_to_ai_map={"account_type": True},
+        )
+        is False
+    )
+
+
 def test_other_fields_respect_send_flag(tmp_path: Path) -> None:
     sid = "SID003"
     writer = ValidationPackWriter(sid, runs_root=tmp_path / "runs")


### PR DESCRIPTION
## Summary
- ensure `_should_send_to_ai` honors missing and mismatch flags and only routes AI-eligible fields or the history fallback
- add regression tests around missing findings and mismatch gating for AI routing

## Testing
- `pytest tests/ai/test_validation_packs.py::test_two_year_history_mismatch_routes_without_send_flag tests/ai/test_validation_packs.py::test_other_fields_respect_send_flag tests/ai/test_validation_packs.py::test_missing_findings_are_never_sent_to_ai tests/ai/test_validation_packs.py::test_mismatch_gate_required_for_ai_fields -q`


------
https://chatgpt.com/codex/tasks/task_b_68e3e37c64448325a691d37dc24663c6