### PR TITLE
Add result output paths to validation index records

### DIFF
--- a/backend/ai/validation_builder.py
+++ b/backend/ai/validation_builder.py
@@ -612,11 +612,21 @@ class ValidationPackWriter:
             summary = self._load_summary(account_id)
         source_hash = self._build_source_hash(summary, lines)
 
+        acct_str = f"{account_id:03d}"
+        results_basename = os.getenv("VALIDATION_RESULTS_BASENAME", "acc_{account}.result")
+        try:
+            results_base = results_basename.format(account=acct_str)
+        except Exception:
+            results_base = f"acc_{acct_str}.result"
+
+        result_jsonl_path = self._results_dir / f"{results_base}.jsonl"
+        result_json_path = self._results_dir / f"{results_base}.json"
+
         entry = ValidationIndexEntry(
             account_id=account_id,
             pack_path=pack_path.resolve(),
-            result_jsonl_path=None,
-            result_json_path=None,
+            result_jsonl_path=result_jsonl_path.resolve(),
+            result_json_path=result_json_path.resolve(),
             weak_fields=tuple(weak_fields),
             line_count=len(lines),
             status="built",

--- a/backend/ai/validation_index.py
+++ b/backend/ai/validation_index.py
@@ -22,19 +22,6 @@ log = logging.getLogger(__name__)
 _SCHEMA_VERSION = 2
 
 
-def _single_result_file_enabled() -> bool:
-    raw = os.getenv("VALIDATION_SINGLE_RESULT_FILE")
-    if raw is None:
-        return True
-
-    lowered = raw.strip().lower()
-    if lowered in {"1", "true", "yes", "y", "on"}:
-        return True
-    if lowered in {"0", "false", "no", "n", "off"}:
-        return False
-    return True
-
-
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
         "+00:00", "Z"
@@ -77,10 +64,7 @@ class ValidationIndexEntry:
                 self.result_json_path, index_dir
             )
 
-        if (
-            not _single_result_file_enabled()
-            and self.result_jsonl_path is not None
-        ):
+        if self.result_jsonl_path is not None:
             payload["result_jsonl"] = _relativize_path(
                 self.result_jsonl_path, index_dir
             )


### PR DESCRIPTION
## Summary
- include per-account result JSON and JSONL targets when building validation pack index entries
- always serialize result_json and result_jsonl paths into schema v2 records for downstream senders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e66e933e448325973225f9146e0d9e