### PR TITLE
Enforce sequential merge and validation pipeline stages

### DIFF
--- a/tests/ai/test_validation_pack_writer.py
+++ b/tests/ai/test_validation_pack_writer.py
@@ -140,8 +140,8 @@ def test_writer_builds_pack_lines(tmp_path: Path) -> None:
     prompt = payload["prompt"]
     assert isinstance(prompt, dict)
     assert prompt["system"].startswith("You are an adjudication assistant")
-    assert prompt["user"].startswith("Review the validation finding JSON")
-    assert prompt["guidance"].startswith("Respond with a JSON object")
+    assert prompt["user"].startswith("Given the field finding below")
+    assert prompt["guidance"].startswith("Respond with strictly valid JSON")
 
     expected_output = payload["expected_output"]
     assert expected_output["properties"]["decision"]["enum"] == ["strong", "no_case"]
@@ -788,7 +788,7 @@ def test_build_validation_pack_respects_env_toggle(
     assert not pack_path.exists()
 
 
-def test_build_validation_packs_for_run_auto_send(
+def test_build_validation_packs_for_run_does_not_auto_send(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     sid = "S601"
@@ -829,7 +829,7 @@ def test_build_validation_packs_for_run_auto_send(
 
     captured: dict[str, Any] = {}
 
-    def _fake_send(manifest: Any) -> list[dict[str, Any]]:
+    def _fake_send(manifest: Any) -> list[dict[str, Any]]:  # pragma: no cover - safety
         captured["manifest"] = manifest
         return []
 
@@ -840,9 +840,7 @@ def test_build_validation_packs_for_run_auto_send(
 
     build_validation_packs_for_run(sid, runs_root=runs_root)
 
-    assert "manifest" in captured
-    expected_index = validation_index_path(sid, runs_root=runs_root)
-    assert Path(captured["manifest"]) == expected_index
+    assert captured == {}
 
 
 def test_rewrite_index_to_canonical_layout(tmp_path: Path) -> None:

--- a/tests/pipeline/test_auto_ai.py
+++ b/tests/pipeline/test_auto_ai.py
@@ -458,21 +458,29 @@ def test_enqueue_auto_ai_chain_orders_signatures(monkeypatch) -> None:
             return signature
 
     score_recorder = _Recorder("score")
-    build_recorder = _Recorder("build")
-    send_recorder = _Recorder("send")
+    build_recorder = _Recorder("merge_build")
+    send_recorder = _Recorder("merge_send")
+    compact_recorder = _Recorder("merge_compact")
+    validation_build_recorder = _Recorder("validation_build")
+    validation_send_recorder = _Recorder("validation_send")
+    validation_compact_recorder = _Recorder("validation_compact")
     consistency_recorder = _Recorder("consistency")
-    validation_recorder = _Recorder("validation")
-    compact_recorder = _Recorder("compact")
+    validation_requirements_recorder = _Recorder("validation_requirements")
+    finalize_recorder = _Recorder("finalize")
     polarity_recorder = _Recorder("polarity")
 
     monkeypatch.setattr(auto_ai_tasks, "ai_score_step", score_recorder)
-    monkeypatch.setattr(auto_ai_tasks, "ai_build_packs_step", build_recorder)
-    monkeypatch.setattr(auto_ai_tasks, "ai_send_packs_step", send_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "merge_build_packs", build_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "merge_send", send_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "merge_compact", compact_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "validation_build_packs", validation_build_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "validation_send", validation_send_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "validation_compact", validation_compact_recorder)
     monkeypatch.setattr(auto_ai_tasks, "ai_consistency_step", consistency_recorder)
     monkeypatch.setattr(
-        auto_ai_tasks, "ai_validation_requirements_step", validation_recorder
+        auto_ai_tasks, "ai_validation_requirements_step", validation_requirements_recorder
     )
-    monkeypatch.setattr(auto_ai_tasks, "ai_compact_tags_step", compact_recorder)
+    monkeypatch.setattr(auto_ai_tasks, "pipeline_finalize", finalize_recorder)
     monkeypatch.setattr(auto_ai_tasks, "ai_polarity_check_step", polarity_recorder)
 
     chain_calls: dict[str, Any] = {}
@@ -499,12 +507,16 @@ def test_enqueue_auto_ai_chain_orders_signatures(monkeypatch) -> None:
     assert task_id == "chain-root-task"
     assert chain_calls["steps"] == (
         ("score", (sid, str(runs_root))),
-        ("build", ()),
-        ("send", ()),
+        ("merge_build", ()),
+        ("merge_send", ()),
+        ("merge_compact", ()),
+        ("validation_build", ()),
+        ("validation_send", ()),
+        ("validation_compact", ()),
         ("polarity", ()),
         ("consistency", ()),
-        ("validation", ()),
-        ("compact", ()),
+        ("validation_requirements", ()),
+        ("finalize", ()),
     )
     assert chain_calls["apply_async"] == chain_calls["steps"]
 


### PR DESCRIPTION
## Summary
- restructure the auto AI Celery chain to run merge build/send/compact before validation build/send/compact and add finalization logging
- add explicit validation build/send/compact tasks and ensure validation packs no longer auto-send during build
- enrich validation pack generation with bureau context and update tests to reflect the new prompts and execution order

## Testing
- pytest tests/pipeline/test_auto_ai.py tests/ai/test_validation_pack_writer.py

------
https://chatgpt.com/codex/tasks/task_b_68e436aaf6888325a651778c69615293