### PR TITLE
Require full validation auto-send toggles

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -1394,7 +1394,9 @@ def _packs_per_field_enabled() -> bool:
 
 
 def _auto_send_enabled() -> bool:
-    return any(_env_flag(name, False) for name in _AUTO_SEND_ENV_VARS)
+    """Return ``True`` when every auto-send toggle is explicitly enabled."""
+
+    return all(_env_flag(name, False) for name in _AUTO_SEND_ENV_VARS)
 
 
 def _pack_max_size_kb() -> float | None:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -124,5 +124,5 @@ RESULTS DIR: ok
 2. `python -m backend.validation.manifest --sid <SID> --check` should print the tabular summary and `All <N> packs present` when every file exists.
 3. `python -m backend.validation.send --sid <SID>` must write new result files under the manifest-defined `results/` directory.
 4. Remove or rename a pack and re-run `--check`; it should clearly report `MISSING` and exit with a non-zero status.
-5. Run your usual pipeline command with `$env:AUTO_VALIDATION_SEND = "1"` (or set the variable in your orchestrator). The builder generates packs, the manifest stays relative, and the sender runs automatically using only the manifest for resolution.
+5. Run your usual pipeline command with `$env:ENABLE_VALIDATION_SENDER = "1"`, `$env:AUTO_VALIDATION_SEND = "1"`, **and** `$env:VALIDATION_SEND_ON_BUILD = "1"` (or set the variables in your orchestrator). The builder generates packs, the manifest stays relative, and the sender runs automatically using only the manifest for resolution.
 

--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -818,9 +818,9 @@ def test_build_validation_packs_for_run_auto_send(
     _write_json(account_dir / "summary.json", summary_payload)
     _write_json(account_dir / "bureaus.json", bureaus_payload)
 
+    monkeypatch.setenv("ENABLE_VALIDATION_SENDER", "1")
     monkeypatch.setenv("AUTO_VALIDATION_SEND", "1")
-    monkeypatch.delenv("ENABLE_VALIDATION_SENDER", raising=False)
-    monkeypatch.delenv("VALIDATION_SEND_ON_BUILD", raising=False)
+    monkeypatch.setenv("VALIDATION_SEND_ON_BUILD", "1")
     monkeypatch.setitem(
         sys.modules,
         "requests",


### PR DESCRIPTION
## Summary
- require all validation auto-send environment toggles to be enabled before triggering the sender
- document the three toggles in the developer checklist
- update auto-send test to set all toggles explicitly

## Testing
- pytest tests/ai/test_validation_pack_writer.py::test_build_validation_packs_for_run_auto_send

------
https://chatgpt.com/codex/tasks/task_b_68e40be484ac8325b9f5477768924f2b