### PR TITLE
Improve validation sender error visibility

### DIFF
--- a/backend/core/ai/paths.py
+++ b/backend/core/ai/paths.py
@@ -312,3 +312,10 @@ def validation_result_filename_for_account(account_id: int | str) -> str:
 
     return validation_result_summary_filename_for_account(account_id)
 
+
+def validation_result_error_filename_for_account(account_id: int | str) -> str:
+    """Return the canonical validation error sidecar filename for ``account_id``."""
+
+    normalized = _normalize_account_id(account_id)
+    return f"acc_{normalized:03d}.result.error.json"
+

--- a/tests/backend/ai/test_validation_sender.py
+++ b/tests/backend/ai/test_validation_sender.py
@@ -32,12 +32,21 @@ class _StubClient:
         self._payload = payload
         self.requests: list[dict[str, object]] = []
 
-    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+    def create(
+        self,
+        *,
+        model: str,
+        messages,
+        response_format,
+        pack_id=None,
+        on_error=None,
+    ):  # type: ignore[override]
         self.requests.append(
             {
                 "model": model,
                 "messages": messages,
                 "response_format": response_format,
+                "pack_id": pack_id,
             }
         )
         return {"choices": [{"message": {"content": json.dumps(self._payload)}}]}
@@ -151,6 +160,8 @@ def test_sender_accepts_valid_json_response(tmp_path: Path) -> None:
         account_label="001",
         line_number=1,
         line_id="acc_001__account_type",
+        pack_id="acc_001",
+        error_path=tmp_path / "acc_001.result.error.json",
     )
 
     assert response == payload


### PR DESCRIPTION
## Summary
- add a helper to compute validation error sidecar filenames
- log HTTP failures with pack context and write truncated sidecar payloads
- propagate empty-content errors to sidecars and clear stale error files before sends

## Testing
- pytest tests/backend/ai/test_validation_sender.py

------
https://chatgpt.com/codex/tasks/task_b_68e417e36ff88325a7f3ae10bd1f75c1