### PR TITLE
Ensure validation sender uses validation manifest paths

### DIFF
--- a/tests/backend/ai/test_validation_sender.py
+++ b/tests/backend/ai/test_validation_sender.py
@@ -162,6 +162,8 @@ def test_sender_accepts_valid_json_response(tmp_path: Path) -> None:
         line_id="acc_001__account_type",
         pack_id="acc_001",
         error_path=tmp_path / "acc_001.result.error.json",
+        result_path=tmp_path / "acc_001.result.json",
+        result_display="results/acc_001.result.json",
     )
 
     assert response == payload

--- a/tests/backend/validation/test_manifest_schema.py
+++ b/tests/backend/validation/test_manifest_schema.py
@@ -31,7 +31,7 @@ def _legacy_results(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class _StubClient:
-    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+    def create(self, *, model: str, messages, response_format, **_: object):  # type: ignore[override]
         payload = {
             "decision": "strong",
             "justification": "auto",
@@ -308,7 +308,7 @@ def test_sender_includes_context_on_api_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     class _ErrorClient:
-        def create(self, *, model, messages, response_format):  # type: ignore[override]
+        def create(self, *, model, messages, response_format, **_: object):  # type: ignore[override]
             raise RuntimeError("boom")
 
     manifest, runs_root = _build_manifest(tmp_path, sid="S999")

--- a/tests/backend/validation/test_send_manifest_loader.py
+++ b/tests/backend/validation/test_send_manifest_loader.py
@@ -20,7 +20,7 @@ sys.modules.setdefault("requests", _requests_stub)
 
 
 class _LoaderStubClient:
-    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+    def create(self, *, model: str, messages, response_format, **_: object):  # type: ignore[override]
         payload = {
             "decision": "strong",
             "rationale": "stub",

--- a/tests/backend/validation/test_send_smoke.py
+++ b/tests/backend/validation/test_send_smoke.py
@@ -23,7 +23,7 @@ class _FixedResponseStubClient:
     def __init__(self, payload: dict[str, object]):
         self._payload = payload
 
-    def create(self, *, model: str, messages, response_format):  # type: ignore[override]
+    def create(self, *, model: str, messages, response_format, **_: object):  # type: ignore[override]
         return {"choices": [{"message": {"content": json.dumps(self._payload)}}]}
 
 


### PR DESCRIPTION
## Summary
- ensure validation manifest loading waits for validation stage paths and reuse the resolved view when sending packs
- add detailed per-request logging and structured response handling for validation HTTP calls
- update validation sender tests and stubs to accommodate the new client interface

## Testing
- pytest tests/backend/validation/test_send_manifest_loader.py
- pytest tests/backend/validation/test_send_smoke.py
- pytest tests/backend/validation/test_manifest_schema.py
- pytest tests/backend/ai/test_validation_sender.py

------
https://chatgpt.com/codex/tasks/task_b_68e4263422ac8325b053b2c49d10365e