### PR TITLE
Ensure validation sender uses validation manifest paths

### DIFF
--- a/backend/ai/manifest.py
+++ b/backend/ai/manifest.py
@@ -1,0 +1,117 @@
+"""Helpers for working with run-level AI manifest documents."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class StageManifestPaths:
+    """Resolved filesystem paths for a specific AI stage."""
+
+    base_dir: Path | None = None
+    packs_dir: Path | None = None
+    results_dir: Path | None = None
+    index_file: Path | None = None
+    log_file: Path | None = None
+
+    def has_any(self) -> bool:
+        """Return ``True`` when at least one path is populated."""
+
+        return any(
+            value is not None
+            for value in (
+                self.base_dir,
+                self.packs_dir,
+                self.results_dir,
+                self.index_file,
+                self.log_file,
+            )
+        )
+
+
+def _coerce_path(value: Any) -> Path | None:
+    if value is None:
+        return None
+
+    try:
+        text = os.fspath(value)
+    except TypeError:
+        return None
+
+    stripped = str(text).strip()
+    if not stripped:
+        return None
+
+    try:
+        return Path(stripped).resolve()
+    except OSError:
+        return Path(stripped)
+
+
+def extract_stage_manifest_paths(
+    manifest: Mapping[str, Any], stage: str
+) -> StageManifestPaths:
+    """Return the preferred filesystem paths for ``stage`` within ``manifest``."""
+
+    stage_key = stage.lower().strip()
+
+    ai_section = manifest.get("ai")
+    if not isinstance(ai_section, Mapping):
+        return StageManifestPaths()
+
+    base_dir: Path | None = None
+    packs_dir: Path | None = None
+    results_dir: Path | None = None
+    index_file: Path | None = None
+    log_file: Path | None = None
+
+    packs_section = ai_section.get("packs")
+    if isinstance(packs_section, Mapping):
+        stage_section = packs_section.get(stage_key)
+        if isinstance(stage_section, Mapping):
+            base_dir = _coerce_path(stage_section.get("base")) or _coerce_path(
+                stage_section.get("dir")
+            )
+            packs_dir = _coerce_path(stage_section.get("packs_dir")) or _coerce_path(
+                stage_section.get("packs")
+            )
+            results_dir = _coerce_path(stage_section.get("results_dir")) or _coerce_path(
+                stage_section.get("results")
+            )
+            index_file = _coerce_path(stage_section.get("index"))
+            log_file = _coerce_path(stage_section.get("logs"))
+
+    legacy_stage = ai_section.get(stage_key)
+    if isinstance(legacy_stage, Mapping):
+        legacy_base = (
+            _coerce_path(legacy_stage.get("dir"))
+            or _coerce_path(legacy_stage.get("base"))
+            or _coerce_path(legacy_stage.get("accounts_dir"))
+            or _coerce_path(legacy_stage.get("accounts"))
+        )
+        if legacy_base is not None:
+            if base_dir is None:
+                base_dir = legacy_base
+            if packs_dir is None:
+                packs_dir = (legacy_base / "packs").resolve()
+            if results_dir is None:
+                results_dir = (legacy_base / "results").resolve()
+            if index_file is None:
+                index_file = (legacy_base / "index.json").resolve()
+            if log_file is None:
+                log_file = (legacy_base / "logs.txt").resolve()
+
+    return StageManifestPaths(
+        base_dir=base_dir,
+        packs_dir=packs_dir,
+        results_dir=results_dir,
+        index_file=index_file,
+        log_file=log_file,
+    )
+
+
+__all__ = ["StageManifestPaths", "extract_stage_manifest_paths"]

--- a/tests/backend/validation/test_send_manifest_loader.py
+++ b/tests/backend/validation/test_send_manifest_loader.py
@@ -137,3 +137,92 @@ def test_sender_loader_converts_v1_manifest_in_memory(
     assert record.result_json == "results/account_002.result.json"
     assert index.resolve_pack_path(record) == pack_file.resolve()
     assert not index_path.exists(), "conversion should not persist the manifest"
+
+
+def test_sender_uses_validation_stage_paths_from_run_manifest(
+    tmp_path: Path, loader_client: _LoaderStubClient
+) -> None:
+    sid = "SID557"
+    base_dir = tmp_path / "runs" / sid / "ai_packs" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    log_path = base_dir / "logs.txt"
+    index_path = base_dir / "index.json"
+
+    packs_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    index_payload = {
+        "schema_version": 2,
+        "sid": sid,
+        "root": ".",
+        "packs_dir": "packs",
+        "results_dir": "results",
+        "packs": [],
+    }
+    index_path.write_text(json.dumps(index_payload), encoding="utf-8")
+
+    run_manifest = {
+        "sid": sid,
+        "ai": {
+            "packs": {
+                "validation": {
+                    "base": str(base_dir),
+                    "packs_dir": str(packs_dir),
+                    "results_dir": str(results_dir),
+                    "index": str(index_path),
+                    "logs": str(log_path),
+                }
+            }
+        },
+        "__index_path__": str(tmp_path / "wrong" / "index.json"),
+    }
+
+    sender = ValidationPackSender(run_manifest, http_client=loader_client)
+
+    index = sender._index  # type: ignore[attr-defined]
+    assert index.index_path == index_path.resolve()
+    assert index.packs_dir_path == packs_dir.resolve()
+    assert index.results_dir_path == results_dir.resolve()
+    assert sender._log_path == log_path.resolve()  # type: ignore[attr-defined]
+
+
+def test_sender_falls_back_to_ai_validation_dir(
+    tmp_path: Path, loader_client: _LoaderStubClient
+) -> None:
+    sid = "SID558"
+    base_dir = tmp_path / "runs" / sid / "ai" / "validation"
+    packs_dir = base_dir / "packs"
+    results_dir = base_dir / "results"
+    index_path = base_dir / "index.json"
+    log_path = base_dir / "logs.txt"
+
+    packs_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    index_payload = {
+        "schema_version": 2,
+        "sid": sid,
+        "root": ".",
+        "packs_dir": "packs",
+        "results_dir": "results",
+        "packs": [],
+    }
+    index_path.write_text(json.dumps(index_payload), encoding="utf-8")
+
+    manifest = {
+        "sid": sid,
+        "ai": {
+            "validation": {
+                "dir": str(base_dir),
+            }
+        },
+    }
+
+    sender = ValidationPackSender(manifest, http_client=loader_client)
+
+    index = sender._index  # type: ignore[attr-defined]
+    assert index.index_path == index_path.resolve()
+    assert index.packs_dir_path == packs_dir.resolve()
+    assert index.results_dir_path == results_dir.resolve()
+    assert sender._log_path == log_path.resolve()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add helpers for extracting stage-specific AI paths from run manifests
- update the validation sender to honor validation manifest paths, wait for the index, and reuse validation logs
- extend validation sender tests to cover run-manifest inputs and legacy fallbacks

## Testing
- pytest tests/backend/validation/test_send_manifest_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68e41bf12a708325b32638fbccada79d