### PR TITLE
Ensure validation manifest directories exist before validation stages

### DIFF
--- a/backend/ai/manifest.py
+++ b/backend/ai/manifest.py
@@ -208,4 +208,17 @@ class Manifest:
         return dict(validation_section)
 
 
-__all__ = ["Manifest", "StageManifestPaths", "extract_stage_manifest_paths"]
+def ensure_validation_section(
+    sid: str, *, runs_root: Path | str | None = None
+) -> dict[str, Any]:
+    """Ensure the validation manifest section and directories exist for ``sid``."""
+
+    return Manifest.ensure_validation_section(sid, runs_root=runs_root)
+
+
+__all__ = [
+    "Manifest",
+    "StageManifestPaths",
+    "ensure_validation_section",
+    "extract_stage_manifest_paths",
+]

--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
-from backend.ai.manifest import Manifest
+from backend.ai.manifest import ensure_validation_section
 from backend.ai.validation_index import (
     ValidationIndexEntry,
     ValidationPackIndexWriter,
@@ -1510,7 +1510,7 @@ def _maybe_send_validation_packs(
     stage: str = "validation",
     recheck: bool = False,
 ) -> None:
-    Manifest.ensure_validation_section(sid, runs_root=runs_root)
+    ensure_validation_section(sid, runs_root=runs_root)
 
     if not _auto_send_enabled():
         log.info("VALIDATION_AUTOSEND_SKIPPED sid=%s reason=env_disabled", sid)
@@ -1609,7 +1609,7 @@ def build_validation_packs_for_run(
     runs_root_path = (
         Path(runs_root).resolve() if runs_root is not None else Path("runs").resolve()
     )
-    Manifest.ensure_validation_section(sid, runs_root=runs_root_path)
+    ensure_validation_section(sid, runs_root=runs_root_path)
 
     if not _packs_enabled():
         log.info(

--- a/backend/pipeline/auto_ai_tasks.py
+++ b/backend/pipeline/auto_ai_tasks.py
@@ -12,6 +12,7 @@ from typing import Mapping, MutableMapping
 
 from celery import chain, shared_task
 
+from backend.ai.manifest import ensure_validation_section
 from backend.ai.validation_builder import build_validation_packs_for_run
 from backend.core.ai.paths import (
     ensure_merge_paths,
@@ -717,6 +718,7 @@ def validation_build_packs(
     _populate_common_paths(payload)
     runs_root = Path(payload["runs_root"])
 
+    ensure_validation_section(sid, runs_root=runs_root)
     logger.info("VALIDATION_STAGE_STARTED sid=%s", sid)
 
     try:


### PR DESCRIPTION
## Summary
- add a helper to guarantee validation manifest sections and directories exist
- call the helper before validation build/send logic to avoid missing index errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e43b0071748325a1397c3301317770