### PR TITLE
Add logging for validation HTTP headers

### DIFF
--- a/backend/validation/send_packs.py
+++ b/backend/validation/send_packs.py
@@ -417,6 +417,10 @@ class _ChatCompletionClient:
         )
         if include_beta_header:
             headers["OpenAI-Beta"] = "response_format=v1"
+        log.info(
+            "VALIDATION_HTTP_HEADERS_SET beta_structured=%s",
+            "true" if include_beta_header else "false",
+        )
         payload = {
             "model": model,
             "messages": list(messages),


### PR DESCRIPTION
## Summary
- log whether the beta structured output header is attached when sending validation packs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e421f72a2c832581e11e64e41280b1