### PR TITLE
Document business-day SLA weekend handling

### DIFF
--- a/docs/ai_packs/validation/README.md
+++ b/docs/ai_packs/validation/README.md
@@ -32,7 +32,10 @@ lines directly to the model without additional lookups.
 `min_days` remains a calendar-day number so existing consumers do not need to
 change units. The canonical SLA is tracked via `min_days_business` and
 `duration_unit` so that downstream builders can migrate to business-day logic
-without breaking older integrations.
+without breaking older integrations. Business-day calculations skip weekends
+(Saturday/Sunday) and do not yet exclude region-specific holidays; a holiday
+provider will be wired in during a future enhancement once requirements are
+finalised.
 
 ## Output payload (result line)
 

--- a/docs/ai_validation_packs.md
+++ b/docs/ai_validation_packs.md
@@ -55,7 +55,9 @@ runs/<SID>/ai_packs/validation/
 
 Copy these payloads verbatim when building or validating artifacts. The calendar
 `min_days` value remains for backwards compatibility while `min_days_business`
-and `duration_unit` capture the new SLA semantics.
+and `duration_unit` capture the new SLA semantics. Business-day calculations
+skip Saturday/Sunday weekends today; holiday exclusions will be layered in as a
+future enhancement once regional requirements are defined.
 
 ### 1.1 Pack line (JSONL) — one line per weak field
 


### PR DESCRIPTION
## Summary
- clarify that validation AI pack documentation uses calendar-day `min_days` alongside business-day SLAs
- note that weekend skipping is implemented today and holiday support will arrive in a future enhancement

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_690cd2dcada883259fea827fbcee4c6e