### PR TITLE
Add feature flag for business-day validation SLAs

### DIFF
--- a/backend/core/logic/validation_requirements.py
+++ b/backend/core/logic/validation_requirements.py
@@ -101,9 +101,10 @@ _ACCOUNT_NUMBER_BUREAU_LABELS: Mapping[str, str] = {
     "transunion": "Tu",
 }
 _ACCOUNT_NUMBER_DETERMINISTIC_FLAG = "VALIDATION_ACCOUNT_NUMBER_DISPLAY_DETERMINISTIC"
-_BUSINESS_DAY_SLA_FLAG = "VALIDATION_BUSINESS_DAY_SLA_ENABLED"
+_BUSINESS_DAY_SLA_FLAG = "VALIDATION_USE_BUSINESS_DAYS"
 
 _FALSE_FLAG_VALUES = {"0", "false", "off", "no"}
+_TRUE_FLAG_VALUES = {"1", "true", "on", "yes"}
 
 
 def _use_deterministic_account_number_policy() -> bool:
@@ -121,13 +122,15 @@ def _use_deterministic_account_number_policy() -> bool:
 def _business_day_sla_enabled() -> bool:
     override = os.getenv(_BUSINESS_DAY_SLA_FLAG)
     if override is None:
-        return True
+        return False
 
     lowered = override.strip().lower()
+    if lowered in _TRUE_FLAG_VALUES:
+        return True
     if lowered in _FALSE_FLAG_VALUES:
         return False
 
-    return True
+    return False
 
 
 def _is_dry_run_enabled() -> bool:

--- a/tests/backend/core/logic/test_validation_requirements.py
+++ b/tests/backend/core/logic/test_validation_requirements.py
@@ -44,6 +44,11 @@ from backend.core.logic.validation_requirements import (
 )
 
 
+@pytest.fixture(autouse=True)
+def enable_business_day_rollout(monkeypatch):
+    monkeypatch.setenv("VALIDATION_USE_BUSINESS_DAYS", "1")
+
+
 def test_compute_inconsistent_fields_detects_money_and_text():
     bureaus = {
         "transunion": {"balance_owed": "$100.00", "account_status": "Open"},

--- a/tests/test_validation_requirements.py
+++ b/tests/test_validation_requirements.py
@@ -1,7 +1,11 @@
 import pytest
-
 from backend.core.logic.consistency import compute_field_consistency
 from backend.core.logic.validation_requirements import build_validation_requirements
+
+
+@pytest.fixture(autouse=True)
+def enable_business_day_rollout(monkeypatch):
+    monkeypatch.setenv("VALIDATION_USE_BUSINESS_DAYS", "1")
 
 
 @pytest.fixture
@@ -66,7 +70,7 @@ def _requirements_by_field(bureaus):
 
 
 def test_business_day_sla_flag_falls_back_to_calendar(monkeypatch):
-    monkeypatch.setenv("VALIDATION_BUSINESS_DAY_SLA_ENABLED", "0")
+    monkeypatch.setenv("VALIDATION_USE_BUSINESS_DAYS", "0")
 
     bureaus = {
         "equifax": {"payment_status": "CO"},


### PR DESCRIPTION
## Summary
- add the VALIDATION_USE_BUSINESS_DAYS guard so calendar-day behavior remains the default until rollout
- update validation requirement tests to explicitly enable the business-day path by default

## Testing
- pytest tests/backend/core/logic/test_validation_requirements.py tests/test_validation_requirements.py tests/backend/validation/test_utils_dates.py

------
https://chatgpt.com/codex/tasks/task_b_690cd19d87f48325a19aa0f4a0e06dc5