### PR TITLE
Ensure validation sender uses validation pack directories

### DIFF
--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -37,9 +37,23 @@ def ensure_validation_paths(
 ) -> ValidationPaths:
     """Return the canonical validation AI pack paths for ``sid``."""
 
-    base_path = (Path(runs_root) / sid / "ai_packs" / "validation").resolve()
-    packs_dir = base_path / "packs"
-    results_dir = base_path / "results"
+    runs_root_path = Path(runs_root).resolve()
+    base_path = (runs_root_path / sid / "ai_packs" / "validation").resolve()
+
+    def _resolve_override(env_name: str, default: Path) -> Path:
+        raw = os.getenv(env_name)
+        if not raw:
+            return default
+
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = (runs_root_path / sid / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        return candidate
+
+    packs_dir = _resolve_override("VALIDATION_PACKS_DIR", base_path / "packs")
+    results_dir = _resolve_override("VALIDATION_RESULTS_DIR", base_path / "results")
     index_file = base_path / "index.json"
     log_file = base_path / "logs.txt"
 

--- a/backend/validation/send_packs.py
+++ b/backend/validation/send_packs.py
@@ -865,6 +865,17 @@ class ValidationPackSender:
             "set" if base_url_set else "missing",
         )
 
+        log.info(
+            "VALIDATION_PACKS_DIR_USED sid=%s dir=%s",
+            self.sid,
+            str(index.packs_dir_path),
+        )
+        log.info(
+            "VALIDATION_RESULTS_DIR_USED sid=%s dir=%s",
+            self.sid,
+            str(index.results_dir_path),
+        )
+
     def send(self) -> list[dict[str, Any]]:
         """Send every pack referenced by the manifest index."""
 


### PR DESCRIPTION
## Summary
- allow validation path helpers to read VALIDATION_PACKS_DIR and VALIDATION_RESULTS_DIR overrides
- log the validation pack and results directories used during validation sends
- cover the new environment override behaviour with tests

## Testing
- pytest tests/core/logic/test_validation_ai_packs.py::test_ensure_validation_paths_honors_env_overrides

------
https://chatgpt.com/codex/tasks/task_b_68e415f5730c83258dd96bbc9532a81c