### PR TITLE
Add Monday start coverage to business day conversion tests

### DIFF
--- a/tests/backend/validation/test_utils_dates.py
+++ b/tests/backend/validation/test_utils_dates.py
@@ -23,6 +23,12 @@ def test_business_to_calendar_days_conversion(business_days, expected):
     assert business_to_calendar_days(business_days) == expected
 
 
+def test_business_to_calendar_handles_monday_start():
+    monday = date(2023, 7, 3)
+    assert business_to_calendar(monday, 1) == 1
+    assert business_to_calendar(monday, 5) == 5
+
+
 def test_business_to_calendar_handles_friday_start():
     # Friday start should require a full weekend skip for the second day.
     assert business_to_calendar(4, 1) == 1


### PR DESCRIPTION
## Summary
- add explicit Monday-start coverage for the `business_to_calendar` helper to lock down calendar conversion expectations

## Testing
- pytest tests/backend/validation/test_utils_dates.py
- pytest tests/backend/core/logic/test_validation_requirements.py tests/test_validation_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_690cd3f5529c832588fd19486111d4db